### PR TITLE
Add source document and structured organization data from APD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem "activesupport"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  specs:
+    activesupport (4.1.5)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    i18n (0.7.0)
+    json (1.8.2)
+    minitest (5.5.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Open Services
+
+A public index of structured social service data
+collected from sources including:
+
+- San Francisco Reentry Council
+- San Francisco Homeless Advocacy Project
+- St. Anthony's of San Francisco
+
+This data set is inspired by and has grown out of
+https://github.com/sfbrigade/sf-openreferral.

--- a/lib/import/apd/import.rb
+++ b/lib/import/apd/import.rb
@@ -1,0 +1,24 @@
+require_relative "../import_helper"
+require_relative "importer"
+require "active_support/inflector"
+require "yaml"
+
+String.include ActiveSupport::Inflector
+
+source = ImportHelper::read_source("apd/guide_2013.txt")
+importer = PlainTextImporter.new(source)
+data = importer.as_json
+dir = "organizations"
+
+data[:organizations].each do |org|
+  filename = "#{dir}/#{org[:name].parameterize[0..100]}"
+  extension = ".yml"
+
+  while File.exist?(filename + extension)
+    puts "Error! Duplicate file: #{filename}"
+    filename = filename + "_dup"
+    puts "Trying as #{filename}"
+  end
+
+  File.write(filename + ".yml", org.to_yaml)
+end

--- a/lib/import/apd/import.rb
+++ b/lib/import/apd/import.rb
@@ -11,6 +11,7 @@ data = importer.as_json
 dir = "organizations"
 
 data[:organizations].each do |org|
+  org[:__meta__] = { version: "0.0.1" }
   filename = "#{dir}/#{org[:name].parameterize[0..100]}"
   extension = ".yml"
 

--- a/lib/import/apd/importer.rb
+++ b/lib/import/apd/importer.rb
@@ -1,0 +1,35 @@
+require_relative "organization_parser"
+
+class PlainTextImporter
+  def initialize(source)
+    @source = source
+  end
+
+  def as_json
+    @json ||= {
+      organizations: organizations
+    }
+  end
+
+  private
+
+  attr_reader :source
+
+  def organizations
+    text_grouped_by_org.map do |org|
+      OrganizationParser.new(org).as_json
+    end
+  end
+
+  def text_grouped_by_org
+    source.scan(/\w[\w\W\n]+?#{last_line}/)
+  end
+
+  def last_line
+    /^Direct Services:.+$/
+  end
+
+  def lines
+    source.split("\n")
+  end
+end

--- a/lib/import/apd/organization_parser.rb
+++ b/lib/import/apd/organization_parser.rb
@@ -1,0 +1,168 @@
+class OrganizationParser
+  EMAIL_REGEX = /\A\s*([^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
+  URL_REGEX = /(?i)\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/
+
+  def initialize(organization_text)
+    @source = organization_text
+  end
+
+  def as_json
+    attributes.map { |attribute| [attribute, send(attribute)] }.to_h
+  end
+
+  private
+
+  attr_reader :source
+
+  def attributes
+    [
+      :accessibility,
+      :address,
+      :contact_name,
+      :description,
+      :eligible_population,
+      :email,
+      :faith_based,
+      :fax,
+      :fees,
+      :languages,
+      :miscellaneous,
+      :name,
+      :phone,
+      :services,
+      :url,
+      :what_to_bring,
+    ]
+  end
+
+  def accessibility
+    labeled_field(:accessibility)
+  end
+
+  def address
+    labeled_field(:address) || line_ending_in_zip_code
+  end
+
+  def line_ending_in_zip_code
+    match = source.match(/.+[^\d]\d{5}$/)
+    match && match.to_s
+  end
+
+  def contact_name
+    labeled_field(:contact_name)
+  end
+
+  def description
+    lines[1].strip.sub(URL_REGEX, "").strip
+  end
+
+  def eligible_population
+    labeled_field(:eligible_population)
+  end
+
+  def email
+    labeled_field(:email) || scan_for_email
+  end
+
+  def scan_for_email
+    match = source.match(EMAIL_REGEX)
+    match && match.to_s
+  end
+
+  def faith_based
+    labeled_field(:faith_based)
+  end
+
+  def fees
+    labeled_field(:fees)
+  end
+
+  def languages
+    parse_english_list(labeled_field(:languages))
+  end
+
+  def miscellaneous
+    lines[2..-1].reject do |line|
+      recognized_lines.any? { |known_line| line =~ known_line }
+    end.join("\n")
+  end
+
+  def recognized_lines
+    labeled_field_lines + ignorable_lines
+  end
+
+  def labeled_field_lines
+    field_labels.values.flatten.map { |label| /^#{label}: / }
+  end
+
+  def field_labels
+    {
+      accessibility: "Accessibility",
+      fees: "Client fees, if any",
+      contact_name: ["Contact Persons", "Contact Person"],
+      services: "Direct Services",
+      eligible_population: "Eligible Population",
+      email: "Email",
+      faith_based: "Faith Based",
+      fax: "Fax",
+      languages: "Languages Spoken",
+      address: "Location",
+      what_to_bring: "What to Bring",
+      phone: "Phone",
+    }
+  end
+
+  def ignorable_lines
+    [
+      /^Things To Know$/,
+      /^To Get Connected$/,
+    ]
+  end
+
+  def name
+    lines.first
+  end
+
+  def phone
+    labeled_field(:phone)
+  end
+
+  def fax
+    labeled_field(:fax)
+  end
+
+  def services
+    parse_semicolon_list(labeled_field(:services))
+  end
+
+  def url
+    source.match(URL_REGEX).to_s
+  end
+
+  def what_to_bring
+    labeled_field(:what_to_bring)
+  end
+
+  def lines
+    source.split(/\n+/).map(&:rstrip)
+  end
+
+  def labeled_field(attribute)
+    potential_labels = Array(field_labels[attribute])
+
+    matches = potential_labels.map do |label|
+      source.match(/(?<=^#{label}: ).+/)
+    end
+
+    result = matches.compact.first
+    result && result.to_s.strip
+  end
+
+  def parse_english_list(text)
+    text.to_s.split(/(\,|\band\b|\.)/).map(&:strip) - [",", "and", "."]
+  end
+
+  def parse_semicolon_list(text)
+    text.to_s.split(/(?<=[a-zA-Z\)]{2})[;\.] */)
+  end
+end

--- a/lib/import/import_helper.rb
+++ b/lib/import/import_helper.rb
@@ -1,0 +1,9 @@
+require "active_support"
+
+module ImportHelper
+  include ActiveSupport::Inflector
+
+  def self.read_source(file)
+    File.read(File.expand_path("../../../sources/#{file}", __FILE__))
+  end
+end

--- a/organizations/a-better-way.yml
+++ b/organizations/a-better-way.yml
@@ -44,3 +44,5 @@
 - Referrals to other resources available as needed
 :url: www.abetterwayinc.net
 :what_to_bring: Medi-Cal or approval from Foster Care Mental Health
+:__meta__:
+  :version: 0.0.1

--- a/organizations/a-better-way.yml
+++ b/organizations/a-better-way.yml
@@ -1,0 +1,46 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1663 Mission Street, San Francisco, CA  94611
+:contact_name: Ann Chu, Program Director
+:description: 'A Better Way (ABW) provides counseling to children and their families. 
+  The agency is a private, non-profit organization.  We mainly service children who
+  are in foster care or at risk of being paced in out of home care.  We have three
+  mental health programs: Therapeutic Visitation Services for families recently separated
+  and in the process of reunification; Outpatient Mental Health Services for children
+  needing individual therapy or families needing family therapy; and Early Childhood
+  Mental Health Services for infants and young children to address their emotional
+  and behavioral development.  Children seen through our program need to be Full-Scope
+  Medi-Cal eligible.'
+:eligible_population: Children are the primary clients; family or adult involvement
+  is through a child.
+:email: achu@abetterwayinc.net
+:faith_based: No.
+:fax: "(415) 715-1051"
+:fees: Client fees are paid by Medi-Cal or per HSA work order.
+:languages:
+- English
+- Spanish
+- Mandarin
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:00am to 6:00pm.
+  Notes: All clients are referred from Human Service Agency and authorized for services through Foster Care Mental Health. We also provide mental health outpatient services for children ages 0-5 who are at risk of emotional and behavioral development difficulties.  These children need to be Full Scope Medi-Cal eligible.
+  Berkeley Office:
+  Restrictions: None.
+  Hours:  Monday-Friday, 8:00am-7:00pm.
+:name: A Better Way
+:phone: "(415) 715-1050"
+:services:
+- Access to Internet
+- Clothing
+- Food/Prepared Meals (snacks and juice for clients)
+- Phone/Voicemail
+- Mental Health Treatment
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Visitation
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/EducationServices for Children
+- Referrals to other resources available as needed
+:url: www.abetterwayinc.net
+:what_to_bring: Medi-Cal or approval from Foster Care Mental Health

--- a/organizations/abode-services.yml
+++ b/organizations/abode-services.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 40849 Fremont Blvd., Fremont, CA  94538
+:contact_name: 
+:description: Abode Services’ mission is to end homelessness by assisting low-income,
+  un-housed people, including those with special needs, to secure stable, supportive
+  housing; and to be advocates for the removal of the causes of homelessness.  Abode
+  Services serves people in Alameda and Santa Clara Counties.
+:eligible_population: Individuals and families who are homeless or about to lose their
+  housing, who live in, or want to relocate to, Alameda and Santa Clara counties
+:email: info@abodeservices.org
+:faith_based: 'No'
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday –Friday, 9am-5pm
+  Notes:  Most of our programs require a referral from a service provider.  However, if
+  you are a veteran, transition-age youth, in need of emergency shelter, or living on the streets, we may be able to help with a referral.  Please contact us via phone or email.  You can also visit tinyurl.com/abodeclinic for the schedule of our mobile health clinic or call (510) 252-0910 to reach our shelter.  No drop-ins at main office.
+:name: Abode Services
+:phone: "(510) 657-7409"
+:services:
+- Emergency Shelter
+- Mobile Health Clinic
+- Housing Assistance for Veterans
+- Services for Transition-Age Youth Formerly in Foster Care
+- Supportive Services for those Reentering the Community through Post Release Control
+  Supervision (must be referred through social worker to Alameda County Sheriff’s
+  Office)
+- Housing Support for Homeless (with low or no income who are seeking to be housed
+  and employed)
+- Medi-Cal and CalFresh Applications for Alameda County
+- Referrals to other resources available as needed
+:url: www.abodeservices.org/
+:what_to_bring: 

--- a/organizations/abode-services.yml
+++ b/organizations/abode-services.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.abodeservices.org/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/aging-and-disability-resource-center.yml
+++ b/organizations/aging-and-disability-resource-center.yml
@@ -1,0 +1,76 @@
+---
+:accessibility: All out stations are accessible
+:address: 1650 Mission St. San Francisco, CA 94103
+:contact_name: 
+:description: Aging and Disability Resource Centers (ADRCs) offer the general public
+  a single source for connecting to free information and assistance on issues affecting
+  older people and people with disabilities, regardless of their income. These resource
+  centers are welcoming and convenient locations for you and your family to get objective
+  and accurate information, advice, and have access to a wide variety of services.  With
+  hubs throughout San Francisco, the ADRC Information and Assistance Specialists provide
+  a wide range of services in multiple languages.
+:eligible_population: Seniors (60+) and Young Adults with Disabilities (18-59).
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- other languages
+- Please call for information
+:miscellaneous: "Office Phone:  Intake\n(415) 487-355-6700\nNotes:  For more info
+  visit one or our ADRC’s or contact ADRC Supervisor at 415-750-4111.\nLocation and
+  Hours:\nRichmond Senior Center:  Golden Gate Senior Services, 6221 Geary Boulevard,
+  3rd Floor, San Francisco, CA  94121, (415)-404-2938 or (415)-752-6444, Monday-Friday
+  9am-3pm (by appointment 8:30am-9am, 3pm-3:30pm)\nAquatic Park Senior Center:  Northern
+  California Presbyterian Homes and Services, 890 Beach Street, San Francisco, CA
+  \ 94109, Spanish (415)-202-2982 or Chinese (415)-202-2983, Monday-Friday 9am-12:30pm,
+  1pm-3pm (by appointment until 4pm)\nToolworks—Main Office:  25 Kearney Street, Suite
+  400, San Francisco, CA  94108,(415)-733-0990 x613, Monday, Tuesday, Thursday, Friday
+  8:30am-4:30pm (Closed Wednesday)\nSelf Help for the Elderly—Main Office:  601 Jackson
+  Street, San Francisco, CA  94108U, (415)-677-7585, Monday, Wednesday, Friday 8:30am-12:30pm
+  , 1:15pm-5:15pm; Tuesday, Thursday 8:30am-12:30pm\nGeen Mun Activity Center:  Self
+  Help for the Elderly,  777 Stockton Street, San Francisco, CA  94108,\n(415)-438-9804,
+  Monday, Wednesday, Friday 8:30am-12:30pm , 1:15pm-5:15pm; Tuesday, Thursday 1:15pm-5:15pm\nSouth
+  Sunset Activity Center:  Self Help for the Elderly, 2601 40th Avenue, San Francisco,
+  CA  94116,\n(415)-566-2845, Monday-Thursday 8:30am-3:00pm , Friday 9am-3pm\nBayview
+  Senior Connections:  Bayview Hunters Point Multipurpose Senior Services, 5600-A
+  3rd Street, San Francisco, CA  94124,(415)-647-5353, Monday-Friday 10am-5pm 8:30am-3:00pm\nDowntown
+  San Francisco Senior Center:  Northern California Presbyterian Homes and Services,
+  481 O’Farrell Street, San Francisco, CA  94102, Spanish (415)-202-2982 Chinese (415)
+  202-2983\nMonday-Friday 9am-12:30pm, 1:00pm-3:30pm (by appointment until 4pm)\nOMI
+  Senior Center:  Catholic Charities, 65 Beverly Street, San Francisco, CA  94132,
+  (415)-334-5550\n\tMonday-Friday 8:30am-2:30pm (by appointment 2:30pm-4pm)\n\n\tOpenhouse—Main
+  Office:  Openhouse (LGBT Hub), 1800 Market Street, 4th Floor, San Francisco, CA
+  \ \t94102, (415)-347-8509, Monday-Friday 9am-5:30pm (by appointment 9am-11:30am,
+  drop-ins \t1pm-4:30pm)\n\t30th Street Senior Center:  225 30th Street, 3rd Floor,
+  San Francisco, CA  94131, (415)-550-2221\n\tMonday-Friday 8:30am-3pm\n\n\tWestern
+  Addition Senior Center:  Bayview Hunters Point Multipurpose Senior Services, 1390
+  ½ Turk \tStreet, San Francisco, CA  94115, (415)-921-7805, Monday-Friday 10am-5pm\n\tDirect
+  Services: The ADRC’s can support individuals with information, referral, and/or
+  assistance in \tthe following areas:  Caregiver Assistance and Support; Case Management
+  Services; Employment \tand Training Opportunities; Financial Assistance and Planning;
+  Food and Nutrition; Health and \tWellness; Housing and Shelter; In-home Care; Legal
+  Assistance; Lesbian, Gay, Bisexual and \tTransgender (LGBT) Programs and Services,
+  Medical and Dental Care; Mental Health and \tCounseling Services; Paperwork and
+  Application Assistance; Prescription Drug Coverage; Senior \tCenters, Translation
+  Services; Transportation.\nEpiscopal Community Services   SF START\nSF-START is
+  designed to provide coordinated and integrated services to support recovery in partnership
+  with Episcopal Community Services’ Skills Center, permanent housing placement support,
+  and benefits advocacy in San Francisco’s single adult homeless shelters.\nurl: www.ecs-sf.org\nPerson
+  to Contact: Contact an SF-START case manager working inside one of the shelters
+  listed below.\nHours: Monday through Saturday, 9:00am to 7:30pm\nNotes: No referral
+  needed. SF-START does not provide shelter beds; it serves people who are already
+  inside the emergency shelter system.\nClient fees: None."
+:name: Aging and Disability Resource Center
+:phone: 
+:services:
+- START team provides case management for individuals with mental health and substance
+  abuse disorders
+- Group Counseling and Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Referrals to other resources available as needed
+:url: www.sfdaas.org
+:what_to_bring: 

--- a/organizations/aging-and-disability-resource-center.yml
+++ b/organizations/aging-and-disability-resource-center.yml
@@ -74,3 +74,5 @@
 - Referrals to other resources available as needed
 :url: www.sfdaas.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/aids-legal-referral-panel-alrp.yml
+++ b/organizations/aids-legal-referral-panel-alrp.yml
@@ -36,3 +36,5 @@
 - Referrals to other services provided, as appropriate
 :url: www.alrp.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/aids-legal-referral-panel-alrp.yml
+++ b/organizations/aids-legal-referral-panel-alrp.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1663 Mission Street, Suite 500
+:contact_name: 
+:description: ALRP works to improve or maintain the health of people living with HIV/AIDS
+  in the San Francisco Bay Area by addressing their legal issues. It provides free
+  and low-cost legal services in areas including housing, employment, insurance, confidentiality
+  matters, family law, credit, government benefits or public accommodations, among
+  others.
+:eligible_population: 
+:email: info@alrp.org
+:faith_based: No.
+:fax: "(415) 701-1400"
+:fees: All ALRP services provided by ALRP staff attorneys are free. Depending on the
+  income and the nature of the case, if the client is referred to an ALRP Panel Attorney,
+  a fee may be charged according to ALRP's Fee Protocol.
+:languages:
+- English
+- Spanish
+- Russian
+- Other languages can be accommodated
+:miscellaneous: |-
+  Specific Intake Days and Times: M-F, 9:00am-5:00pm
+  Hours: Monday – Friday from 9:00am-5:00pm.
+  San Francisco, CA 94103
+  Notes: No referral needed. Please call or write to make an appointment.
+  Eligible Population Served: All individuals and family members who have HIV/AIDS and live in Alameda, Contra Costa, Marin, San Francisco, San Mateo, Sonoma or Solano Counties.
+  Primary Community Served: People living with HIV/AIDS/Lesbian/Gay/Bisexual/Transgender
+:name: AIDS Legal Referral Panel (ALRP)
+:phone: "(415) 701-1100"
+:services:
+- ALRP assists clients with HIV/AIDS with legal issues related to their housing, including
+  eviction defense
+- ALRP also provides assistance with legal issues related to private and public health
+  and disability income insurance
+- Referrals to other services provided, as appropriate
+:url: www.alrp.org
+:what_to_bring: 

--- a/organizations/america-works-of-california-employment-placement-services.yml
+++ b/organizations/america-works-of-california-employment-placement-services.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1663 Mission Street, San Francisco, CA 94103
+:contact_name: Intake
+:description: America Works lifts people out of poverty using its unique brand of
+  intensive, personalized, employment services.  Called “a company with a conscience,”
+  it was founded in 1984 by social activist and entrepreneur Peter Cover.   America
+  Works’ guiding principle is the belief that the best way to lift people out of poverty
+  is to help them find a job—real private sector jobs.  In other words, it believes
+  that work first works best.
+:eligible_population: All individuals supervised by the San Francisco Adult Probation
+  Department.  Must be referred by San Francisco Adult Probation.
+:email: 
+:faith_based: No.
+:fax: "(415) 552-9683"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm.
+  Notes: Clients must be referred by San Francisco Adult Probation.
+:name: America Works of California   Employment Placement Services
+:phone: "(415) 552-9676"
+:services:
+- Employment Placement
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Access to Internet
+- Assistance with Resumes
+- Interview Clothes
+- Referrals to other resources available as needed
+:url: www.americaworks.com
+:what_to_bring: CA ID, Social Security Card.

--- a/organizations/america-works-of-california-employment-placement-services.yml
+++ b/organizations/america-works-of-california-employment-placement-services.yml
@@ -33,3 +33,5 @@
 - Referrals to other resources available as needed
 :url: www.americaworks.com
 :what_to_bring: CA ID, Social Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/anders-and-anders-foundation.yml
+++ b/organizations/anders-and-anders-foundation.yml
@@ -1,0 +1,40 @@
+---
+:accessibility: 
+:address: '1460 McKinnon Ave. #206'
+:contact_name: Terry Anders, Director
+:description: To break the cycle of recidivism through job opportunities.
+:eligible_population: All individuals (men, women, veterans), ages 18 and older, who
+  are formerly incarcerated or have struggled with addiction.
+:email: andersandanders6@yahoo.com
+:faith_based: 'No'
+:fax: 
+:fees: No fees.
+:languages:
+- English
+- some Spanish
+:miscellaneous: |2-
+   To Get Connected
+  Hours: Monday – Friday, 9:00am-7:00pm
+  San Francisco, CA 94124
+  Notes: No referral needed. Please call for appointment. No drop-ins.
+:name: Anders and Anders Foundation
+:phone: "(415) 309-6330"
+:services:
+- 'Assistance with Union Dues:  Assistance with Work Tools and Clothing'
+- Assistance Getting Driver’s License or Other ID
+- Access to Computers
+- Addiction Counseling
+- Mentorship
+- Intensive Case Management
+- Outreach
+- Post-Incarceration Support
+- Basic Remedial Education
+- Employment Training (18 week pre-apprentice green construction training)
+- Employment Placement (union trades—placement in 26 trades)
+- Employment Retention
+- Job Readiness/Life Skills
+- Professional Clothing
+- Referrals to other resources available as needed
+:url: www.andersandandersfoundation.org
+:what_to_bring: State-Issued ID, Social Security Card. Program will assist client
+  in getting these.

--- a/organizations/anders-and-anders-foundation.yml
+++ b/organizations/anders-and-anders-foundation.yml
@@ -38,3 +38,5 @@
 :url: www.andersandandersfoundation.org
 :what_to_bring: State-Issued ID, Social Security Card. Program will assist client
   in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/ara-first-step-home-sober-living-house.yml
+++ b/organizations/ara-first-step-home-sober-living-house.yml
@@ -46,3 +46,5 @@
 - Attendance at meetings is considered a requirement of residence in the Home
 :url: www.arafirststephome.com
 :what_to_bring: Valid Identification
+:__meta__:
+  :version: 0.0.1

--- a/organizations/ara-first-step-home-sober-living-house.yml
+++ b/organizations/ara-first-step-home-sober-living-house.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: 
+:address: 1035 Haight Street, San Francisco, CA  94117
+:contact_name: ARA Staff
+:description: The Alcoholics Rehabilitation Association of San Francisco, Inc., operates
+  the ARA First Step Home, a residence for men and women who are suffering from alcoholism.
+  Our main objective is to return the alcoholic to his or her rightful place in society.
+  The recovery program is oriented towards Alcoholics Anonymous. Help is also provided
+  to make use of community resources to aid in the recovery process. All residents
+  are required to attend the Monday and Thursday A.A. meetings held at 7:30 PM in
+  the First Step Home and one outside meeting of their choice. They will also be required
+  to attend the weekly home forum meeting on Tuesdays at 6:30 PM.
+:eligible_population: 'The primary qualifications for residence in the ARA First Step
+  Home are:'
+:email: arahouse@pacbell.net
+:faith_based: 'No'
+:fax: "(415) 863-3670"
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Specific Intake Days and Times: Monday, Wedensday, Friday 6:30am-9:30am
+  Hours: Monday – Friday, 6:00am to 2:00pm, Saturday and Sunday, 7:00am to 10:00am
+  Notes: Applicants are referred to the house by institutions, clinics, AA clubs, members, doctors, and other responsible individuals.  If you are on probation or parole, you must be on supervision in San Francisco.  We do not accept probationers or parolees from other counties.
+  Checklist
+  1. Call to be sure you meet the minimum requirements.
+  2. Telephone Interview.
+  3. Once accepted to waiting list, check-in Mon, Wed., & Fridays 9-5.
+  4. Know the House Meeting requirements.
+  5. Valid identification
+  6. TB test required upon entering or within 1st seven days.
+
+  Client fee, if any:  Call for information.
+  1. Completion of a primary program (minimum 28 days) within the last year.
+  2. An honest and sincere desire to gain and maintain sobriety.
+  3. The need for food, shelter, and an atmosphere of friendly understanding.
+  4. Ability and willingness to accept gainful employment.
+:name: ARA First Step Home   Sober Living House
+:phone: "(415) 863-3661"
+:services:
+- Sober Living
+- Transitional Housing
+- Meals
+- AA Meetings
+- There are three meetings of Alcoholics Anonymous held at the Home each week
+- Attendance at meetings is considered a requirement of residence in the Home
+:url: www.arafirststephome.com
+:what_to_bring: Valid Identification

--- a/organizations/arab-cultural-and-community-center.yml
+++ b/organizations/arab-cultural-and-community-center.yml
@@ -20,3 +20,5 @@
 - Referrals to range of community resources and social services
 :url: ''
 :what_to_bring: State-Issued ID; Proof of San Francisco residency.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/arab-cultural-and-community-center.yml
+++ b/organizations/arab-cultural-and-community-center.yml
@@ -1,0 +1,22 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 2 Plaza Street, San Francisco, CA 94116
+:contact_name: 
+:description: Assist immigrant families in adjusting/adapting to hardships in American
+  societies, and aim to provide any services needed through referrals.
+:eligible_population: All individuals, and family members.
+:email: info@arabculturalcenter.org
+:faith_based: No.
+:fax: "(415) 664-2280"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday - Friday, 10:00am to 5:00pm
+  Notes: No referral needed. By appointment only. No drop-ins.
+:name: Arab Cultural and Community Center
+:phone: "(415) 664-2200"
+:services:
+- Referrals to range of community resources and social services
+:url: ''
+:what_to_bring: State-Issued ID; Proof of San Francisco residency.

--- a/organizations/arriba-juntos-power-up-youth.yml
+++ b/organizations/arriba-juntos-power-up-youth.yml
@@ -33,3 +33,5 @@
 - Referrals to other resources available as needed
 :url: www.arribajuntos.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/arriba-juntos-power-up-youth.yml
+++ b/organizations/arriba-juntos-power-up-youth.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: 
+:address: 
+:contact_name: Mark Aquino, Youth Program Coordinator
+:description: Arriba Juntos provides educational and employment programs on a citywide
+  basis serving many neighborhoods and many different ethnic groups and cultures.
+  Its mission is to promote economic self sufficiency through employment services
+  and vocational education.
+:eligible_population: All individuals, ages 14-24, including pregnant women, women
+  with children, families, and individuals on Juvenile Probation.
+:email: maquino@arribajuntos.org
+:faith_based: No.
+:fax: "(415) 401-4899"
+:fees: 
+:languages: []
+:miscellaneous: 'Hours: Monday – Friday, 9:00am to 5:00pm'
+:name: Arriba Juntos   Power Up Youth
+:phone: "(415) 401-4931"
+:services:
+- Access to Internet
+- Youth Computer Lab
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Interview Attire
+- Prepared Meals on Thursdays and Snacks for Clients
+- Personal Hygiene Items
+- Postal Services
+- Transit Vouchers for WIA-Qualified Clients
+- Mental Health Specialist for Victims and Witnesses of Violence
+- GED Program
+- Application for Food Stamps
+- Employment and Job Readiness Services
+- Referrals to other resources available as needed
+:url: www.arribajuntos.org
+:what_to_bring: 

--- a/organizations/asian-american-recovery-services-comprehensive-outreach-program-for-pacific-islanders-and-asian-subst.yml
+++ b/organizations/asian-american-recovery-services-comprehensive-outreach-program-for-pacific-islanders-and-asian-subst.yml
@@ -30,3 +30,5 @@
 - Referrals to other resources available as needed
 :url: www.aars.org
 :what_to_bring: TB Clearance. Program will assist clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/asian-american-recovery-services-comprehensive-outreach-program-for-pacific-islanders-and-asian-subst.yml
+++ b/organizations/asian-american-recovery-services-comprehensive-outreach-program-for-pacific-islanders-and-asian-subst.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 2166 Hayes Street, Suite 206, San Francisco, CA  94117
+:contact_name: Stephen Fields, Program Manager.
+:description: Asian American Recovery Services COPPASA's, a program of Healthright360,
+  provides challenged and underserved community members with mental health and substance
+  abuse pretreatment services for direct placement into San Francisco based community
+  programs.
+:eligible_population: All individuals who do not have a criminal conviction for arson
+  and are not registered sex offenders.
+:email: sfields@aars.org
+:faith_based: No.
+:fax: "(415) 876-6850"
+:fees: Public Health Funded, no client is turned away for lack of money or insurance.
+:languages:
+- English
+:miscellaneous: |
+  url: www.aars.org
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Drop-ins are welcome.
+:name: Asian American Recovery Services   Comprehensive Outreach Program for Pacific
+  Islanders and Asian Substance Abusers (COPPASA)
+:phone: "(415) 541-9404"
+:services:
+- Transit Vouchers
+- Counseling and Referral to Treatment
+- Prevention and Pretreatment Counseling
+- Family Crisis Intervention
+- Mental Health and AOD Intervention
+- Referrals to other resources available as needed
+:url: www.aars.org
+:what_to_bring: TB Clearance. Program will assist clients in getting these.

--- a/organizations/asian-american-recovery-services-lee-woodward-counseling-center.yml
+++ b/organizations/asian-american-recovery-services-lee-woodward-counseling-center.yml
@@ -39,3 +39,5 @@
 :url: www.aars.org
 :what_to_bring: Proof of SF Residency, TB Clearance. Program will assist clients in
   getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/asian-american-recovery-services-lee-woodward-counseling-center.yml
+++ b/organizations/asian-american-recovery-services-lee-woodward-counseling-center.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: Lee Woodward Counseling Center, 2166 Hayes Street, Suite 303, San Francisco,
+  CA 94117
+:contact_name: Nicole Richards or Stephen Fields for program information and intakes.
+:description: Asian American Recovery Services LWCC, a program of Healthright360,
+  is committed to providing services that will support women, children, and their
+  families to develop strengths, skills and self determination in an addiction-free
+  life. We provide a safe haven where women and children can rebuild their lives through
+  a program of recovery and learn to break the intergenerational cycle of addiction.
+:eligible_population: Mothers and children, women of color, transgender individuals,
+  women with co-occurring disorders and physical health problems; Women seeking non-residential
+  treatment services. May not have a criminal conviction for arson; may not be a registered
+  sex offender.
+:email: sfields@aars.org
+:faith_based: No.
+:fax: 
+:fees: Public Health funded, no clients is turned away for lack of money or insurance.
+:languages:
+- English
+:miscellaneous: |-
+  url: www.aars.org
+  Notes: No referral needed. Drop-ins are welcome.
+:name: Asian American Recovery Services   Lee Woodward Counseling Center
+:phone: "(415) 776-1001"
+:services:
+- Access to Internet
+- Food/Prepared Meals
+- Phone/Voicemail
+- Substance Abuse Treatment
+- Anger Management
+- Individual Counseling and group sessions
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Childcare (provided for participating clients while in program)
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.aars.org
+:what_to_bring: Proof of SF Residency, TB Clearance. Program will assist clients in
+  getting these.

--- a/organizations/asian-american-recovery-services-project-adapt.yml
+++ b/organizations/asian-american-recovery-services-project-adapt.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 2020 Hayes Street, San Francisco, CA 94117
+:contact_name: Nicole Richards or Stephen Fields for program information and intakes.
+:description: Asian American Recovery Services Project ADAPT, a program of Healthright360,
+  provides outpatient drug and alcohol treatment to individuals that adheres to a
+  holistic approach intended to promote the development of a healthy body, mind and
+  spirit. The aim is to help individuals reduce substance use and develop a clean
+  and sober lifestile.
+:eligible_population: Must be a resident of San Francisco, over the age of 18, have
+  a drug or alcohol problem.
+:email: sfields@aars.org
+:faith_based: No.
+:fax: 
+:fees: Sliding scale.
+:languages:
+- English
+- Cantonese
+- Mandarin
+- Tagalog
+- Korean
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Call or write for appointment. No drop-ins.
+:name: Asian American Recovery Services   Project ADAPT
+:phone: "(415) 541-9404"
+:services:
+- Substance Abuse Treatment
+- Individual Counseling and Group Sessions
+- Group Counseling/Therapy
+- Referrals to other resources available as needed
+:url: www.aars.org
+:what_to_bring: TB Clearance.

--- a/organizations/asian-american-recovery-services-project-adapt.yml
+++ b/organizations/asian-american-recovery-services-project-adapt.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.aars.org
 :what_to_bring: TB Clearance.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/asian-american-recovery-services.yml
+++ b/organizations/asian-american-recovery-services.yml
@@ -55,3 +55,5 @@
 :url: www.aars.org
 :what_to_bring: Proof of SF Residency, TB Clearance. Program will assist entering
   clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/asian-american-recovery-services.yml
+++ b/organizations/asian-american-recovery-services.yml
@@ -1,0 +1,57 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities accommodated.
+:address: 2024 Hayes Street, San Francisco, CA 94117
+:contact_name: Stephen Fields, Program Manager
+:description: Our primary goal is to change an individual's substance-abusing lifestyle.
+  This change comes about through four fundamental processes. First, individuals must
+  acknowledge their problems, their own roles and responsibilities in abusing substances.
+  Second, they must have the willingness to resolve and change their substance abusing
+  behavior. Third, there needs to be an understanding and reconciliation of any conflict
+  within themselves, their families and cultural traditions. Finally, they need to
+  develop abilities and skills in managing their lives in the social, economic and
+  political reality of their environment and community. The AARS-residential is a
+  therapeutic community which recognizes the need for providing structure, support
+  and opportunity within a multi-cultural environment. It is a highly structured environment
+  with defined boundaries, both moral and ethical. The program employs community imposed
+  sanctions as well as earned advancement of status and privileges as part of the
+  recovery and growth process. Being part of something greater than oneself is an
+  especially important factor in facilitating positive growth.
+:eligible_population: Men, Women, 18 and older. May not have criminal conviction for
+  sex offense, gang-related offense, or arson. May not be a registered sex offender.
+:email: sfields@aars.org
+:faith_based: No.
+:fax: "(415) 776-1011"
+:fees: No fee.
+:languages:
+- English
+- Cantonese
+:miscellaneous: |-
+  Facility Hours: 24 hours/7days. Intake hours Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Call or write for appointment. No drop-ins.  This is a smoke free facility.
+:name: Asian American Recovery Services
+:phone: "(415) 541-9404"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/ Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Shower Facilities
+- Substance
+- Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Anger Management
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Assessment & Application for Food Stamps
+- Assessment & Application for General Assistance
+- Family Reunification
+- Referrals to other resources available as needed
+:url: www.aars.org
+:what_to_bring: Proof of SF Residency, TB Clearance. Program will assist entering
+  clients in getting these.

--- a/organizations/asian-law-caucus.yml
+++ b/organizations/asian-law-caucus.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 55 Columbus Ave , San Francisco, CA 94111
+:contact_name: Phil Van, Intake Coordinator
+:description: The mission of the Asian Law Caucus is to promote, advance, and represent
+  the legal and civil rights of Asian and Pacific Islander (API) communities. Recognizing
+  that social, economic, political and racial inequalities continue to exist in the
+  United States, the Asian Law Caucus is committed to the pursuit of equality and
+  justice for all sectors of our society, with a specific focus directed toward addressing
+  the needs of low-income, immigrant and underserved APIs.
+:eligible_population: 
+:email: philipv@asianlawcaucus.org
+:faith_based: No.
+:fax: "(415) 896-1702"
+:fees: None.
+:languages:
+- Cantonese
+- Mandarin
+- Tagalog
+- Vietnamese
+- Gujarati
+- Thai
+:miscellaneous: |-
+  Since the vast majority of Asians and Pacific Islanders in America are immigrants and refugees, the Caucus strives to create informed and educated communities empowered to assert their rights and to participate actively in American society. This perspective is reflected in our broad strategy which integrates the provision of legal services, educational programs, community organizing initiatives and advocacy. www.asianlawcaucus.org
+  Hours: Monday – Friday from 9:00am-5:00pm. Some evening and weekend clinics.
+  Notes: No referral needed. Please call or write for an appointment.
+  What to bring: Proof of income.
+  Eligible Population Served:
+  All individuals and family members.
+:name: Asian Law Caucus
+:phone: "(415) 896-1701"
+:services:
+- Community Education & Mediation
+- Know Your Rights Trainings
+- Inmate & Parolee Legal Issues, mainly juvenile and deportation cases
+- employment law and employment discrimination
+- Housing & Eviction Defense
+- Restraining/Stay Away Orders
+- Voting Outreach & Education
+- Census and Redistricting advocacy
+- Referrals to other services provided, as appropriate
+:url: www.asianlawcaucus.org
+:what_to_bring: 

--- a/organizations/asian-law-caucus.yml
+++ b/organizations/asian-law-caucus.yml
@@ -41,3 +41,5 @@
 - Referrals to other services provided, as appropriate
 :url: www.asianlawcaucus.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/asian-neighborhood-design-construction-training-program.yml
+++ b/organizations/asian-neighborhood-design-construction-training-program.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1021 Mission St. San Francisco, CA  94103
+:contact_name: Chris Reyes, Program Manager
+:description: Our mission is to reduce poverty by building communities and providing
+  opportunities for low-income residents to become economically self sufficient.
+:eligible_population: Men, Women, Transgender people, ages 17 and older, Women with
+  children, All families. Individuals with criminal convictions for a sex offense
+  are considered on a case-by-case basis.
+:email: creyes@andnet.org
+:faith_based: No.
+:fax: "(415) 575-0425"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 7:00pm to 3:30pm.
+  Orientation are Thursdays, 10:00am
+  Notes: No referral needed. Drop-ins are welcome, but orientations are held every Thursday at 10am.
+:name: Asian Neighborhood Design   Construction Training Program
+:phone: "(415) 575-0423 x218"
+:services:
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Light Meals
+- Access to Phones
+- Transit Vouchers
+- Anger Management
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Intensive Case Management
+- Mentorship
+- Post-Incarceration Support
+- Basic/Remedial Education
+- GED and High School Education with 5 Keys Charter School on-site
+- Job Skills
+- Job Readiness
+- Job Placement
+- Construction Job Training
+- Employment Retention
+- Money Management/Personal Financial Education
+- Referrals provided for mental health treatment, medical care, dental care, vision
+  care, trauma recovery services
+- Referrals to other resources available as needed
+:url: www.andnet.org
+:what_to_bring: Proof of SF Residency.

--- a/organizations/asian-neighborhood-design-construction-training-program.yml
+++ b/organizations/asian-neighborhood-design-construction-training-program.yml
@@ -46,3 +46,5 @@
 - Referrals to other resources available as needed
 :url: www.andnet.org
 :what_to_bring: Proof of SF Residency.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/bay-area-addiction-research-and-treatment-baart-programs.yml
+++ b/organizations/bay-area-addiction-research-and-treatment-baart-programs.yml
@@ -32,3 +32,5 @@
 - Referrals to other resources available as needed
 :url: www.baartprograms.com
 :what_to_bring: State-Issued ID.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/bay-area-addiction-research-and-treatment-baart-programs.yml
+++ b/organizations/bay-area-addiction-research-and-treatment-baart-programs.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1111 Market Street, San Francisco, CA  94103
+:contact_name: Kevin Houston, Intake Coordinator
+:description: BAART's/BBHS's mission is to provide people with cost effective, short-term
+  substance abuse treatment and other health care services, including primary medical
+  care, at its clinics or through community linkages, and to make such services available
+  to as many people as possible who seek them.
+:eligible_population: All individuals and family members, ages 18 and older
+:email: khouston@baartprograms.com
+:faith_based: No.
+:fax: "(415) 863-7343"
+:fees: 
+:languages:
+- English
+- Spanish
+- Tagalog
+- Russian
+:miscellaneous: |-
+  Market Street Hours: Weekdays except Wednesday ,6:00am to 2:00pm (Wednesday, 6:00am to 12:00pm); Saturday and Sunday, 8:00am to 12:00pm.
+  Notes: No referral needed.  Drop-ins welcome
+  Turk Street Hours: Weekdays except Wednesday, 7:00am to 3:00pm (Wednesday, 7:00am to 1:00pm); Saturday and Sunday, 8:00am to 12:00pm
+  Notes: No referral needed. Drop-ins welcome.
+  Client Fees:  Based on sliding scale.  Private insurance, Medi-Cal.
+:name: Bay Area Addiction Research and Treatment   BAART Programs
+:phone: "(415) 863-3883"
+:services:
+- Mental Health Treatment
+- Substance Abuse Treatment (Methadone/Suboxone)
+- Individual Counseling/Therapy
+- Turk Street location offrers FACET program for pregnant clients on methadone
+- Referrals to other resources available as needed
+:url: www.baartprograms.com
+:what_to_bring: State-Issued ID.

--- a/organizations/bay-area-addiction-research-and-treatment-community-healthcare.yml
+++ b/organizations/bay-area-addiction-research-and-treatment-community-healthcare.yml
@@ -33,3 +33,5 @@
 - Referrals to other resources available as needed
 :url: www.baartprograms.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/bay-area-addiction-research-and-treatment-community-healthcare.yml
+++ b/organizations/bay-area-addiction-research-and-treatment-community-healthcare.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1111 Market Street, San Francisco, CA  94103
+:contact_name: Medical Secretary
+:description: BAART Community HealthCare is a non-profit entity established to provide
+  medical care through a network of community clinics. BCH focuses primarily on providing
+  low cost primary care services to indigent populations. BCH and its predecessors
+  have been providing services for 35 years.    www.baarthealthcare.org/index.html
+:eligible_population: All individuals and family members, ages 18 and older.
+:email: 
+:faith_based: No.
+:fax: "(415) 863-7343"
+:fees: Medi-Cal, SFHP, Sliding fee scale, BCC
+:languages:
+- English
+- Spanish
+- Tagalog
+- Russian
+:miscellaneous: |-
+  Contact person:  Medical Secretary
+  Market Street Hours: Weekdays except Wednesday ,6:00am to 2:00pm (Wednesday, 6:00am to 12:00pm)
+  Notes: No referral needed.  Drop-ins welcome
+  Turk Street Hours: Weekdays except Wednesday, 7:00am to 3:00pm (Wednesday, 7:00am to 1:00pm)
+  Notes: No referral needed. Drop-ins welcome.
+:name: Bay Area Addiction Research And Treatment   Community HealthCare
+:phone: "(415) 863-3883"
+:services:
+- Medical Care
+- Mental Health Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Assessment & Application for SSI
+- Referrals to other resources available as needed
+:url: www.baartprograms.com
+:what_to_bring: 

--- a/organizations/bay-area-legal-aid-baylegal.yml
+++ b/organizations/bay-area-legal-aid-baylegal.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: Wheelchair accessible. Will provide whatever ADA accommodation is
+  necessary for any disability.
+:address: No drop-in services provided. Please call Legal Advice Line for screening.
+:contact_name: 
+:description: BayLegal's clients are low- and very low-income members of our communities.
+  BayLegal's clients are spread across our seven county service area, from San Francisco
+  to Livermore, Gilroy to Napa. They include the working poor, our elderly neighbors,
+  military veterans, people with disabilities, and single mothers.
+:eligible_population: Must be out of custody.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Vietnamese
+- Mandarin
+- Cantonese
+- Tagalog
+- French
+- BayLegal will serve clients in any other languages through use of Language Line
+  or other assistance
+:miscellaneous: |-
+  Legal Advice Line for Screening:
+  (415) 354-6360
+  Hours:
+  Monday and Thursday, 9:30am-3:00pm
+  Tuesday and Wednesday, 9:30am-1:00pm
+  1035 Market St., San Francisco, CA 94103
+  Notes: No referrals needed.
+  Client fees: None.
+:name: Bay Area Legal Aid (BayLegal)
+:phone: 
+:services:
+- Housing & Eviction Defense
+- Access to Public Benefits
+- Law for Domestic Violence Survivors
+- For PAES recipients, any civil legal issue that makes it harder to get or keep a
+  job, such as driver's license suspension, child support orders, or credit issues
+  (including referrals to Clean Slate/Conviction Expungement Services)
+- Will not provide assistance with contesting a Temporary Restraining Order for people
+  with prior criminal convictions for violence
+- For health care access issues such as Medi-Cal, Medi-Care, Covered California or
+  private health insurance, contact our Health Consumer Center at (855) 693-7285.
+  Referrals to other services provided, as appropriate
+:url: www.baylegal.org
+:what_to_bring: If you receive an appointment after being screened by the Legal Advice
+  Line, identification and documentation of U.S. citizenship or non-citizen status.
+  BayLegal may assist in securing these documents.

--- a/organizations/bay-area-legal-aid-baylegal.yml
+++ b/organizations/bay-area-legal-aid-baylegal.yml
@@ -49,3 +49,5 @@
 :what_to_bring: If you receive an appointment after being screened by the Legal Advice
   Line, identification and documentation of U.S. citizenship or non-citizen status.
   BayLegal may assist in securing these documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/bay-area-women-s-children-s-center.yml
+++ b/organizations/bay-area-women-s-children-s-center.yml
@@ -31,3 +31,5 @@
   available as needed
 :url: www.bawcc.org
 :what_to_bring: Some form of I.D.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/bay-area-women-s-children-s-center.yml
+++ b/organizations/bay-area-women-s-children-s-center.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 318 Leavenworth Street, San Francisco, CA 94102
+:contact_name: Diane Van Stralen, Nancy Ong or Midge Wilson
+:description: BAWCC offers a variety of direct services that address immediate needs
+  and assists with achieving long-term stability. BAWCC's advocacy, planning and policy
+  work on issues of low-income children and families has had a positive impact on
+  the lives of thousands since we opened in 1981. BAWCC's long-term projects have
+  resulted in the creation of playgrounds, a recreation center, school, and family
+  center.
+:eligible_population: Women, Transgender individuals, including those pregnant or
+  with children.
+:email: 
+:faith_based: No.
+:fax: "(415)474-5525"
+:fees: None.
+:languages:
+- English
+- Cantonese
+- Mandarin
+- Limited Spanish
+- "& Vietnamese"
+:miscellaneous: |-
+  Hours: Tuesdays and Thursdays, 8:30am to 12:30pm (drop-in)
+  Notes: No referral needed. Drop-ins are welcome. Appointments can be made.
+:name: Bay Area Women’s & Children’s Center
+:phone: "(415) 474-2400"
+:services:
+- Clothing, Dental Care (in partnership with UCSF), Food pantry, Literacy/Basic Education,
+  Scholarship fund for Tenderloin college age students,. Referrals to other resources
+  available as needed
+:url: www.bawcc.org
+:what_to_bring: Some form of I.D.

--- a/organizations/black-coalition-on-aids.yml
+++ b/organizations/black-coalition-on-aids.yml
@@ -33,3 +33,5 @@
 - and referrals for health screening, treatment and primary care
 :url: www.bcoa.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/black-coalition-on-aids.yml
+++ b/organizations/black-coalition-on-aids.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: 
+:address: 601 Cesar Chavez Street, San Francisco, CA 94124
+:contact_name: Francis Broome, Coordinator of Prevention and Education
+:description: The Black Coalition on AIDS (BCA) focuses on reducing health disparities
+  in the Black community, most notably, the spread of HIV/AIDS. BCA strives to achieve
+  this focus by providing health and wellness services including, but not limited
+  to, transitional housing, health education, advocacy, health case management and
+  other health-promoting activities.
+:eligible_population: African Americans, HIV + individuals and those at risk for HIV
+  and other health disparities
+:email: fbroome@bcoa.org or bcoa@bcoa.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: ''
+:name: Black Coalition on AIDS
+:phone: "(415) 615-9945, ext. 114"
+:services:
+- Transitional housing
+- health case management
+- counseling
+- community outreach
+- health education workshops
+- drop-in and support groups
+- health enhancement and stress reduction classes
+- complementary alternative medicine
+- wellness services
+- dinner-and-a-movie night
+- women’s HIV prevention education
+- and referrals for health screening, treatment and primary care
+:url: www.bcoa.org
+:what_to_bring: 

--- a/organizations/california-pacific-medical-center-pep-jobs.yml
+++ b/organizations/california-pacific-medical-center-pep-jobs.yml
@@ -29,3 +29,5 @@
 :url: www.cpmc/org/pepjobs
 :what_to_bring: Proof of right-to-work documents such as, State-Issued ID; Social
   Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/california-pacific-medical-center-pep-jobs.yml
+++ b/organizations/california-pacific-medical-center-pep-jobs.yml
@@ -1,0 +1,31 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: CPMC Davies Campus, 45 Castro Street, B-Level, South Tower, San Francsico,
+  CA  94114
+:contact_name: Tom Post or Lia Kantor, Employment Coordinators
+:description: The mission of PEP Jobs is to serve people with epilepsy and/or brain
+  injuries in navigating a career path, including finding and maintaining suitable
+  employment, offering the highest quality assistance possible.
+:eligible_population: All individuals, ages 18 and older, with a medical diagnosis
+  of epilepsy or traumatic/acquired brain injury. Must be clean and sober for at least
+  90 days prior to intake.
+:email: infopep@sutterhealth.org
+:faith_based: No.
+:fax: "(415) 600-4879"
+:fees: No fees.
+:languages:
+- English
+- Translation services available
+:miscellaneous: |-
+  Lia Kantor:  (415) 600-4878
+  Notes: Referral from CA Department of Rehabilitation - 301 Howard St, San Francisco, CA 94105. Call 415-904-4100. No Drop-ins.
+:name: California Pacific Medical Center   PEP Jobs
+:phone: 'Tom Post:  (415) 600-4875;'
+:services:
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Referrals to other resources available as needed
+:url: www.cpmc/org/pepjobs
+:what_to_bring: Proof of right-to-work documents such as, State-Issued ID; Social
+  Security Card.

--- a/organizations/catholic-charities-cyo-leland-house.yml
+++ b/organizations/catholic-charities-cyo-leland-house.yml
@@ -41,3 +41,5 @@
 :url: www.cccyo.org
 :what_to_bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance;
   Medi-Cal card or other proof of insurance so that medications can be ordered.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/catholic-charities-cyo-leland-house.yml
+++ b/organizations/catholic-charities-cyo-leland-house.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 141 Leland Avenue, San Francisco, CA  94134
+:contact_name: Timothy Quinn, Intake Coordinator
+:description: Cathonic Charities/CYO’s mission is to house homeless people with disabling
+  HIV and AIDS. At Leland House, which provides permanent housing, we respond to residents
+  on a Harm Reduction basis working with behaviors as they become difficult for others
+  and when they  impede the safety of the resident themselves.
+:eligible_population: All currently homeless individuals, 18 years or older, with
+  disabling HIV or AIDS, psychiatric disorders or substance abuse issues.
+:email: TQuinn@cccyo.org
+:faith_based: No.
+:fax: "(415) 337-1137"
+:fees: Rent is calculated at 30% of monthly income. There is an annual income limit.
+:languages:
+- English
+- Spanish
+- German
+:miscellaneous: |-
+  Intake Days: Wednesdays and Thursdays
+  Facility Hours: 24 hours/7 days
+  Notes: Referral required. Intake appointment needed – no drop-ins.
+:name: Catholic Charities/CYO   Leland House
+:phone: "(415) 405-2063"
+:services:
+- Permanent Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Food/Prepared Meals
+- P.O. Box/Mail Service
+- Voicemail
+- Shower Facilities
+- Utilities (hot water, heat)
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education through in house dietician
+- Anger Management
+- Group Counseling/Therapy - Anger Management, HIV Support, Harm Reduction
+- Money Management/Personal Financial Education
+- Many additional supportive services available upon referral behavioral health, employment,
+  case management, and other specialists, as needed
+:url: www.cccyo.org
+:what_to_bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance;
+  Medi-Cal card or other proof of insurance so that medications can be ordered.

--- a/organizations/cats-a-woman-s-place-care-program.yml
+++ b/organizations/cats-a-woman-s-place-care-program.yml
@@ -27,3 +27,5 @@
 :url: www.catsinc.org
 :what_to_bring: Letter of Diagnosis for HIV+ and tb clearance documentation – both
   within 6 months; current income verification.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cats-a-woman-s-place-care-program.yml
+++ b/organizations/cats-a-woman-s-place-care-program.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1049 Howard St. San Francisco, CA 94103
+:contact_name: Pau Lagarde, HIV Case Manager/Mental Health Worker
+:description: The CARE Program offers Transitional Housing for up to 18 months available
+  for HIV+ women (including transgender women) residents of San Francisco; services
+  also include case management and – if needed – mental health counseling.
+:eligible_population: Homeless HIV+ women (including transgender women) residents
+  of San Francisco.
+:email: pau@awpcats.org
+:faith_based: No.
+:fax: 
+:fees: 30% of monthly net income, plus requirement to set aside additional money in
+  savings account – amount to be determined.
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  Days and Times: Sunday-Thursday, 8am-4pm.
+  Notes: Prefer that clients be referred by service provider, but clients can self-refer by calling contact person (above) and scheduling intake appointment.  Clients must provide documentation of HIV+ status and income verification at intake.  Program is Harm-Reduction-based: there are no sobriety requirements for clients, but no substance use is allowed on the premises.
+:name: CATS   A Woman’s Place-CARE Program
+:phone: "(415) 293-7364"
+:services:
+- Transitional Housing
+- Case Management
+- Mental Health Counseling
+:url: www.catsinc.org
+:what_to_bring: Letter of Diagnosis for HIV+ and tb clearance documentation – both
+  within 6 months; current income verification.

--- a/organizations/center-for-employment-opportunities-ceo-employment-services.yml
+++ b/organizations/center-for-employment-opportunities-ceo-employment-services.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1212 Broadway, Suite 1700, Oakland, CA  94612
+:contact_name: Intake
+:description: The Center for Employment Opportunities (CEO) is dedicated to providing
+  immediate, effective and comprehensive employment services to men and women with
+  recent criminal convictions. Our highly structured and tightly supervised programs
+  help participants regain the skills and confidence needed for successful transitions
+  to stable, productive lives.  CEO’s vision is that anyone with a recent criminal
+  history who wants to work has the preparation and support needed to find a job and
+  to stay connected to the labor force.
+:eligible_population: All individuals over the age of 18 referred from Alameda County
+  Parole or Alameda County Probation
+:email: 
+:faith_based: 'No'
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday –Friday, 8am-5pm
+  Notes:  Please call for more information. Must be on Alameda County Parole or Alameda County Probation.  Please get referral from supervising officer.
+:name: Center For Employment Opportunities (CEO)   Employment Services
+:phone: "(510) 251-2240"
+:services:
+- Job Readiness/Life Skills
+- Employment Training
+- Employment Placement
+:url: www.ceoworks.org
+:what_to_bring: 

--- a/organizations/center-for-employment-opportunities-ceo-employment-services.yml
+++ b/organizations/center-for-employment-opportunities-ceo-employment-services.yml
@@ -28,3 +28,5 @@
 - Employment Placement
 :url: www.ceoworks.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/center-for-restorative-justice-works-get-on-the-bus.yml
+++ b/organizations/center-for-restorative-justice-works-get-on-the-bus.yml
@@ -41,3 +41,5 @@
   board buses and travel from cities all over the State of California to be united
 :url: www.crjw.us
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/center-for-restorative-justice-works-get-on-the-bus.yml
+++ b/organizations/center-for-restorative-justice-works-get-on-the-bus.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: ADA compliant.
+:address: 6400 Laurel Canyon Blvd. Ste 304
+:contact_name: 
+:description: The Center for Restorative Justice Works unites children, families and
+  communities separated by crime and the criminal justice system. CRJW calls the community
+  to set aside pre-judgments about women and men in prison in order to work together
+  to accompany families torn apart by the crime and the criminal justice system; create
+  awareness about the negative impacts of incarceration on children and families;
+  and advocate for programs and policies that restore relationships.  CJRW re-weaves
+  the web of relationships that have been torn apart by crime and the policies of
+  the criminal justice system. Get on the Bus is a program of The Center for Restorative
+  Justice Works. Get On The Bus brings children and their guardians/caregivers from
+  throughout the state of California to visit their mothers and fathers in prison.
+  An annual event, Get On The Bus offers free transportation for the children and
+  their caregivers to the prison, provides travel bags for the children, comfort care
+  bags for the caregivers, a photo of each child with his or her parent, and meals
+  for the day (breakfast, snacks on the bus, lunch at the prison, and dinner on the
+  way home) — all at no cost to the children’s family. On the bus trip home, following
+  a four-hour visit, each child receives a teddy bear with a letter from their parent
+  and post-event counseling.       www.getonthebus.us
+:eligible_population: Children (Infant to 18 yrs.) of incarcerated Mothers & Fathers
+  (including caregivers).
+:email: info@getonthebus.us
+:faith_based: Inter-Faith.
+:fax: "(818) 980-7702"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Contact Persons:
+  Main Office:  Southern California Office
+  Hours: Monday – Friday, 9:00am to 5:00pm Intake Tuesday – Friday.
+  North Hollywood, CA  91606
+  Notes: No referral needed.  Applications are received from the incarcerated parent at select institutions.  Call for more info..
+:name: Center for Restorative Justice Works   Get On The Bus
+:phone: "(818) 980-7714"
+:services:
+- Each year around Mothers Day and Father’s Day, hundreds of children and their caregivers
+  board buses and travel from cities all over the State of California to be united
+:url: www.crjw.us
+:what_to_bring: 

--- a/organizations/center-for-young-womens-development-sisters-rising-gdap.yml
+++ b/organizations/center-for-young-womens-development-sisters-rising-gdap.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: '832 Folsom Street, Suite #700, San Francisco, CA 94107'
+:contact_name: Program Director
+:description: For 20 years, the Center for Young Women’s Development has empowered
+  and inspired thousands of young women experiencing incarceration or life on the
+  streets to create positive personal and social change.  CYWD offers a paid internship
+  program for young women exiting the juvenile justice system or underground street
+  economy.  Our mission is to empower and inspire young women who have been involved
+  with the juvenile justice system and/or the underground street economy to create
+  positive change in their lives and communities.
+:eligible_population: Women and girls ages 12-24, Pregnant women, Women with children
+  who are involved in the criminal/juvenile justice system.
+:email: info@cywd.org
+:faith_based: No.
+:fax: "(415) 703-8818"
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm Intake Monday – Friday.
+  Notes: No referral needed. Drop-ins welcome.
+:name: Center for Young Womens Development   Sisters Rising & GDAP
+:phone: "(415) 703-8800"
+:services:
+- Employment Program
+- Access to Internet
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Phone/Voicemail
+- Community Education & Mediation
+- Post-Incarceration Support
+- Employment Training
+- Referrals to other resources available as needed
+:url: www.cywd.org
+:what_to_bring: 

--- a/organizations/center-for-young-womens-development-sisters-rising-gdap.yml
+++ b/organizations/center-for-young-womens-development-sisters-rising-gdap.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.cywd.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/center-on-juvenile-and-criminal-justice-cjcj-cameo-house-alternative-sentcing-program.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-cjcj-cameo-house-alternative-sentcing-program.yml
@@ -78,3 +78,5 @@
 - Referrals to other resources available as needed
 :url: www.cjcj.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/center-on-juvenile-and-criminal-justice-cjcj-cameo-house-alternative-sentcing-program.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-cjcj-cameo-house-alternative-sentcing-program.yml
@@ -1,0 +1,80 @@
+---
+:accessibility: 
+:address: Located in San Francisco. Write to Cameo House, 40 Boardman Place, San Francisco,
+  CA 94103.
+:contact_name: Intake/Staff
+:description: In partnership with the San Francisco Adult Probation Department, the
+  Center on Juvenile and Criminal Justice’s Cameo House serves criminally involved
+  pregnant and parenting women, who are certified as homeless (as defined by the City
+  and County of San Francisco).  The goal of Cameo House is to identify eligible women
+  who are awaiting adjudication and recommend to the courts that they be sentenced
+  to Cameo House in lieu of State Prison or County Jail, when appropriate.  All women
+  residing at Cameo House must have at least one child in their custody, have active
+  reunification services with at least one of their children or be pregnant at the
+  time of enrollment. Cameo House is a 12-month program but clients can remain for
+  up to two years.  All residents must be willing to participate in case management
+  and other clinical services as a condition of the residency. During their stay at
+  Cameo House women are expected to obtain employment, reunify with at least one of
+  their children, remain clean and sober (verified through random UAs conducted at
+  Cameo House at least once per month), satisfy their Probation requirements, and
+  obtain steady employment; with the goal being for them to obtain and sustain permanent
+  housing.  Cameo House Residents work intensively with our on-site Case Manager and
+  Therapist to insure that all these objectives are met. 
+:eligible_population: Formerly incarcerated women with young children. May not have
+  a criminal conviction for a sex offense or be a registered sex offender.
+:email: 
+:faith_based: No.
+:fax: "(415) 703-0550"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Facility Hours: 24 hours/7 days
+  Notes: Clients may call for more information about the referral process.  Appointments required.
+:name: Center on Juvenile and Criminal Justice (CJCJ)   Cameo House Alternative Sentcing
+  Program
+:phone: "(415) 703-0600"
+:services:
+- Assistance with Permanent Housing
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Storage Facilities
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Restorative Justice/Survivor Impact
+- Basic/Remedial Education
+- College & Graduate Education
+- GED & High School Education
+- Reading/Literacy
+- Assessment & Application for Food Stamps, General Assistance, SSI
+- Credit Repair
+- Employment Training
+- Employment Retention
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Clean Slate/ Conviction Expungement Services
+- Inmate & Parolee Legal Issues
+- Employment Law
+- Childcare
+- Family Reunification
+- Parenting Support/Education
+- Services for Children
+- Referrals to other resources available as needed
+:url: www.cjcj.org
+:what_to_bring: 

--- a/organizations/center-on-juvenile-and-criminal-justice-employment-services.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-employment-services.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: 
+:address: 40 Boardman Place, San Francisco, CA 94103
+:contact_name: Employment Services
+:description: The Center on Juvenile and Criminal Justice (CJCJ)  San Francisco Training
+  Partnership and Homeless Employment Collaborative offers program participants referrals
+  to short-term trainings, job search workshops, job placements, life skills training
+  that prepares them for employment, to return to school, or to enroll and participate
+  in an occupational or vocational training programs.
+:eligible_population: All individuals, ages 18 and older who are homeless.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: 'Notes: No referral necessary.  Appointments are preferred but drop-ins
+  will be seen.'
+:name: Center On Juvenile And Criminal Justice   Employment Services
+:phone: "(415) 621-5661"
+:services:
+- Job Readiness/Life Skills
+- Employment Training
+- Vocational Training
+- Employment Retention
+- Access to internet
+- Assistance Getting Driver’s License/CA ID
+- Case Management
+:url: www.cjcj.org
+:what_to_bring: CA ID; Social Security Card.

--- a/organizations/center-on-juvenile-and-criminal-justice-employment-services.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-employment-services.yml
@@ -28,3 +28,5 @@
 - Case Management
 :url: www.cjcj.org
 :what_to_bring: CA ID; Social Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/center-on-juvenile-and-criminal-justice-nova-services.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-nova-services.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 40 Boardman Street, San Francisco, CA 94103
+:contact_name: Gerald Miller, Director of Community-Based Services
+:description: The Center on Juvenile Justice’s NoVA mission is to provide high-quality
+  professional pre-release planning and intensive case management to individuals who
+  are returnign to the community from San Francisco’s Jails.
+:eligible_population: All individuals incarcerated in or recently released from San
+  Francisco County Jail and referred by Pre-Trial Diversion.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: All referrals are made through San Francisco Pre-Trial Diversion. No drop-ins.
+:name: Center on Juvenile and Criminal Justice   NoVA Services
+:phone: "(415) 621-5661"
+:services:
+- Access to Internet
+- Assistance Getting Driver’s License, other ID
+- Clothing
+- Hygiene/Personal Care Items
+- Intensive Case Management
+- Individual and Group Therapy/Counseling
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Employment Training
+:url: www.cjcj.org
+:what_to_bring: 

--- a/organizations/center-on-juvenile-and-criminal-justice-nova-services.yml
+++ b/organizations/center-on-juvenile-and-criminal-justice-nova-services.yml
@@ -32,3 +32,5 @@
 - Employment Training
 :url: www.cjcj.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/centerforce-positive-connections-program-project-start.yml
+++ b/organizations/centerforce-positive-connections-program-project-start.yml
@@ -33,3 +33,5 @@
   HIV care in the community
 :url: www.centerforce.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/centerforce-positive-connections-program-project-start.yml
+++ b/organizations/centerforce-positive-connections-program-project-start.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: 
+:address: 'Administrative Office Mailing Address: PO Box 415, San Quentin, CA 94964'
+:contact_name: 'Jessica McGhie-Osorio Phone: (415) 456-9980 ext 204'
+:description: Centerforce’s Positive Connections Program provides intensive transitional
+  case management services for HIV+ individuals who are leaving prison and returning
+  to either San Francisco or Alameda County.
+:eligible_population: HIV+ individuals
+:email: jmcghie@centerforce.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Translation services will be arranged when possible
+:miscellaneous: |-
+  Specific Intake Days and Times:
+  Intakes are completed on an ongoing basis, either during incarceration in prison or shortly after release, in the community.
+  Service Areas: Bay Area
+  Administrative Office Mailing Address: PO Box 415, San Quentin, CA 94964
+  Notes:  For other Centerforce programs call 415-456-9980.
+   
+  Client fees: None.
+  currently incarcerated in – or recently
+  released from – state prison, returning to
+  Bay Area Counties.
+:name: Centerforce   Positive Connections Program/Project Start
+:phone: 
+:services:
+- Pre- and Post-Release Transitional Case Management to link HIV+ clients with housing,
+  food, clothing, transportation, benefits assistance, case management and primary
+  HIV care in the community
+:url: www.centerforce.org
+:what_to_bring: 

--- a/organizations/central-american-resource-center-carecen-not-updated.yml
+++ b/organizations/central-american-resource-center-carecen-not-updated.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 3101 Mission Street, Suite 101, San Francisco, CA  94110
+:contact_name: Tracy Tognetti
+:description: Second Chance Tattoo Removal Program provides tattoo removal services
+  for young adults wishing to remove gang-related tattoos. Dental services include
+  emergency dental care, cleanings, examinations, x-rays, extractions, root canals,
+  fillings, pit and fissure sealants, denture repairs, crowns, and referrals for other
+  dental services.
+:eligible_population: All individuals and family members. For tattoo removal services,
+  ages 12-24 only. Men, Transgender people, Pregnant women.
+:email: info@carecensf.org
+:faith_based: No.
+:fax: "(415) 282-9037"
+:fees: Free to those who qualify.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Specific Intake Days and Times: Call for details.
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Make an appointment or drop in to inquire.
+  How does this program serve individuals whose primary language is not English? For other than Spanish we can access interpretation services.
+   Direct Services: Tattoo Removal. Referrals to other resources available as needed.
+  Community Acupuncture Project Ear Clinic at the American College of Traditional Chinese Medicine (ACTCM)
+  The American College of Traditional Chinese Medicine’s Community Acupuncture Project brings ACTCM clinical faculty and interns to various locations in San Francisco. On average, ACTCM provides more than 20,000 treatments in its Community Clinic and off-site Community Acupuncture Project (CAP) sites annually. www.actcm.edu
+  Drop-In Clinic Hours: Please call for clinic hours and days
+  Notes: No referral needed. Drop-in only.
+:name: Central American Resource Center (CARECEN) NOT UPDATED
+:phone: For tattoo removal services, call (415) 642-4425 or (415) 642-4400.
+:services:
+- Acupuncture
+- Referrals to other resources available as needed
+:url: www.carecensf.org
+:what_to_bring: Second Chance Tattoo Removal Program Application or Referral.

--- a/organizations/central-american-resource-center-carecen-not-updated.yml
+++ b/organizations/central-american-resource-center-carecen-not-updated.yml
@@ -33,3 +33,5 @@
 - Referrals to other resources available as needed
 :url: www.carecensf.org
 :what_to_bring: Second Chance Tattoo Removal Program Application or Referral.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/central-city-hospitality-house.yml
+++ b/organizations/central-city-hospitality-house.yml
@@ -69,3 +69,5 @@
 - Referrals to other resources available as needed
 :url: www.hospitalityhouse.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/central-city-hospitality-house.yml
+++ b/organizations/central-city-hospitality-house.yml
@@ -1,0 +1,71 @@
+---
+:accessibility: All programs wheelchair accessible.  Other disabilities are accommodated.
+:address: 'Sixth Street Self-Help Ctr: 169 & 181 Sixth St., San Francisco, CA 94103'
+:contact_name: 
+:description: Hospitality House is a community center for San Francisco’s Tenderloin
+  neighborhood, providing opportunities for personal growth and self-determination
+  to homeless people and neighborhood residents. The agency’s mission is to build
+  community strength by advocating policies and rendering services which foster self-sufficiency
+  and cultural enrichment. We encourage self-help, mutual respect, and increased self-esteem.
+  The goal of these efforts is to make the heart of San Francisco a better place for
+  us all. Facilities include the Tenderloin Self-Help Center (TSCH), the Sixth Street
+  Self-Help Center, a shelter, and the Community Arts Program (CAP) , the Employment
+  Program (EP), and the Community Building Program (CBP.
+:eligible_population: All individuals and family members.
+:email: info@hospitalityhouse.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Chinese
+:miscellaneous: |-
+  Office Phone: (415) 749-2100
+  Office Fax: (415) 749-2136
+  TSHC: (415) 749-2143
+  Sixth Street: (415) 369-3040
+  Shelter: (415) 749-2103
+  CAP: (415) 749-2133
+  Employment Program: (415) 749-2175
+  CBP:  (415) 749-2102
+  Hours:
+  TSHC: Mon-Fri, 7:00am to 7:00pm
+  Sixth Street: Mon-Fri: 9am-5pm
+  Shelter: Mon-Fri, 4:00pm to 8:00am; 24-hours Weekends & Holidays
+  CAP: M/W/F: 1-6pm; Tue/Thurs: 10am-3pm
+  CBP:  Mon-Fri 9:00 -5:00pm
+  Location:
+  Main Office, TSHC & Community Building Program: 290 Turk Street, San Francisco, CA 94102
+  Sixth Street Self-Help Ctr: 169 & 181 Sixth St., San Francisco, CA 94103
+  Shelter: 146 Leavenworth St., San Francisco, CA 94102
+  Community Arts Program: 1007 Market St., San Francisco, CA 94102
+  Employment Program: 146 Leavenworth, San Francisco, CA  94102
+  Notes: No referral needed. Drop-ins welcome.
+:name: Central City Hospitality House
+:phone: 
+:services:
+- Emergency Shelter
+- Rental Move-in Assistance
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Post-Incarceration Support
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Couples/Family Counseling
+- Meals
+- Shower Facilities
+- Referrals to other resources available as needed
+:url: www.hospitalityhouse.org
+:what_to_bring: 

--- a/organizations/charity-cultural-services-center-citybuild-academy.yml
+++ b/organizations/charity-cultural-services-center-citybuild-academy.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: 
+:address: 731 Commercial Street, San Francisco, CA  94108
+:contact_name: Calvin Phan, Program Coordinator
+:description: Charity Cultural Services Center (CCSC) offers a variety of vocational
+  training programs.  The goal of the CityBuild program is to provide San Francisco
+  residents the opportunity to receive vocational training and enter the union trades
+  post graduation from the 18 week curriculum. sfccsc.org
+:eligible_population: All individuals, ages 18 and older (171/2 ok with written permission
+  from parents).  To enter CityBuild all clients must have a valid CDL and a high
+  school diploma/GED.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Cantonese
+- Mandarin
+- Vietnamese
+- Interpreter service available
+:miscellaneous: 'Notes: Appointments are preferred but drop-ins will be seen.  Clients
+  who are interested in a career in construction must be SF residents.'
+:name: Charity Cultural Services Center   CityBuild Academy
+:phone: "(415) 989-8224  x102"
+:services:
+- Construction Training
+- Assistance Getting Driver’s License and Other ID
+- High School Diploma/GED
+- Vocational Education
+- Job Readiness
+- Employment Placement
+- Case Management
+- Access to Internet
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: Drivers License; Social Security Card.

--- a/organizations/charity-cultural-services-center-citybuild-academy.yml
+++ b/organizations/charity-cultural-services-center-citybuild-academy.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: Drivers License; Social Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/children-s-council-of-san-francisco.yml
+++ b/organizations/children-s-council-of-san-francisco.yml
@@ -1,0 +1,31 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 445 Church Street, San Francisco, CA  94114
+:contact_name: Any Resource and Referral Counselor
+:description: Children’s Council connects families to child care that meets their
+  needs and works with parents, providers, and community partners to make quality
+  child care and early education a reality for all children in our city.
+:eligible_population: 'Any parent who needs child care for one of these reasons:  working,
+  looking for work, attending vocational training.'
+:email: rr@childrenscouncil.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- Russian
+- Vietnamese
+:miscellaneous: |-
+  Hours:  Monday-Thursday, 8:30am to 4:00pm; Friday, 8:30am to 12:00pm
+  Notes:  No referral needed.  Drop-ins welcome.
+:name: Children’S Council of San Francisco
+:phone: "(415) 343-3300"
+:services:
+- Resources for parents and families
+- Referrals to other resources available as needed
+:url: www.childrenscouncil.org/
+:what_to_bring: Nothing required; helpful documents are anything showing household
+  income or employment.

--- a/organizations/children-s-council-of-san-francisco.yml
+++ b/organizations/children-s-council-of-san-francisco.yml
@@ -29,3 +29,5 @@
 :url: www.childrenscouncil.org/
 :what_to_bring: Nothing required; helpful documents are anything showing household
   income or employment.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/city-college-of-san-francisco-guardian-scholars-program.yml
+++ b/organizations/city-college-of-san-francisco-guardian-scholars-program.yml
@@ -49,3 +49,5 @@
 :url: https://www.ccsf.edu/en/student-services/student-counseling/guardians-scholars-program.html
 :what_to_bring: Verification of foster youth or out of home placement status for at
   least one year when minor. Program will assist client in getting documentation.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/city-college-of-san-francisco-guardian-scholars-program.yml
+++ b/organizations/city-college-of-san-francisco-guardian-scholars-program.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: 
+:address: San Francisco CA, 94112
+:contact_name: Reception
+:description: Our mission is to make the dream of attending college a reality for
+  former foster youth or out of home placement youth in juvenile justice system.
+:eligible_population: All individuals 18-25 who have experienced foster care.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Additional language translation possible
+:miscellaneous: |-
+  url: https://www.ccsf.edu/en/student-services/student-counseling/guardians-scholars-program.html
+  Hours: Monday –Thursday, 8:00am to 5:00pm; Closed Friday.
+  Location:
+  Guardian Scholars Program
+  50 Phelan Avenue
+  Multi-Use Building
+  Room MU298
+  San Francisco CA, 94112
+  Notes: Confirmation of foster youth or out-of-home placement status is required. Foster Youth Status (Referral from County Human Services agency); Out of Home Placement Status (Referral from County Juvenile Justice agency or State Social Services Agency). Drop-in services provided; appointments made on request.
+:name: City College of San Francisco   Guardian Scholars Program
+:phone: "(415) 239-3279"
+:services:
+- Rental Move-in Assistance
+- Transitional Housing Referrals
+- Access to Internet
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Storage Facilities
+- Transit Vouchers
+- Mental Health Treatment referrals
+- Medical Care through referral either
+- Intensive Case Management
+- Mentorship
+- Basic/Remedial Education
+- Employment Training
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Legal Rights Workshops on Housing, Education, Employment
+- Summer College Readiness Program
+- Referrals to other resources available as needed
+:url: https://www.ccsf.edu/en/student-services/student-counseling/guardians-scholars-program.html
+:what_to_bring: Verification of foster youth or out of home placement status for at
+  least one year when minor. Program will assist client in getting documentation.

--- a/organizations/city-college-of-san-francisco-second-chance-program.yml
+++ b/organizations/city-college-of-san-francisco-second-chance-program.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: 
+:address: City College of San Francisco – EOPS, 50 Phelan Avenue, San Francisco, CA
+  94112
+:contact_name: Charles E. Moore, Outreach Recruiter/Community Liaison
+:description: The Extended Opportunity Programs and Services (EOPS) Second Chance
+  program at City College of San Francisco (CCSF) serves students who are formerly
+  incarcerated, offering them education as an alternative to incarceration. Through
+  understanding and addressing the unique needs of this student population, the Second
+  Chance program provides comprehensive academic support services with the goal of
+  increasing their probability for academic success, while simultaneously reducing
+  the likelihood of recidivism.
+:eligible_population: Individuals, ages 18 and older. Must be highly motivated and
+  have a strong desire to be in college and to participate in higher education.  Good
+  to be clean and sober or actively participating in 12-step or other recovery program,
+  if applicable.
+:email: cemoore@ccsf.edu
+:faith_based: 'No'
+:fax: "(415) 239-3514"
+:fees: None
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:00am to 2:00pm.
+  Notes: No referral needed. Drop-ins allowed, but appointments are highly recommended. Applicants on probation or parole need to provide verification of their status from their probation/parole officer.
+:name: City College of San Francisco   Second Chance Program
+:phone: "(415) 239-3075"
+:services:
+- Assist w/Matriculation & Application
+- Peer Counseling
+- Tutors
+- Book Vouchers
+- Academic Advising
+- Educational Planning
+- Voc
+- Education
+- Associate Degree
+- Transfer Programs
+:url: www.ccsf.edu
+:what_to_bring: 'State-Issued ID; Social Security Card; Proof of SF Residency. Accessibility:
+  Wheelchair accessible. Other disabilities are accommodated.'

--- a/organizations/city-college-of-san-francisco-second-chance-program.yml
+++ b/organizations/city-college-of-san-francisco-second-chance-program.yml
@@ -39,3 +39,5 @@
 :url: www.ccsf.edu
 :what_to_bring: 'State-Issued ID; Social Security Card; Proof of SF Residency. Accessibility:
   Wheelchair accessible. Other disabilities are accommodated.'
+:__meta__:
+  :version: 0.0.1

--- a/organizations/city-college-of-san-francisco-way-pass-women-s-aftercare-program.yml
+++ b/organizations/city-college-of-san-francisco-way-pass-women-s-aftercare-program.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible; other disabilities will be accommodated.
+:address: City College of San Francisco – Way Pass, 50 Phelan Avenue, Multi-Use Building
+  MUB 301-C, San Francisco, CA 94112
+:contact_name: Tandy Iles, Faculty Advisor
+:description: The Women’s Aftercare Program and Services is a collaborative project
+  with City College of San Francisco, under the auspices of the Health Science Department
+  and the Women’s Studies Department. We are designed to address the unique needs
+  of self-identified women who are formerly incarcerated. We serve women coming home
+  from prisons, jails, and drug programs. It is our belief that education is the best
+  alternative to incarceration and it is our desire to assist our sisters in their
+  academic endeavors.
+:eligible_population: Formerly incarcerated women.
+:email: tiles@ccsf.edu
+:faith_based: No.
+:fax: 
+:fees: Free to any current City College student.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Tuesday – Thursday, 12:00pm to 5:00pm when school is in session or by appointment.
+  Notes: No referral needed.
+:name: City College of San Francisco   Way Pass Women’s Aftercare Program
+:phone: "(415) 452-4889"
+:services:
+- Case Management
+- Help with Registration Forms
+- Informal Counseling and Support
+- Class Planning and Management
+- Support Groups and Workshops
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: Positive attitude

--- a/organizations/city-college-of-san-francisco-way-pass-women-s-aftercare-program.yml
+++ b/organizations/city-college-of-san-francisco-way-pass-women-s-aftercare-program.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: Positive attitude
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cityteam-international-rescue-mission-men-s-emergency-shelter.yml
+++ b/organizations/cityteam-international-rescue-mission-men-s-emergency-shelter.yml
@@ -34,3 +34,5 @@
 - Hygiene/Personal Care Items
 :url: www.cityteam.org/san-jose/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cityteam-international-rescue-mission-men-s-emergency-shelter.yml
+++ b/organizations/cityteam-international-rescue-mission-men-s-emergency-shelter.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: ADA compliant.
+:address: 'Corporate Office:  2304 Zanker Road, San Jose, CA 95131'
+:contact_name: Shelter Intake
+:description: In San Jose, Cityteam is providing hot meals, safe shelter, showers,
+  and clean clothing to our city's homeless population. Located in the heart of Silicon
+  Valley, Cityteam brings real help and real hope to the men, women, children, and
+  families in crisis that are struggling with poverty or homelessness in San Jose
+  and throughout Santa Clara County. Cityteam San Jose also has renowned recovery
+  programs for men and women seeking help to transform their lives from addiction
+  to drugs and alcohol. Cityteam provides long-term compassionate ministry to people
+  that walk through our doors. Through the generous support of our staff, volunteers,
+  and donors, Cityteam is able to provide real help and real hope in Christ in order
+  to bring real change into their lives.
+:eligible_population: Men ages 18 and older.
+:email: sanjose@cityteam.org
+:faith_based: Yes.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: Monday-Friday, 9am to 5pm
+  Corporate Office:  2304 Zanker Road, San Jose, CA 95131
+  Notes: Check in is Monday-Sunday at 5:30pm.  Must show up in person to 1174 Old Bayshore Highway, San Jose, CA  95112 by 5:00pm nightly.  We are a Men only shelter.  Call for more information.
+  Client fees: None.
+:name: CITYTEAM International   Rescue Mission/Men’s Emergency Shelter
+:phone: "(408) 288-2153 Fax: (408) 428-9505"
+:services:
+- Emergency Shelter
+- Sower Facilities
+- Meals
+- Hygiene/Personal Care Items
+:url: www.cityteam.org/san-jose/
+:what_to_bring: 

--- a/organizations/cityteam-international-substance-abuse-treatment-services.yml
+++ b/organizations/cityteam-international-substance-abuse-treatment-services.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Wheelchair accessible.
+:address: Men’s Recovery Program, 580 Charles Street, San Jose, CA 95112
+:contact_name: Recovery Program
+:description: In San Jose, Cityteam is providing hot meals, safe shelter, showers,
+  and clean clothing to our city's homeless population. Located in the heart of Silicon
+  Valley, Cityteam brings real help and real hope to the men, women, children, and
+  families in crisis that are struggling with poverty or homelessness in San Jose
+  and throughout Santa Clara County. Cityteam San Jose also has renowned recovery
+  programs for men and women seeking help to transform their lives from addiction
+  to drugs and alcohol. Cityteam provides long-term compassionate ministry to people
+  that walk through our doors. Through the generous support of our staff, volunteers,
+  and donors, Cityteam is able to provide real help and real hope in Christ in order
+  to bring real change into their lives.
+:eligible_population: Men ages 18 and older.
+:email: sanjose@cityteam.org
+:faith_based: Yes.
+:fax: "(408) 428-9505"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: Monday-Friday, 9am to 5pm
+  Notes: Please call first for an intake.   Call (408) 885-8080 for our Women’s Recovery Program.
+
+  Client fees: Sliding Scale.
+:name: CITYTEAM International   Substance Abuse Treatment Services
+:phone: "(408) 288-2185"
+:services:
+- Residential Substance Abuse Treatment
+- 12 Step Program
+- Health and Wellness Education
+- Anger Management
+- Case Management
+- Mentorship
+- Therapy
+- Clothing
+- Meals
+- Hygiene/Personal Care Items
+- Referrals to other services available as needed
+:url: www.cityteam.org/san-jose/
+:what_to_bring: State-Issued ID

--- a/organizations/cityteam-international-substance-abuse-treatment-services.yml
+++ b/organizations/cityteam-international-substance-abuse-treatment-services.yml
@@ -41,3 +41,5 @@
 - Referrals to other services available as needed
 :url: www.cityteam.org/san-jose/
 :what_to_bring: State-Issued ID
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cityteam-men-s-residential-recovery-program.yml
+++ b/organizations/cityteam-men-s-residential-recovery-program.yml
@@ -36,3 +36,5 @@
 - Referrals to other services available as needed
 :url: www.cityteam.org/san-francisco/
 :what_to_bring: State-Issued ID
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cityteam-men-s-residential-recovery-program.yml
+++ b/organizations/cityteam-men-s-residential-recovery-program.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: No.
+:address: 164 6th Street, San Francisco, CA 94103
+:contact_name: Recovery Program
+:description: Cityteam of San Francisco’s Men’s recovery program serves men who are
+  seeking treatment in their drug and alcohol addiction.  This long-term, residential
+  program takes a holistic approach, addressing addictions as well as psychological,
+  spiritual, education and vocational issues.  We provide individual and group counseling,
+  GED prep classes, computer skills training, medical treatment and community involvement.
+:eligible_population: Men ages 18 and older.
+:email: sanfrancisco@cityteam.org
+:faith_based: Yes.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: Monday-Friday, 9am to 5pm
+  Notes: Please call first for an intake.
+
+  Client fees: Program fee is 30% of Net income not to exceed 500 dollars a month.
+:name: CITYTEAM   Men’s Residential Recovery Program
+:phone: "(415) 861-8688"
+:services:
+- Residential Substance Abuse Treatment
+- 12 Step Program
+- Health and Wellness Education
+- Anger Management
+- Case Management
+- Mentorship
+- Therapy
+- Clothing
+- Meals
+- Hygiene/Personal Care Items
+- Referrals to other services available as needed
+:url: www.cityteam.org/san-francisco/
+:what_to_bring: State-Issued ID

--- a/organizations/community-assessment-and-services-center-casc-a-partnership-of-the-san-francisco-adult-probation-depa.yml
+++ b/organizations/community-assessment-and-services-center-casc-a-partnership-of-the-san-francisco-adult-probation-depa.yml
@@ -48,3 +48,5 @@
 - Referrals to other services as appropriate
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-assessment-and-services-center-casc-a-partnership-of-the-san-francisco-adult-probation-depa.yml
+++ b/organizations/community-assessment-and-services-center-casc-a-partnership-of-the-san-francisco-adult-probation-depa.yml
@@ -1,0 +1,50 @@
+---
+:accessibility: 
+:address: 564 6th Street, San Francisco, CA  94103
+:contact_name: Intake
+:description: The CASC is a one-stop community corrections reentry center that bridges
+  APD probation supervision services with comprehensive case management, barrier removal,
+  and income benefits acquisition assistance. The CASC co-locates services that build
+  self-sufficiency, including a charter high school, vocational and employment readiness
+  training, mental health, and substance abuse prevention services, batterers’ intervention
+  programs, cognitive behavioral interventions, and meeting space for community partners. 
+   The goals of the CASC are to reduce recidivism, build self-sufficiency skills,
+  and increase public safety.   APD provides on-site probation supervision services.
+  Leaders in Community Alternatives is the CASC’s primary services provider and coordinates
+  all CASC services.  Other key partners include the 5 Keys Charter School, Center
+  on Juvenile and Criminal Justice, America Works, Community Works West, Senior Ex
+  Offender Program, OTTP, Transitions Clinic, Healthright360, Tenderloin Housing Clinic,
+  RSN, the Department of Public Health, Human Services Agency and Department of Child
+  Support Services.
+:eligible_population: Clients of the San Francisco Adult Probation Department.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Language access for limited English proficient (LEP) individuals is available
+:miscellaneous: |-
+  CASC Hours: Monday, Tuesday, Thursday, Friday 8am-8pm; Wednesday 8am-5pm
+  Notes: For referrals, please contact your DPO at 415-553-1706.  For general CASC services information, please contact CASC Program Director Melissa Gelber at (415) 489-7301 or by email at mgelber@lcaservices.com or the Asst. Program Director Roth Johnson at 415-489-7302 or by email at rjohnson@lcaservices.com
+   
+  Client fees: None.
+:name: Community Assessment and Services Center (CASC)   A Partnership of the San
+  Francisco Adult Probation Department (APD) and Leaders in Community Alternatives
+  (LCA)
+:phone: 415-489-7300
+:services:
+- Case Management
+- Education (literacy services, high school and GED instruction)
+- Employment Readiness
+- Job Placement
+- Job Readiness/Life Skills
+- Vocational Training
+- Parenting
+- Anger Management
+- Behavioral Health Assessments and Treatment
+- Cognitive Behavioral Services
+- Referrals to other services as appropriate
+:url: ''
+:what_to_bring: 

--- a/organizations/community-housing-partnership-chp.yml
+++ b/organizations/community-housing-partnership-chp.yml
@@ -1,0 +1,55 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 519 Ellis St., San Francisco, CA  94109
+:contact_name: 
+:description: CHP is a San Francisco-based nonprofit organization.  CHP’s mission
+  is to help homeless people secure housing and become self-sufficient.  Community
+  Housing Partnership is an outcome focused nonprofit that fulfills its mission by
+  developing and managing high quality supportive housing and providing services to
+  homeless individuals, seniors and families to help them rebuild their lives and
+  break the cycle of homelessness.
+:eligible_population: All currently homeless individuals and family members.  There
+  are additional eligibility requirements per property that may include, but not limited
+  to, annual income limits and verified disability.  Please visit the website for
+  more onformation.
+:email: housingopportunities@chp-sf.org
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: |-
+  Administration Mailing Address:
+  Occupancy & Compliance
+  519 Ellis St., San Francisco, CA  94109
+  For information regarding properties with and without wait lists please call 415-563-3205 x123, or visit www.chp-sf.org
+  Properties Without Waitlists:
+  684 Ellis Street
+  850 Broderick Street
+  650 Eddy Street
+  365 Fulton
+  25 Essex
+  3155 Scott
+  374 5th St.
+  810 Avenue D
+  Notes: The above properties do not maintain waitlists.  All vacancies are filled through referrals provided to CHP by programs through the HSA and DPH depending on the property.  Please visit the website for more info.
+:name: Community Housing Partnership (CHP)
+:phone: "(415) 563-3205 x123"
+:services:
+- Permanent Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Hygiene/Personal Care Items
+- Phone/Voicemail
+- Substance Abuse Treatment
+- Health & Wellness Education
+- Intensive Case Management
+- Outreach
+- Assessment & Application for Food Stamps, General Assistance, and SSI
+- Employment Training
+- Job Readiness/Life Skills
+- Parenting Support/Education
+- Services for Children
+- Referral to other services as needed
+:url: www.chp-sf.org
+:what_to_bring: State-Issued ID. Program will assist client in getting this.

--- a/organizations/community-housing-partnership-chp.yml
+++ b/organizations/community-housing-partnership-chp.yml
@@ -53,3 +53,5 @@
 - Referral to other services as needed
 :url: www.chp-sf.org
 :what_to_bring: State-Issued ID. Program will assist client in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-works-west-inc-one-family-parenting-inside-out.yml
+++ b/organizations/community-works-west-inc-one-family-parenting-inside-out.yml
@@ -1,0 +1,27 @@
+---
+:accessibility: 
+:address: SFSD’s Women’s Reentry Center (mothers), SFSD’s Community Programs (fathers
+  and mothers), CASC (fathers and mothers)
+:contact_name: Sarah Carson, LCSW
+:description: One Family is an initiative led by Community Works in collaboration
+  with the San Francisco Children of Incarcerated Parents Partnership (SFCIPP) and
+  the San Francisco Sheriff ’s Department. The goal of One Family is to strengthen
+  families impacted by incarceration.
+:eligible_population: Any parent.
+:email: scarson@communityworkswest.org
+:faith_based: 'No'
+:fax: 
+:fees: 
+:languages: []
+:miscellaneous: |-
+  url: www.communityworkswest.org/index.php/one-family
+  Hours/Meeting times: Call for times
+  Primary Community Served: Open to all formerly incarcerated parents (custodial and noncustodial) with children under 18
+:name: Community Works West, Inc.   One Family/Parenting Inside Out
+:phone: "(415) 407-5130"
+:services:
+- One Family provides Parenting Inside Out, a CPS certified parent education program
+- One Family also provides Family Transition Circles and Restorative Circles for reunification
+  of families after release from incarceration
+:url: www.communityworkswest.org/index.php/one-family
+:what_to_bring: 

--- a/organizations/community-works-west-inc-one-family-parenting-inside-out.yml
+++ b/organizations/community-works-west-inc-one-family-parenting-inside-out.yml
@@ -25,3 +25,5 @@
   of families after release from incarceration
 :url: www.communityworkswest.org/index.php/one-family
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-works-west-inc-project-what.yml
+++ b/organizations/community-works-west-inc-project-what.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible.
+:address: Community Works' Project WHAT!
+:contact_name: Zoe Willmott, Program Manager
+:description: Project WHAT! is a paid job and leadership development program that
+  works to empower youth ages 13-18 who currently or in the past have had parents
+  incarcerated by raising awareness about the impacts of parental incarceration on
+  children, families, and communities.
+:eligible_population: Youth, ages 13-18, who have had a parent incarcerated (currently
+  or in the past), living within or going to school in San Francisco.
+:email: zwillmott@communityworkswest.org
+:faith_based: No.
+:fax: 510-647-5860
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  4681 Telegraph Avenue, Oakland, CA 94609
+  Note: Application process is required.  No drop-ins, appointment required.
+  Client fee, if any:  None
+:name: Community Works West, Inc.   Project WHAT!
+:phone: "(510) 486-2340"
+:services:
+- Paid Internship
+- Snacks Provided During Meetings
+- Transit Vouchers
+- Job Readiness/Life Skills
+- Personal Financial Education
+- Services for Children
+- The program is a job, peer support group, and leadership development all in one
+- Referrals to other resources available as needed
+:url: www.communityworkswest.org/index.php/project-what
+:what_to_bring: 

--- a/organizations/community-works-west-inc-project-what.yml
+++ b/organizations/community-works-west-inc-project-what.yml
@@ -32,3 +32,5 @@
 - Referrals to other resources available as needed
 :url: www.communityworkswest.org/index.php/project-what
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-works-west-women-rising-rising-voices.yml
+++ b/organizations/community-works-west-women-rising-rising-voices.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: 
+:address: San Francisco Sheriff’s Department Women’s Resource Center, 930 Bryant Street,
+  San Francisco, CA  94103
+:contact_name: Chloe Turner
+:description: Women Rising/Rising Voices provides formerly incarcerated young women
+  with the tools/resources to lead healthy and productive lives, as well as reducing
+  their rates of re-arrest, by providing a full continuum of services, combining the
+  principles of restorative justice and youth development through a paid theater internship
+  and case management.  Rising Voices is a restorative justice theater ensemble for
+  formerly incarcerated young women ages 18-25.  Rising Voices is a paid job opportunity.
+:eligible_population: Open to all formerly incarcerated women ages 18-25 years old.
+:email: cturner@communityworkswest.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours:  Monday-Friday 8:00am-4:00pm
+   
+  Client fees: None
+:name: Community Works West   Women Rising/Rising Voices
+:phone: "(415)-734-3150"
+:services:
+- Case Management
+- Individual Service Plans that address short term and long term goals around employment,
+  housing, education, counseling, and substance abuse
+- Job Development
+- Restorative Justice Theater Program for Young Women
+:url: www.communityworkswest.org
+:what_to_bring: 

--- a/organizations/community-works-west-women-rising-rising-voices.yml
+++ b/organizations/community-works-west-women-rising-rising-voices.yml
@@ -30,3 +30,5 @@
 - Restorative Justice Theater Program for Young Women
 :url: www.communityworkswest.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-works-west-young-men-s-reentry-program-voices-on-the-rise.yml
+++ b/organizations/community-works-west-young-men-s-reentry-program-voices-on-the-rise.yml
@@ -33,3 +33,5 @@
 - Restorative Justice Theater Program for Young Men
 :url: www.communityworkswest.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/community-works-west-young-men-s-reentry-program-voices-on-the-rise.yml
+++ b/organizations/community-works-west-young-men-s-reentry-program-voices-on-the-rise.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: 
+:address: San Francisco Sheriff’s Department Community Programs, 70 Oak Grove, San
+  Francisco, CA  94103
+:contact_name: Teeoni Newsom
+:description: The Young Men’s Reentry Program is a full-service reentry program for
+  18-25 year old, previously incarcerated men.  Voices on the Rise is a restortaive
+  justice theater ensemble for formerly incarcerated young men ages 18-25 years old.  The
+  program starts in late Fall/early Winter and meets twice a week at the San Franscisco
+  Sheriff’s Department (SFSD) Community Programs and culminates in several public
+  performances in the Spring.  Voices on the Rise is a paid job opportunity.
+:eligible_population: Men ages 18-25.
+:email: tnewsom@communityworkswest.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours:  Monday-Friday 8:30am-4:30pm
+   
+  Client fees: None
+:name: Community Works West   Young Men’s Reentry Program/Voices on the Rise
+:phone: "(415)-575-6409"
+:services:
+- Intensive Case Management
+- Individual Service Plans
+- Short term and long term goals around employment, housing, education, counseling,
+  and substance abuse
+- Job Development
+- Life Skills
+- Thinking for a Change and Manalive Classes
+- Restorative Justice Theater Program for Young Men
+:url: www.communityworkswest.org
+:what_to_bring: 

--- a/organizations/compass-family-services-access-child-care.yml
+++ b/organizations/compass-family-services-access-child-care.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: 
+:description: ACCESS  (Accessible Child Care Expediated for the Shelter System) is
+  a child care subsidy that provides quality child care to families in San Francisco
+  with the greatest need.
+:eligible_population: Must have one child 0-3 years old and have lived in homeless/
+  domestic violence shelter within past 6 months.  Please call for more information.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: There are no client fees to receive the subsidy.  Childcare providers have
+  their own set of policies that may include fees and/or other responsibilities asked
+  of the family.
+:languages:
+- English
+- Spanish
+- Mandarin
+- cantonese
+- We are all able to request translation services for languages outside of our capacity
+:miscellaneous: |-
+  compass-sf.org/programs/family-resource-center
+  Contact:  Compass Family Services
+  Notes:  ACCESS uses the SF3C list to enroll participants.  It is important that you are on the list and that your contact information is up to date.  To get onto the SF3C:
+  Contact a shelter case manager
+  Contact Compass at (415) 644-0504
+  Apply online at www.sf3c.org or by phone at (415) 343-3300 or (415) 391-4956
+:name: Compass Family Services   ACCESS Child Care
+:phone: "(415) 644-0504"
+:services:
+- Full- or part-time child care at designated family child care homes or centers for
+  all children (ages 0-13 years) needing care until the youngest child turns 3 years
+  old
+:url: compass-sf.org/programs/family-resource-center
+:what_to_bring: Please bring verification of shelter stay within the last 6 months,
+  ID’s for all adults, and birth certificates for children.

--- a/organizations/compass-family-services-access-child-care.yml
+++ b/organizations/compass-family-services-access-child-care.yml
@@ -35,3 +35,5 @@
 :url: compass-sf.org/programs/family-resource-center
 :what_to_bring: Please bring verification of shelter stay within the last 6 months,
   ID’s for all adults, and birth certificates for children.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/compass-family-services-compass-clara-house.yml
+++ b/organizations/compass-family-services-compass-clara-house.yml
@@ -1,0 +1,45 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 111 Page Street, San Francisco, CA 94102
+:contact_name: Felicia Less, Intake Coordinator
+:description: Compass Clara House (CCH) is a two-year transitional housing program
+  of Compass Family Services and is aimed at supporting families with minor children
+  to permanently break the cycle of homelessness.  Through intensive case management,
+  on-site therapy, life skills classes, parenting support, on-site licensed childcare
+  for children through age 5, after school programs, education/vocational support,
+  money management, and recovery support, our two-year program helps families build
+  a lasting foundation for success.
+:eligible_population: Only homeless families with minor children.  Parents or guardians
+  must have 50% legal and physical custody of the children or a solid reunification
+  plan.  Clients must have 6 months clean prior to being referred.  Clients who have
+  experienced domestic violence must be able to demonstrate at least 2 months separation
+  from batterer.  Must not have a conviction for a violent offence, sex offenses,
+  or arson.
+:email: fless@compass-sf.org
+:faith_based: No.
+:fax: 
+:fees: 30% of monthly income for program fees, and a mandatory 20% of monthly income
+  towards savings, returned upon exit.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  www.compass-sf.org
+  Hours: Monday – Friday, 10:00am to 6:00pm
+  Notes: Clients must be referred by a social service agency (such as a family shelter or substance abuse treatment program. Appointment required.
+:name: Compass Family Services   Compass Clara House
+:phone: "(415) 644-0504 ext. 5104"
+:services:
+- Case Management
+- Life Skills
+- Permanent Housing Placement
+- Licensed Child Care and Afterschool Activities
+- Transitional Housing (up to 2 years)
+- Individual Therapy
+- Educational/Vocational Support
+- Referrals to other resources available as needed
+:url: www.compass-sf.org
+:what_to_bring: First, case manager or referring agency speaks with intake coordinator.
+  After that, necessary documents include TB Clearance, proof of custody of minor(s),
+  proof of income (if any), and identification information (state-issued or other)
+  are required.

--- a/organizations/compass-family-services-compass-clara-house.yml
+++ b/organizations/compass-family-services-compass-clara-house.yml
@@ -43,3 +43,5 @@
   After that, necessary documents include TB Clearance, proof of custody of minor(s),
   proof of income (if any), and identification information (state-issued or other)
   are required.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/compass-family-services-compass-connecting-point.yml
+++ b/organizations/compass-family-services-compass-connecting-point.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Any hotline worker or Crisis Intervention Counselor
+:description: Compass Connecting Point (CCP) is a unique program that gives any San
+  Francisco family experiencing a housing crisis quick access to the services that
+  they need most, including eviction prevention, emergency shelter, health care, child
+  care and eductional programs.  CCP manages the shelter waiting list for the City
+  funded long-term family shelters.  Our goals are to place families into shelter
+  and provide supportive services during that wait, including emergency food, diapers,
+  transportation assistance, and intensive supoort with housing search.  Additionally
+  CCP provides a one time interest free loan for move in funds and eviction prevention.
+:eligible_population: All families, pregnant women, women with children.  Eligible
+  families have at least one legal adult plus either a minor child in their custody
+  or a preganancy.  There is no maximum family size.  For shelter wait list, families
+  must be homeless and receiving public benefits in SF or willing to transfer to SF.  For
+  rental assisitance, families must be SF residents.  For move in funds, they must
+  be homeless in SF and have a unit they have been accepted into.
+:email: 
+:faith_based: No.
+:fax: "(415) 442-5138"
+:fees: 
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- German
+- We are able to arrange ASL interpreters
+:miscellaneous: |-
+  url: www.compass-sf.org/programs/connecting-point
+  Specific Intake Days/Times:  Monday 9am-12pm and 1pm-5pm; Tuesday 9am-12pm and 3pm-5pm; Wednesday 9am-12pm and 1pm-5pm; Thursday 9am-12pm and 2pm-5pm; and Friday 9am-12pm and 1pm-5pm
+  Note:  No referral required.  All clients are required to do a 15 minute phone intake over the hotline at (855) 234-2667.  Drop-in services are available Monday 9am-12pm, Wednesday 10:30am-12pm, Friday 9am-12pm..  Families are typically on the waitlist for 6 to 8 months during which we provide supportive services.
+  Client fees: None
+:name: Compass Family Services   Compass Connecting Point
+:phone: "(855) 234-2667"
+:services:
+- Emergency Shelter
+- Rental Move-in Assistance
+- Access to Internet
+- Assistance Getting Driver’s License and Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygeine/Personal Care Items
+- P.O. Box/Mail Service
+- Transit Vouchers
+- Mental Health Treatment
+- Health & Wellness Education
+- Assistance Applying for Calfresh/Food stamps
+:url: www.compass-sf.org/programs/connecting-point
+:what_to_bring: 

--- a/organizations/compass-family-services-compass-connecting-point.yml
+++ b/organizations/compass-family-services-compass-connecting-point.yml
@@ -49,3 +49,5 @@
 - Assistance Applying for Calfresh/Food stamps
 :url: www.compass-sf.org/programs/connecting-point
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/compass-family-services-sf-home.yml
+++ b/organizations/compass-family-services-sf-home.yml
@@ -39,3 +39,5 @@
 - Access to Educational/Recreational Activities for Children
 :url: www.compass-sf.org
 :what_to_bring: We will let you know what documents are needed at the time you apply.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/compass-family-services-sf-home.yml
+++ b/organizations/compass-family-services-sf-home.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 995 Market St, 5th Floor, SF 94103
+:contact_name: Beth Mitchell, Program Director
+:description: Compass SF HOME helps families in danger of homelessness to stabilize
+  and maintain their housing and rapidly re-houses homeless families so that they
+  can work towards long-term economic self-sufficiency.  The program is designed to
+  help homeless families find a unit, and then provide a rental subsidy paired with
+  case management until the family increases their income to the point that they can
+  pay the rent on their own.
+:eligible_population: Homeless families staying in San Francisco. Must have more than
+  50% custody of a child under 18, minimum income of $500, maximum income 50% AMI.
+  Must have a concrete plan to increase your income to the point where you can afford
+  rent.
+:email: bmitchell@compass-sf.org
+:faith_based: No.
+:fax: 
+:fees: None, although families must pay 40-50% of their net income towards the rent
+  in their unit.
+:languages:
+- English
+- Spanish
+:miscellaneous: 'Notes: Please call for more information and to receive an application
+  packet.  No referral required but families we prioritize families who are either
+  in a shelter or on the Connecting Point family shelter waitlist.'
+:name: Compass Family Services   SF Home
+:phone: "(415) 644-0504 ext. 2201"
+:services:
+- Assistance Obtaining Permanent Housing
+- Rental Subsidies
+- Intensive Case Management
+- Education and Professional Goals
+- Money management
+- Access to a Food Pantry
+- Clothing
+- Personal Hygiene Products
+- Diapers and Baby Supplies
+- Transportation Assistance
+- Access to Educational/Recreational Activities for Children
+:url: www.compass-sf.org
+:what_to_bring: We will let you know what documents are needed at the time you apply.

--- a/organizations/contra-costa-county-behavioral-health-access-line-alcohol-and-other-drug-services.yml
+++ b/organizations/contra-costa-county-behavioral-health-access-line-alcohol-and-other-drug-services.yml
@@ -27,3 +27,5 @@
   the general public, and makes prevention referrals 800-846-1652 (Call Toll Free)'
 :url: cchealth.org/aod/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/contra-costa-county-behavioral-health-access-line-alcohol-and-other-drug-services.yml
+++ b/organizations/contra-costa-county-behavioral-health-access-line-alcohol-and-other-drug-services.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: 'ADA Accommodations: Wheelchair accessibility'
+:address: 
+:contact_name: Zachariah Todd, AOD Counselor
+:description: Contra Costa County Behavioral Health Access Line, Alcohol and Other
+  Drug Services, provides information on existing alcohol and other drug program treatment
+  and prevention services. Referrals will be provided to available residential, detoxification,
+  MAT, NTP, outpatient treatment services in the greater Contra Costa and surrounding
+  regions.
+:eligible_population: Must be a Contra Costa County resident.
+:email: 
+:faith_based: 'No'
+:fax: 
+:fees: Sliding scale.  No one will be denied services based on inability to pay.
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  Hours: Monday-Friday, 8am-5:00pm
+  Notes: Application Procedure: Call 1-800-846-1652
+:name: Contra Costa County Behavioral Health Access Line   Alcohol and Other Drug
+  Services
+:phone: "(800) 846-1652"
+:services:
+- 'Contra Costa Residents can access Alcohol and Other Drugs Services through multiple
+  ports of entry: The Information and Referral Phone Line provides information to
+  the general public, and makes prevention referrals 800-846-1652 (Call Toll Free)'
+:url: cchealth.org/aod/
+:what_to_bring: 

--- a/organizations/cooperative-restraining-order-clinic.yml
+++ b/organizations/cooperative-restraining-order-clinic.yml
@@ -1,0 +1,25 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 3543 – 18th Street, San Francisco, CA 94110
+:contact_name: Tara Berta, Supervising Attorney
+:description: Cooperative Restraining Order Clinic provides information on and assistance
+  in applying for Domestic Violence restraining orders.
+:eligible_population: All individuals and family members.
+:email: tara@roclinic.org
+:faith_based: No.
+:fax: "(415) 241-9491"
+:fees: None.
+:languages:
+- English
+- Spanish
+- other languages as needed
+:miscellaneous: |-
+  Hours: By Appointment Only. Call Intake Phone, (415) 255-0165.
+  Notes: No referrals needed. Please call Intake Phone for appointment.
+:name: Cooperative Restraining Order Clinic
+:phone: "(415) 864-1790"
+:services:
+- Legal Assistance/Advocacy
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: CA ID and any other relevant documents for the restraining order.

--- a/organizations/cooperative-restraining-order-clinic.yml
+++ b/organizations/cooperative-restraining-order-clinic.yml
@@ -23,3 +23,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: CA ID and any other relevant documents for the restraining order.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cots-mary-isaak-center-transitional-housing-emergency-shelter.yml
+++ b/organizations/cots-mary-isaak-center-transitional-housing-emergency-shelter.yml
@@ -49,3 +49,5 @@
   Center
 :url: www.cots-homeless.org/index.php/how-we-help/homeless-services
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/cots-mary-isaak-center-transitional-housing-emergency-shelter.yml
+++ b/organizations/cots-mary-isaak-center-transitional-housing-emergency-shelter.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: Wheelchair accessibile.
+:address: P.O. Box 2744, Petaluma, CA 94953; 900 Hopper Street, Petaluma, CA  94952
+:contact_name: Staff
+:description: Committee on the Shelterless (COTS) Mary Isaak Center facility is the
+  setting for the majority of COTS' programs and services. These programs help families
+  and single adults to heal from trauma and homelessness, gain life skills, optimize
+  their income, and acquire permanent housing. We know that trauma influences how
+  people respond and live in the world. If we do not deal with this history, it is
+  extremely difficult to help people move forward.  The second floor of the building
+  is dedicated to the Family Transitional Housing program, which provides shelter
+  and a wide range of transformative programs for up to 11 families at a time. Families
+  may stay for up to two years, during which time they receive intensive support services
+  and individualized case management. Parents are required to participate in Kids
+  First, COTS' 12-week parenting skills training, and in Rent Right, a 9-week course
+  in financial literacy and housing search. More than 70% of families graduate into
+  permanent housing and independent stable lives. The 100-bed Emergency Shelter for
+  Single Adults is located on the first floor of the Mary Isaak Center. Services include
+  food, clothing, showers, access to phones and a messaging system, access to computers,
+  transportation assistance, mental health and chemical dependency recovery support,
+  job skills training, and assistance in obtaining employment and/or public benefits.
+  Residents may stay for up to six months and more than 50% graduate into either transitional
+  or permanent housing. The Emergency Shelter for Single Adults serves up to 500 individuals
+  annually.
+:eligible_population: Homeless adults and families.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+- Translation services available upon request
+:miscellaneous: |-
+  Hours: Vary depending on program.  Business hours are Monday-Friday, 9:00am-5:00pm.
+  Notes: It is okay to drop-in.
+:name: COTS   Mary Isaak Center (transitional Housing/Emergency Shelter)
+:phone: "(707) 765-6530"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Life Skills
+- Food/Prepared Meals
+- Clothing
+- Shower Facilities
+- Access to Laundry Machines
+- The Petaluma Kitchen is the central contact point of COTS' outreach to persons living
+  on the streets, to encourage them to seek shelter and support at the Mary Isaak
+  Center
+:url: www.cots-homeless.org/index.php/how-we-help/homeless-services
+:what_to_bring: 

--- a/organizations/david-lewis-community-reentry-center.yml
+++ b/organizations/david-lewis-community-reentry-center.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 2277 University Avenue, East Palo Alto, CA 94303 
+:contact_name: Jose Cabrera
+:description: The City of East Palo Alto and the County of San Mateo created and are
+  funding the David Lewis Reentry Program to assist residents returning home from
+  prison or jail with their reintegration back into the community. The David Lewis
+  Reentry Center provides case management, classes in personal development and like
+  skills, and referrals to other community partners for employment services.
+:eligible_population: AB 109 (referred from San Mateo County Probation). We also accept
+  regular probation and parole referrals as well.
+:email: jcabrera@smcgov.org
+:faith_based: We are not a faith based program but we do work with churches in our
+  community if a client wishes to participate in faith based activities.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: 8:00am-5:00pm
+  Notes: It is okay to drop-in and/or call/email for an appointment.
+:name: David Lewis Community Reentry Center
+:phone: "(650) 853-3188"
+:services:
+- Case Management
+- Supportive Services
+- Personal Development
+- Life Skills
+- Financial management
+- Cognitive Restructuring
+- Resume Development
+- Job Search
+- Access to Computers
+- Referrals to other resources available as needed
+:url: www.ci.east-palo-alto.ca.us/index.aspx?nid=255
+:what_to_bring: 

--- a/organizations/david-lewis-community-reentry-center.yml
+++ b/organizations/david-lewis-community-reentry-center.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.ci.east-palo-alto.ca.us/index.aspx?nid=255
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/deaf-community-counseling-services-dccs.yml
+++ b/organizations/deaf-community-counseling-services-dccs.yml
@@ -38,3 +38,5 @@
 - Referrals to other resources available as needed
 :url: felton.org/social-services/adult/dccs/
 :what_to_bring: Proof of SF residency.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/deaf-community-counseling-services-dccs.yml
+++ b/organizations/deaf-community-counseling-services-dccs.yml
@@ -1,0 +1,40 @@
+---
+:accessibility: 
+:address: 1500 Franklin Street, San Francisco, CA  94109
+:contact_name: 
+:description: DCCS, formally known as the UCSF Center on Deafness,a program of Family
+  Service Agency of San Francisco/Felton Institute, provides outpatient mental health
+  and substance abuse services for individuals who are Deaf, Deaf-Blind, Hard of Hearing
+  and Late Deafened.
+:eligible_population: Services are for people who are deaf, hard of hearing, and deaf/blind.  Adluts,
+  seniors, and children.
+:email: dccs@felton.org
+:faith_based: No.
+:fax: "(415) 447-9701"
+:fees: 
+:languages:
+- English
+- American Sign Language
+:miscellaneous: |-
+  url: felton.org/social-services/adult/dccs/
+  Hours: Mon-Fri, 9am-5pm
+  Notes: Please call for information.
+:name: Deaf Community Counseling Services  (DCCS)
+:phone: "(415) 474-7310"
+:services:
+- Mental Health & Substance Abuse Assessment and Therapy
+- Psychiatric & Medication Services
+- Co-Occurring/Dual Diagnosis Treatment
+- Health and Wellness Education
+- Group and Individual Counseling/Therapy
+- Intensive Case Management
+- Basic/Remedial Education
+- Support with Assessment and Application for Food Stamps, General Assistance and
+  SSI
+- Money Management and Personal Finance Education
+- Couples Counseling/Therapy
+- Parenting Support/Education
+- Counseling/Therapy for Children
+- Referrals to other resources available as needed
+:url: felton.org/social-services/adult/dccs/
+:what_to_bring: Proof of SF residency.

--- a/organizations/delancey-street-foundation-los-angeles.yml
+++ b/organizations/delancey-street-foundation-los-angeles.yml
@@ -60,3 +60,5 @@
 - Referrals to other resources available as needed
 :url: www.delanceystreetfoundation.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/delancey-street-foundation-los-angeles.yml
+++ b/organizations/delancey-street-foundation-los-angeles.yml
@@ -1,0 +1,62 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities accommodated.
+:address: 400 N. Vermont Ave., Los Angeles, CA 90004
+:contact_name: Intake Coordinator
+:description: Delancey Street is a residential education center for former substance
+  abusers and ex-convicts. Its philosophy is that the people with the problems can
+  teach themselves to become the solution. The program requires a minimum two-year
+  commitment, and many individuals stay for longer. The Delancey Street Foundation
+  Los Angeles facility is located near midtown, right off the Hollywood freeway. The
+  facility, housing approximately 300 residents, was constructed as a 220 room hotel;
+  the Mission style building complex includes a huge ballroom for catering events
+  for up to 500 people, with smaller catering rooms as well. The buildings surround
+  a large 8,000 square foot tropical garden with cascading waterfalls. Residents have
+  completely renovated the building since we bought it in 1993. In order to make the
+  hotel more of a home, residents turned the guest rooms into living units ranging
+  from dorms for the newcomers into small apartments as residents earn their way to
+  more spacious living quarters, and opened up the dining area to 6,000 square feet
+  for resident meals. Delancey Street-Los Angeles also has a 50,000 square foot warehouse
+  Business Complex located in Montebello. This complex houses a number of Delancey
+  Training Schools including Moving & Trucking, Automotive, Auto Body Shop, Warehouse
+  Shipping and Receiving, Terrarium, Ceramics and Iron Handcraft Works and Sales.
+:eligible_population: Men, Women, Transgender people, ages 18 older. May not have
+  a criminal conviciton for arson; may not be a registered sex offender; may not have
+  a serious medical/mental health condition requiring medication.
+:email: 
+:faith_based: No.
+:fax: "(323) 644-4147"
+:fees: No fee.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Facility Hours: 24 hours/7 days
+  Notes: No referrals needed. Drop-ins welcome.
+:name: Delancey Street Foundation Los Angeles
+:phone: "(323) 644-4122"
+:services:
+- Transitional Housing
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Medical CareEmergency
+- Anger Management
+- Mentorship
+- Basic/Remedial Education
+- College & Graduate Education
+- GED & High School
+- Education
+- Reading/Literacy
+- Vocational Education
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Inmate & Parolee Legal Issues
+- Voting Outreach & Education
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.delanceystreetfoundation.org
+:what_to_bring: 

--- a/organizations/delancey-street-foundation.yml
+++ b/organizations/delancey-street-foundation.yml
@@ -48,3 +48,5 @@
 - Referrals to other resources available as needed
 :url: www.delanceystreetfoundation.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/delancey-street-foundation.yml
+++ b/organizations/delancey-street-foundation.yml
@@ -1,0 +1,50 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities accommodated.
+:address: 600 Embarcadero, San Francisco, CA 94107
+:contact_name: Sonny Rendall, Intake Coordinator
+:description: Delancey Street is a residential education center for former substance
+  abusers and ex-convicts. Its philosophy is that the people with the problems can
+  teach themselves to become the solution. The program requires a minimum two-year
+  commitment, and many individuals stay for longer.
+:eligible_population: Men, Women, Transgender people, ages 18 older. May not have
+  a criminal conviciton for arson; may not be a registered sex offender; may not have
+  a serious medical/mental health condition requiring medication.
+:email: 
+:faith_based: No.
+:fax: "(415) 512-5141"
+:fees: No fee.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  url: www.delanceystreetfoundation.org
+  Facility Hours: 24 hours/7 days
+  Notes: No referrals needed. Drop-ins welcome.
+:name: Delancey Street Foundation
+:phone: "(415) 512-5104"
+:services:
+- Transitional Housing
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Medical CareEmergency
+- Anger Management
+- Mentorship
+- Basic/Remedial Education
+- College & Graduate Education
+- GED & High School
+- Education
+- Reading/Literacy
+- Vocational Education
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Inmate & Parolee Legal Issues
+- Voting Outreach & Education
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.delanceystreetfoundation.org
+:what_to_bring: 

--- a/organizations/department-of-rehabilitation.yml
+++ b/organizations/department-of-rehabilitation.yml
@@ -28,3 +28,5 @@
 - Referrals to other resources available as needed
 :url: www.rehab.cahwnet.gov
 :what_to_bring: State-Issued photo ID. Medical records or documentation of disability.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/department-of-rehabilitation.yml
+++ b/organizations/department-of-rehabilitation.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible. Other disabilites are accommodated.
+:address: 301 Howard Street, Suite 700
+:contact_name: 
+:description: The California Department of Rehabilitation works in partnership with
+  consumers and other stakeholders to provide services and advocacy resulting in employment,
+  independent living and equality for individuals with disabilities.
+:eligible_population: Individuals with a documented disability.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: No fees.
+:languages:
+- English
+:miscellaneous: |-
+  (415) 904-7138 (TTY)
+  (415) 904-7100 (TTY)
+  San Francisco, CA 94105
+  Notes: Orientations are held on Tuesdays and Thursdays at 2:00pm and on Wednesdays at 8:30am.
+:name: Department of Rehabilitation
+:phone: "(415) 904-7100 (Voice)"
+:services:
+- Individualized Service Plan
+- Counseling
+- Transportation Assistance
+- Vocational Training
+- Assistance Getting and/or Maintaining Employment
+- Referrals to other resources available as needed
+:url: www.rehab.cahwnet.gov
+:what_to_bring: State-Issued photo ID. Medical records or documentation of disability.

--- a/organizations/discovery-house-residential-substance-abuse-program.yml
+++ b/organizations/discovery-house-residential-substance-abuse-program.yml
@@ -34,3 +34,5 @@
 - supportive services and referrals
 :url: cchealth.org/aod/pdf/Discovery-House-brochure.pdf
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/discovery-house-residential-substance-abuse-program.yml
+++ b/organizations/discovery-house-residential-substance-abuse-program.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: 'ADA Accommodations: Wheelchair accessibility'
+:address: 4645 Pacheco Blvd., Martinez, CA  94553
+:contact_name: Susan Martinez or Intake
+:description: Discovery House provides a 90-day residential substance abuse treatment
+  program Provides a 90-day residential substance abuse treatment program for men
+  utilizing a therapeutic community/social modality. Services include individual,
+  group, and family counseling, psychological and physical evaluation, chemical dependency
+  and co-dependency education, 12-Step work, Narcotics Anonymous meetings, and recreational
+  activities. Arranges for vocational rehabilitation and other services as needed.
+  Some slots available through AB109.  cchealth.org/   and
+:eligible_population: Men (only), 18-64 years of age.  Must be a Contra Costa County
+  resident.
+:email: 
+:faith_based: 'No'
+:fax: "(925) 646-9276"
+:fees: Sliding scale.  No one will be denied services based on inability to pay.
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  cchealth.org/aod/pdf/Discovery-House-brochure.pdf
+  Hours: 24 hours per day/7 days per week
+  Notes: Application Procedure: Apply by telephone by calling 1-800-846-1652.
+  Transportation: From Pleasant Hill BART, take County Connections bus #116
+  (headed towards Am-Track), get off at Pacheco and Arthur.
+:name: Discovery House   Residential Substance Abuse Program
+:phone: "(925) 646-9270"
+:services:
+- Residential substance abuse treatment
+- individualized program
+- exercise and recreational activities
+- vocational rehabilitation
+- supportive services and referrals
+:url: cchealth.org/aod/pdf/Discovery-House-brochure.pdf
+:what_to_bring: 

--- a/organizations/domestic-violence-shelters.yml
+++ b/organizations/domestic-violence-shelters.yml
@@ -65,3 +65,5 @@
 - Referrals to other resources available as needed
 :url: www.sfaws.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/domestic-violence-shelters.yml
+++ b/organizations/domestic-violence-shelters.yml
@@ -1,0 +1,67 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 
+:contact_name: Crisis Line
+:description: If you are in danger of violence, seek help. The following shelters
+  offer temporary housing at confidential locations.
+:eligible_population: Women, Transgender people, Pregnant women, Women with children,
+  All families.  No male adults over the age of 18.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 'no'
+:languages:
+- Arabic
+- Bengali
+- Cantonese
+- Dutch
+- Farsi
+- Georgian
+- Gujarati
+- Hindi
+- Indonesian
+- Japanese
+- Javanese
+- Kachi
+- Kannada
+- Korean
+- Lao
+- Mandarin
+- Punjabi
+- Russian
+- Spanish
+- Tagalog
+- Taiwanese
+- Tamil
+- Telugu
+- Thai
+- Toisa
+:miscellaneous: |-
+  Asian Women's Shelter
+  The mission of the Asian Women’s Shelter (AWS) is to eliminate domestic violence by promoting the social, economic, and political self-determination of women. AWS is committed to every person’s right to live in a violence-free home. It specifically addresses the cultural and language needs of immigrant, refugee, and U.S.-born Asian women and their children. AWS’s perspective is reflected in the agency’s broad strategy, which integrates culturally knowledgeable and language-accessible shelter services, educational programs, and community-based initiatives and advocacy. www.sfaws.org
+  Crisis Line: Monday – Friday, 9:00am to 5:00pm. After hours, crisis line rolls over to WOMAN, Inc.
+  Mailing Address: 3543 - 18th Street #19, SF, CA 94110
+  Notes: No referral needed. Call crisis line at any time. Location is confidential, so no drop-ins, but call to get connected with services.
+:name: Domestic Violence Shelters
+:phone: "(415) 751-0880"
+:services:
+- Emergency Shelter
+- Rental Move-in Assistance
+- Access to Internet
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Phone/Voicemail
+- Shower Facilities
+- Storage Facilities
+- Transit Vouchers
+- Health & Wellness Education
+- Intensive Case Management
+- Outreach
+- Childcare (Emergency)
+- Children Program Activities
+- Parenting Support/Education
+- Services for Children
+- Referrals to other resources available as needed
+:url: www.sfaws.org
+:what_to_bring: 

--- a/organizations/dress-for-success-san-francisco.yml
+++ b/organizations/dress-for-success-san-francisco.yml
@@ -28,3 +28,5 @@
 :url: www.dressforsuccess.org/sanfrancisco
 :what_to_bring: Dress for Success San Francisco does not require ID at check-in. Check
   in at security desk required.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/dress-for-success-san-francisco.yml
+++ b/organizations/dress-for-success-san-francisco.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.
+:address: " Location: 500 Sutter Street # 218, San Francisco, CA  94102"
+:contact_name: Gia Barsi, Program Manager
+:description: The mission of Dress for Success is to promote the economic independence
+  of disadvantaged women by providing professional attire, a network of support and
+  the career development tools to help women thrive in work and in life.
+:eligible_population: Female only; 16 years and older; must be actively job searching,
+  attending a job fair/networking event, or enrolled in a job training/internship
+  program. Clients are eligible to be seen twice a year for clothing services (once
+  for an initial interview outfit; again when you have secured part-time/full-time
+  employment).
+:email: sanfrancisco@dressforsuccess.org
+:faith_based: No.
+:fax: 415-362-0035
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday 9am -5pm
+   Location: 500 Sutter Street # 218, San Francisco, CA  94102
+  Notes: Written Referral required for a Suiting Appointment. No walk-in’s, by appointment only. Suiting appointments are Tuesday – Thursday, 11am – 3pm. No children or visitors are allowed to accompany you to your appointment.   All items are based on inventory.
+:name: Dress For Success San Francisco
+:phone: "(415) 362-0034"
+:services:
+- Professional and Working Wardrobe Attire, Job Mentorship Program, Professional Women’s
+  Group Networking Program,
+:url: www.dressforsuccess.org/sanfrancisco
+:what_to_bring: Dress for Success San Francisco does not require ID at check-in. Check
+  in at security desk required.

--- a/organizations/emergency-shelter-for-families.yml
+++ b/organizations/emergency-shelter-for-families.yml
@@ -1,0 +1,49 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Any hotline worker or Crisis Intervention Counselor
+:description: If you are an adult with your children, you can seek emergency shelter
+  for families through Compass Connecting Point for family shelters. You should get
+  on this waiting list as soon as possible. If you need a family shelter bed tonight,
+  contact Hamilton Family Residences and Emergency Center (on the following page).
+:eligible_population: All families, pregnant women, women with children.  Eligible
+  families have at least one legal adult plus either a minor child in their custody
+  or a preganancy.  There is no maximum family size.  For shelter wait list, families
+  must be homeless and receiving public benefits in SF or willing to transfer to SF.  For
+  rental assisitance, families must be SF residents.  For move in funds, they must
+  be homeless in SF and have a unit they have been accepted into.
+:email: 
+:faith_based: No.
+:fax: "(415) 442-5138"
+:fees: 
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- German
+- We are able to arrange ASL interpreters
+:miscellaneous: |-
+  Compass Family Services   Compass Connecting Point
+  Compass Connecting Point (CCP) is a unique program that gives any San Francisco family experiencing a housing crisis quick access to the services that they need most, including eviction prevention, emergency shelter, health care, child care and eductional programs.  CCP manages the shelter waiting list for the City funded long-term family shelters.  Our goals are to place families into shelter and provide supportive services during that wait, including emergency food, diapers, transportation assistance, and intensive supoort with housing search.  Additionally CCP provides a one time interest free loan for move in funds and eviction prevention.
+  www.compass-sf.org/programs/connecting-point
+  Specific Intake Days/Times:  Monday 9am-12pm and 1pm-5pm; Tuesday 9am-12pm and 3pm-5pm; Wednesday 9am-12pm and 1pm-5pm; Thursday 9am-12pm and 2pm-5pm; and Friday 9am-12pm and 1pm-5pm
+  Note:  No referral required.  All clients are required to do a 15 minute phone intake over the hotline at (855) 234-2667.  Drop-in services are available Monday 9am-12pm, Wednesday 10:30am-12pm, Friday 9am-12pm..  Families are typically on the waitlist for 6 to 8 months during which we provide supportive services.
+  Client fees: None
+:name: Emergency Shelter for Families
+:phone: "(855) 234-2667"
+:services:
+- Emergency Shelter
+- Rental Move-In Assistance
+- Access to Internet
+- Assistance Getting Driver’s License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygeine/Personal Care Items
+- P.O. Box/Mail Service
+- Transit Vouchers
+- Mental Health Treatment
+- Health & Wellness Education
+- Assistance Applying for Calfresh/Food Stamps
+:url: www.compass-sf.org/programs/connecting-point
+:what_to_bring: 

--- a/organizations/emergency-shelter-for-families.yml
+++ b/organizations/emergency-shelter-for-families.yml
@@ -47,3 +47,5 @@
 - Assistance Applying for Calfresh/Food Stamps
 :url: www.compass-sf.org/programs/connecting-point
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/emergency-shelter-for-individuals.yml
+++ b/organizations/emergency-shelter-for-individuals.yml
@@ -46,3 +46,5 @@
 - Referrals to other resources available as needed
 :url: www.catsinc.org
 :what_to_bring: TB Clearance.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/emergency-shelter-for-individuals.yml
+++ b/organizations/emergency-shelter-for-individuals.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible; all other reasonable accommodations as needed.
+:address: '330 Ellis Street, #101, San Francisco, CA'
+:contact_name: Case Manager on duty
+:description: If you are an adult without children with you, you can seek emergency
+  shelter through any one of the following locations. These places can help you reserve
+  a shelter bed during the days and times listed, at one of the emergency shelters
+  for individuals in San Francisco.  Further, these locations can help you get connected
+  to more permanent housing opportunities.
+:eligible_population: All Women, MTF Transgender people, Pregnant women. Program does
+  not serve FTM Transgender individuals.
+:email: 
+:faith_based: No.
+:fax: "(415)775-1989"
+:fees: Emergency shelter clients do not pay program fees. Clients in Substance Abuse
+  or Transitional Housing pay 30% of income based on HUD guidelines.
+:languages:
+- Spanish
+- English
+:miscellaneous: "Glide Walk-In Center\nLanguage(s) Spoken: English, Cantonese and
+  Spanish\nHours: Monday - Friday: 7:00am to 11:00am; 4:00pm to 9:00pm\nMission Neighborhood
+  Resource Center\nLanguage(s) Spoken: English and Spanish\nHours:\tMonday – Friday:
+  7:00am to 12:00pm and 2:00pm to 7:00pm (Thurs until 5pm)\nSaturday: 7:00am to 12:00pm\nMulti-Service
+  Center (MSC) South\nLanguage(s) Spoken: English\nHours:\t24 Hours; Shelter Reservations
+  from 5:00pm-1:00am\nUnited Council of Human Services\nLanguage(s) Spoken: English
+  and Spanish\nHours:\tEveryday: 7:00am to 9:00am (Breakfast), 9:00am to 5:00pm (Office
+  Hours), 5:00pm to 7:00pm (Dinner), 7pm-9pm (Showers)\nDirect Services:\nCATS   A
+  Woman's Place\nCATS helps those most in need get off the street, achieve stability
+  and establish permanent housing by providing compassionate, culturally sensitive
+  services and stays of 4-18 months. www.catsinc.org\nTransitional Housing: sherita@awpcats.org\nHIV
+  Caseworker:  pau@awpcats.org\nSubstance use treatmen: Blake@awpcats.org\nProgram
+  Coordinator: rachel@awpcats.org\nIntake: Everyday 8am-4pm.\nFacility Hours: 24 hours/7
+  days. Business hours: 8am-4:00pm; Drop-in 12pm-4:30pm.\nNotes: No referral needed."
+:name: Emergency Shelter for Individuals
+:phone: "(415) 674-6012"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Access to Internet (no computers available, wireless only)
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Phones (no voicemai)
+- Shower Facilities
+- Substance Abuse Treatment
+- Medical Care
+- Referrals to other resources available as needed
+:url: www.catsinc.org
+:what_to_bring: TB Clearance.

--- a/organizations/episcopal-community-services-adult-education-center.yml
+++ b/organizations/episcopal-community-services-adult-education-center.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 165 8th Street, San Francisco, CA  94103
+:contact_name: 
+:description: The Adult Education Center specializes in providing a stable, caring
+  and individualized learning environment for students who are coping with the inter-related
+  challenges of homelessness, illiteracy, learning disabilities, substance abuse,
+  and mental health issues. While created particularly for homeless adults and those
+  formerly homeless adults living in supportive housing, the Adult Education Center
+  is open to all low-income individuals in San Francisco who would like to further
+  develop their academic skills or need job counseling, training and placement.
+:eligible_population: Adults, age 18 and older.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  url: www.ecs-sf.org/programs/skills.htm
+  Person to Contact: Staff
+  School Hours: Monday -Thursday, 9am to 3pm  Friday, 9am-12pm.
+  Notes: No referral needed. Drop-ins welcome. Orientations are drop in every Monday-Thursday at 1:00pm
+:name: Episcopal Community Services   Adult Education Center
+:phone: "(415) 487-3300 ext. 1101"
+:services:
+- Access to Internet
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Health and Wellness Education
+- Basic/Remedial Education
+- GED preparation
+- High School Diploma
+- Reading and Literacy Assistance
+- Job Readiness and Life Skills
+- Money Management and Personal Finance Education
+- Referrals to other resources available as needed
+:url: www.ecs-sf.org/programs/skills.htm
+:what_to_bring: 

--- a/organizations/episcopal-community-services-adult-education-center.yml
+++ b/organizations/episcopal-community-services-adult-education-center.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: www.ecs-sf.org/programs/skills.htm
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/episcopal-community-services-chefs.yml
+++ b/organizations/episcopal-community-services-chefs.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: 'Wheelchair accessible. Other disabilities are accommodated. Note:
+  Student must be able to work safely in a small kitchen.'
+:address: 165Natoma Street
+:contact_name: Sally Ray or Emile Sanders, Employment Specialist
+:description: It is our mission to train homeless individuals in culinary arts and
+  to assist them in finding and keeping employment, in order to support their move
+  out of homelessness.
+:eligible_population: Must be homeless and SF resident.
+:email: sray@ecs-sf.org or esanders@ecs-sf.org
+:faith_based: No.
+:fax: "(415) 487-3330"
+:fees: No fees.
+:languages:
+- English
+:miscellaneous: |-
+  Emile Sanders: (415) 487-3300 x1107
+  Hours: Monday – Friday, 9am to 5pm
+  San Francisco, CA  94103
+  Notes: Intake takes place at several points throughout the year, and requires three professional references. No formal referral form is needed, and drop-ins are welcome. Please call or write for more information.
+:name: Episcopal Community Services   CHEFS
+:phone: 'Sally Ray:  (415) 487-3300  x6115'
+:services:
+- Emergency Shelter
+- Permanent Housing
+- Access to Internet
+- Clothing
+:url: www.ecs-sf.org
+:what_to_bring: Staff will assist cleints with necessary documents.

--- a/organizations/episcopal-community-services-chefs.yml
+++ b/organizations/episcopal-community-services-chefs.yml
@@ -27,3 +27,5 @@
 - Clothing
 :url: www.ecs-sf.org
 :what_to_bring: Staff will assist cleints with necessary documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/eviction-defense-collaborative-edc-and-rental-assistance-radco.yml
+++ b/organizations/eviction-defense-collaborative-edc-and-rental-assistance-radco.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: '995 Market, #1200, San Francisco, CA 94103'
+:contact_name: 
+:description: The Eviction Defense Collaborative is the principal organization in
+  San Francisco helping low-income tenants to respond to eviction lawsuits. Each year
+  we provide emergency legal services, through EDC, and rental assistance, through
+  RADCo, to more than 5,000 tenants in San Francisco.
+:eligible_population: All individuals and family members.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Certain services have sliding-scale fees. Nobody turned away for lack of funds.
+:languages:
+- English
+- Spanish
+- Chinese
+- French
+- Russian
+:miscellaneous: |-
+  Hours: Monday – Friday from 9:30am-11:30am; 1:00pm-3:00pm
+  Notes: No referrals needed. Drop-In only.
+   Things To Know
+:name: Eviction Defense Collaborative (EDC) and Rental Assistance (RADCo)
+:phone: 415-947-0797
+:services:
+- 'EDC’s legal services include counseling and legal help to tenants during the eviction
+  process: programs include preparing a response to the lawsuit, limited representation
+  at the settlement conference, and preparation of requests for delays of the sheriff’s
+  eviction'
+- RADCo’s provides rental assistance to more than 600 families each year, in the form
+  of interest-free loans and grants
+- 'Please note: The Eviction Defense Collaborative does not provide the services of
+  a lawyer – clients act as their own lawyer'
+- Referrals to other services provided, as appropriate
+:url: www.evictiondefense.org
+:what_to_bring: Proof of San Francisco Residency

--- a/organizations/eviction-defense-collaborative-edc-and-rental-assistance-radco.yml
+++ b/organizations/eviction-defense-collaborative-edc-and-rental-assistance-radco.yml
@@ -35,3 +35,5 @@
 - Referrals to other services provided, as appropriate
 :url: www.evictiondefense.org
 :what_to_bring: Proof of San Francisco Residency
+:__meta__:
+  :version: 0.0.1

--- a/organizations/five-keys-charter-school-los-angeles.yml
+++ b/organizations/five-keys-charter-school-los-angeles.yml
@@ -54,3 +54,5 @@
 - " "
 :url: www.fivekeyscharter.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/five-keys-charter-school-los-angeles.yml
+++ b/organizations/five-keys-charter-school-los-angeles.yml
@@ -1,0 +1,56 @@
+---
+:accessibility: 
+:address: WorkSource CA -Hub Cities Consortium, 2677 Zoe Ave, Huntington Park, CA
+  90255
+:contact_name: 
+:description: Five Keys Charter School provides educational options for obtaining
+  a High School Diploma, GED, Computer Literacy, and English as a Second Language.  Our
+  goal is to increase educational levels, finding employment, and reintegrating into
+  the community. Class times and schedules are flexible, offering students classroom
+  based instruction and independent study programs. Five Keys partners with both Worksource
+  and Youthsource centers that provide wrap around support services that our students
+  need to meet their education and Career goals. We have twelve community locations
+  throughout Los Angeles County.
+:eligible_population: 
+:email: joses@fivekeyscharter.org
+:faith_based: 
+:fax: "(415) 734-3314"
+:fees: 
+:languages: []
+:miscellaneous: |-
+   
+  Contact Person: Jose Sanchez, Administrative Coordinator
+  Phone: (415) 638-1284
+  Administrative Office:  2677 Zoe Avenue, Huntington Park, CA 90255
+  Hours:  Monday-Friday, 8:30am-4:30pm
+  Notes: Free education.  GED test is paid for by 5 Keys.  No referral needed. Drop-ins  welcome.  We have numerous locations in Los Angeles County.  Call for a location near you.
+
+  Languages Spoken: English, Spanish.
+  Client fees, if any: None.
+  Eligible Population: All individuals 18 and older.
+  Faith Based: No.
+  Locations:
+  WorkSource CA -Hub Cities Consortium, 2677 Zoe Ave, Huntington Park, CA 90255
+  Southeast L.A.-Crenshaw WorkSource Center, 3965 S. Vermont Ave Los Angeles, CA 90037
+  WorkSource Center Wilshire, 3550 Wilshire Blvd, Suite 500 Los Angeles, CA 90010
+  WorkSource Center Compton, 2939 E. Pacific Commerce Dr. Compton, CA 90221
+  WorkSource Center Goodwill, 342 San Fernando Rd.  Los Angeles, CA 90031
+  WorkSource El Monte, 11635 Valley Blvd. Unit G, El Monte, CA 91732
+  WorkSource Center Alhambra, 2550 W. Main St. #103, Alhambra, CA 91801
+  Boyle Heights Technology Youth Center, 1600 E. Fourth St., Los Angeles, CA 90033
+  Para Los Niños East Los Angeles, 3845 Selig Pl. Suite #150, Los Angeles, CA 90031
+  New Beginnings Lancaster, 44814 Cedar Ave., Lancaster, CA 93534
+  *Healthright 360, 2307 W. 6th Street Los Angeles, CA 90057
+  *Amity Foundation: Amistad de Los Angeles,  3745 S. Grand Ave., Los Angeles, CA 90007
+  *These sites do not have open enrollment.
+:name: Five Keys Charter School   Los Angeles
+:phone: 
+:services:
+- Basic/Remedial Education
+- English as a Second Language
+- GED & High School Education
+- Reading/Literacy
+- Referrals to other resources available as needed
+- " "
+:url: www.fivekeyscharter.org
+:what_to_bring: 

--- a/organizations/five-keys-charter-school.yml
+++ b/organizations/five-keys-charter-school.yml
@@ -51,3 +51,5 @@
   groups
 :url: www.fivekeyscharter.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/five-keys-charter-school.yml
+++ b/organizations/five-keys-charter-school.yml
@@ -1,0 +1,53 @@
+---
+:accessibility: 70 Oak Grove is not wheelchair accessible.
+:address: 'Address:  70 Oak Grove, San Francisco, CA  94107'
+:contact_name: Administrative Office
+:description: Five Keys Charter School provides basic adult educational options for
+  obtaining a High School Diploma or High School Equivalency.  Our goal is to increase
+  educational levels for successful Re-entry, finding employment and reintegrating
+  into the community. Class times and schedules are flexible, offering students classroom
+  based instruction, independent study and online learning. Five Keys partners with
+  respected CBO’s that provide wrap around support services that our students need
+  to meet their educational and career goals.  We have over 20 community locations
+  throughout San Francisco where a teacher is integrated into the program model so
+  education, treatment or work readiness is integrated to education.
+:eligible_population: All individuals 18 and older, 16 and above at 1601 Lane St location.
+:email: 
+:faith_based: No.
+:fax: "(415) 734-3314"
+:fees: None.
+:languages:
+- English
+- Spanish
+- Chinese
+:miscellaneous: |-
+  Address:  70 Oak Grove, San Francisco, CA  94107
+  Notes: Free education.  GED test is paid for by 5 Keys.  No referral needed. Drop-ins welcome at 70 Oak Grove and 1800 Oakdale.
+  Locations:
+  Goodwill Industries:  Comprehensive Access Point (CAP), 1500 Mission Street, San Francisco, CA, 94103, (415) 730-3218
+  Arriba Juntos: 1850 Mission Street, San Francisco, CA, 94103, (415) 730-3218
+  Asian Neighborhood Design:  1245 Howard Street, San Francisco, CA, 94103, (415) 730-3218
+  Bayview YMCA: 1601 Lane Street, San Francisco, CA , 94124 (415) 730-3218
+  CASC: 564 6th Street, San Francisco, CA  94103, (415) 489-7320
+  CCSF Southeast Campus: 1800 Oakdale Street, San Francisco, CA 94124, (415) 821-2400
+  Ella Hill Hutch Community Center:  1050 McAllister Street, San Francisco, CA, 94115 (415) 730-3218
+  FACES SF:  Visitation Valley Neighborhood Access Point, 1099 Sunnydale Ave, 2nd Floor, San Francisco, CA, 94134, (415)308-1689
+  HSA/MEDA: 3120 Mission Street, San Francisco, CA, 94114,(415) 730-3218
+  Mission Economic Development Agency: 2301 Mission Street, San Francisco, CA  (415) 730-3218
+  SFAPD Learning Center: 850 Bryant Street, San Francisco, CA  94103, (415) 553-1924
+  Thomas Paine Square Community Center:   1086 Golden Gate Avenue, #G, San Francisco, CA, 94115,  (415) 929-1104
+  TURF/Sunnydale Housing: 1652 Sunnydale Ave, San Francisco, CA, 94134 (415) 730-3218
+  Visitation Valley Strong Family: (ESL only) 50 Raymond Street, San Francisco, CA  94134, (415) 730-3218
+  WANAP Success Center:  1449 Webster Street, San Francisco, CA, 94115, (415) 730-3218
+  Women’s Resource Center:  930 Bryant St., San Francisco, CA, 94103, (415) 734-3150
+:name: Five Keys Charter School
+:phone: "(415) 734-3310"
+:services:
+- Basic/Remedial Education
+- English as a Second Language
+- GED & High School Education
+- Reading/Literacy
+- Vocations Education, Independent Study, Intensive Case Management and Re-entry support
+  groups
+:url: www.fivekeyscharter.org
+:what_to_bring: 

--- a/organizations/friendship-house.yml
+++ b/organizations/friendship-house.yml
@@ -36,3 +36,5 @@
 :url: www.friendshiphousesf.org
 :what_to_bring: California-Issued ID and TB Clearance, current within last 6 months.
   (If ID is from any state other than Calif., a Tribal ID is required.)
+:__meta__:
+  :version: 0.0.1

--- a/organizations/friendship-house.yml
+++ b/organizations/friendship-house.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: Must call first – Intake done over the phone.
+:contact_name: Laura Gutierrez, Intake
+:description: Residential treatment facility dedicated to serve American Indian communities,
+  and all people with alcohol/drug abuse issues who would benefit from pro-social
+  model of treatment influenced by American Indian traditions.
+:eligible_population: All individuals with no convictions for arson, no serious medical,
+  psychological or emotional conditions that could interfere with participation in
+  social-model treatment program. Must be clean and sober for at least 72 hours. Women
+  may bring 1 or 2 children ages 0-5.
+:email: 
+:faith_based: Yes.
+:fax: "(415) 575-4065"
+:fees: Sliding scale.
+:languages:
+- English
+- Navajo
+- ''
+- other American Indian languages
+:miscellaneous: |
+  Hours: Monday-Friday, 8:00am-5:00pm
+  Notes: No referral needed. No drop-ins. Must call for appointment first.
+:name: Friendship House
+:phone: "(415) 865-0964"
+:services:
+- Substance Abuse Treatment
+- Housing
+- Intensive Case Management
+- Life Skills Development
+- Relapse Prevention
+- Family Counseling/Reunification
+- Job Readiness Training
+- Assistance with Transition Back into the Community
+- Referrals to other resources available as needed
+:url: www.friendshiphousesf.org
+:what_to_bring: California-Issued ID and TB Clearance, current within last 6 months.
+  (If ID is from any state other than Calif., a Tribal ID is required.)

--- a/organizations/ged-testing-service.yml
+++ b/organizations/ged-testing-service.yml
@@ -1,0 +1,59 @@
+---
+:accessibility: 
+:address: 50 Phelan Ave San Francisco, CA 94112
+:contact_name: 
+:description: 'Preparing to pay for college: Free Application for Federal Student
+  Aid (FAFSA). One of the tools you can use to estimate your eligibility for federal
+  student financial assistance is the Financial Aid Estimator Tool – FAFSA4caster
+  – which is available online at .  You may have heard that if you have been convicted
+  of a felony, you are not eligible to receive financial aid. This is not necessarily
+  true. A student convicted for the possession or sale of illegal drugs may have eligibility
+  suspended if the offense occurred while the student was receiving federal student
+  aid (grants, loans, or work-study). When you complete the Free Application for Federal
+  Student Aid (FAFSA), you will be asked whether you had a drug conviction for an
+  offense that occurred while you were receiving federal student aid. If the answer
+  is yes, you will be provided a special worksheet to help you determine whether your
+  conviction affects your eligibility for federal student aid. You may preview the
+  worksheet in the FAFSA Information section at www.studentaid.ed.gov/pubs. If you
+  have been convicted of a forcible or nonforcible sexual offense, and you are subject
+  to an involuntary civil commitment upon completion of a period of incarceration
+  for that offense, you are ineligible to receive a Federal Pell Grant.'
+:eligible_population: Individuals with a disability that causes a limitation in an
+  educational setting.
+:email: 
+:faith_based: 'No'
+:fax: 
+:fees: 
+:languages: []
+:miscellaneous: |-
+  Contact:  gedtestingservice.com
+  Direct Services:
+  City College of San Francisco   Disabled Students Programs & Services (DSPS)
+  The overall mission of DSPS is to provide exemplary instruction, support services and access to students with disabilities. DSPS will support students with disabilities in educationally related activities consistent with the mission and vision of CCSF and in compliance with federal and state laws. To "level the playing field" for students with disabilities through ensuring equal access to programs and facilities and to provide reasonable accommodations for documented disabilities. www.ccsf.edu/dsps
+  TDD: (415) 452-5451
+  Locations:
+  John Adams Campus
+  1860 Hayes Street
+  San Francisco, CA 94117
+  Ocean Campus
+  50 Phelan Ave San Francisco, CA 94112
+  Notes: Students can make an appointment to see a DSPS counselor at the Mission, Downtown, Chinatown, and Southeast campuses by calling (415) 452-5481.
+:name: GED Testing Service
+:phone: "(415) 452-5481"
+:services:
+- Access to Internet
+- Mental Health Treatment
+- Medical Care
+- Disability Management Counseling
+- Group Counseling/Therapy, Test-Taking Anxiety Workshops
+- Basic/Remedial Education
+- College & Graduate Education
+- Creative or Performing Arts Programs
+- English as a Second Language
+- GED & High School Education
+- Vocational Education
+- Employment Training
+- Employment Placement
+- Referrals to other resources available as needed
+:url: www.fafsa4caster.ed.gov
+:what_to_bring: 

--- a/organizations/ged-testing-service.yml
+++ b/organizations/ged-testing-service.yml
@@ -57,3 +57,5 @@
 - Referrals to other resources available as needed
 :url: www.fafsa4caster.ed.gov
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/geo-reentry-services-taylor-street-facility.yml
+++ b/organizations/geo-reentry-services-taylor-street-facility.yml
@@ -53,3 +53,5 @@
 - Referrals to other resources available as needed
 :url: www.geogroup.com
 :what_to_bring: TB Clearance. Program will assist entering clients in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/geo-reentry-services-taylor-street-facility.yml
+++ b/organizations/geo-reentry-services-taylor-street-facility.yml
@@ -1,0 +1,55 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 111 Taylor Street, San Francisco, CA  94102
+:contact_name: Daionne Washington
+:description: GEO Reentry Services’ mission is to help prepare individuals to reintegrate
+  back to society and be responsible individuals who are accountable for their actions.
+  Placements usually last from six months to one year.
+:eligible_population: All individuals without criminal conviction for sex offense,
+  arson, or who are not registered sex offenders.
+:email: 
+:faith_based: No.
+:fax: "(415) 346-0358"
+:fees: Self-pay residents pay $80/day. No sliding scale. All other residents are covered
+  by an agency. BOP requires 25% of income for subsistence. No cost for CDCR residents
+  but residents must save 75% of net income in saving account for their release.
+:languages:
+- English
+- some Spanish
+:miscellaneous: |-
+  Facility Hours: 24 hours/7 days
+  Notes: Must be referred by CDCR Agent of Record or Federal BOP, Probation Officer/ Federal Pretrial services. Self-pay county beds call for info. No drop-ins.
+:name: GEO Reentry Services   Taylor Street Facility
+:phone: "(415) 346-9769"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Shower Facilities
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Anger Management
+- Community Education & Mediation
+- Individual Counseling/Therapy
+- Post-Incarceration Support
+- Victim/Survivor Services
+- Basic/Remedial Education
+- GED & High School Education referral
+- Reading/Literacy
+- Vocational Education
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Family Reunification
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.geogroup.com
+:what_to_bring: TB Clearance. Program will assist entering clients in getting this.

--- a/organizations/glide-foundation-glide-daily-free-meals-program.yml
+++ b/organizations/glide-foundation-glide-daily-free-meals-program.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.glide.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/glide-foundation-glide-daily-free-meals-program.yml
+++ b/organizations/glide-foundation-glide-daily-free-meals-program.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 330 Ellis Street, San Francisco, CA  94102
+:contact_name: 
+:description: The goal of this program is to provide three nutritious meals a day,
+  364 days a year, to anyone in need.
+:eligible_population: All individuals and family members.
+:email: 
+:faith_based: No.
+:fax: "(415) 921-6951"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Person to Contact: Bruce McKinney, Manager
+  Hours:
+  Monday – Friday
+  Breakfast: 8:00am to 9:00am
+  Lunch: 12:00pm to 1:30pm
+  Dinner: 4:00pm to 5:30pm
+  Saturday & Sunday
+  Breakfast:  8am-9am
+  Lunch:  12:00pm-1:30pm
+  Bagged dinner provided after lunch 
+  Notes: No referral needed. Drop-ins welcome.
+:name: Glide Foundation   Glide Daily Free Meals Program
+:phone: "(415) 674-6043"
+:services:
+- Prepared Meals
+- Referrals to other resources available as needed
+:url: www.glide.org
+:what_to_bring: 

--- a/organizations/glide-foundation-men-in-progress.yml
+++ b/organizations/glide-foundation-men-in-progress.yml
@@ -28,3 +28,5 @@
 - Referrals to other resources available as needed
 :url: www.glide.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/glide-foundation-men-in-progress.yml
+++ b/organizations/glide-foundation-men-in-progress.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 330 Ellis Street, San Francisco, CA  94102 (go to Freedom Hall)
+:contact_name: 
+:description: Men In Progress is a Violence Intervention Program dedicated to working
+  with all men in straightforward and practical ways on issues that affect their lives.
+  The goal is to support men to gain understanding and strength in their relationships
+  with themselves, partners, family, friends and community.
+:eligible_population: All individuals and family members.
+:email: 
+:faith_based: No.
+:fax: "(415) 771-8420"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Person to Contact: Group Facilitator
+  Hours: Tuesday and Thursdays 5pm-8pm
+  Notes: To join the group you must show up on a Tuesday at 4:30pm.  No referral needed. Drop-ins welcome.
+:name: Glide Foundation   Men In Progress
+:phone: "(415) 674-6195"
+:services:
+- Anger Management
+- Community Education and Mediation
+- Group Counseling/Therapy
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: www.glide.org
+:what_to_bring: 

--- a/organizations/glide-foundation-walk-in-center.yml
+++ b/organizations/glide-foundation-walk-in-center.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 330 Ellis Street, Room 101, San Francisco, CA  94102
+:contact_name: 
+:description: To provide clients with immediate assistance to prevent their situations
+  from escalating, and to engage them in more extended, intensive services when they
+  are ready.
+:eligible_population: All individuals and family members.
+:email: 
+:faith_based: No.
+:fax: "(415) 771-8420"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Person to Contact: Client Advocate
+  Hours: Monday – Thursday, 8:00am to 1:00pm, 2:00pm to 4:30pm; Friday, 8:30am to 12:45pm
+  Emergency Shelter Bed Reservations: 365 days/year, 7:00am to 10:30am and 4:00pm to 9:00pm
+  Notes: No referral needed. Drop-ins welcome.
+:name: Glide Foundation   Walk-In Center
+:phone: "(415) 674-6033"
+:services:
+- Rental Move-in Assistance
+- The Walk-In Center assists clients in obtaining rental assistance through Season
+  of Sharing, HPRP, Catholic Charities, FEPCO, HOME, etc
+- Staff screen for eligibility, and assist clients with the full application process
+- Emergency Shelter Bed Reservations
+- Permanent Housing
+- Transitional Housing
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Phone/Voicemail Access
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Intensive Case Management
+- Referrals to other resources available as needed
+:url: www.glide.org
+:what_to_bring: 

--- a/organizations/glide-foundation-walk-in-center.yml
+++ b/organizations/glide-foundation-walk-in-center.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: www.glide.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/glide-foundation-women-s-center.yml
+++ b/organizations/glide-foundation-women-s-center.yml
@@ -32,3 +32,5 @@
 - Referrals to other resources available as needed
 :url: www.glide.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/glide-foundation-women-s-center.yml
+++ b/organizations/glide-foundation-women-s-center.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: 
+:address: 330 Ellis Street, San Francisco, CA  94102
+:contact_name: Case Manager
+:description: To introduce Afro-centric and socio/historical/political contexts for
+  a culturally sensitive and holistic approach to healing and transformation for African
+  American women impacted by domestic violence.
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Tuesday, 9:00am to 10:30am; Wednesday, 9:00am to 10:30am, 3:00pm to 4:30pm; Thursday and Friday, 9:00am to 10:30am
+  Notes: No referral needed. Drop-ins are welcome.
+:name: Glide Foundation   Women's Center
+:phone: "(415) 674-6026"
+:services:
+- Emergency Shelter Bed Reservations
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Health and Welness Education
+- Group Counseling
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Victim/Survivor Services
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: www.glide.org
+:what_to_bring: 

--- a/organizations/golden-gate-university-school-of-law-women-s-employment-rights-clinic.yml
+++ b/organizations/golden-gate-university-school-of-law-women-s-employment-rights-clinic.yml
@@ -1,0 +1,25 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 40 Jessie Street, 5th Floor, San Francisco, CA 94105
+:contact_name: Law Student Hotline
+:description: The Clinic provides free or low-cost legal services to people with employment-related
+  legal problems, with an emphasis on problems affecting women and low-wage immigrant
+  workers. Law students provide legal services.
+:eligible_population: All individuals and family members.
+:email: werc@ggu.edu
+:faith_based: No.
+:fax: "(415) 896-2450"
+:fees: No fees for legal services. Possible costs for photocopying, etc.
+:languages:
+- English
+- Other languages can be accommodated
+:miscellaneous: |-
+  Hours: Monday – Friday from 9:00am-5:00pm, January-April and September-November, only.
+  Notes: No referrals needed. Please call the hotline for an appointment first. No drop-ins.
+:name: Golden Gate University School of Law   Women’s Employment Rights Clinic
+:phone: "(415) 442-6647"
+:services:
+- Legal Assistance/Advocacy
+- Referrals to other services provided, as appropriate
+:url: www.ggu.edu/law/werc
+:what_to_bring: 

--- a/organizations/golden-gate-university-school-of-law-women-s-employment-rights-clinic.yml
+++ b/organizations/golden-gate-university-school-of-law-women-s-employment-rights-clinic.yml
@@ -23,3 +23,5 @@
 - Referrals to other services provided, as appropriate
 :url: www.ggu.edu/law/werc
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/good-shepherd-gracenter.yml
+++ b/organizations/good-shepherd-gracenter.yml
@@ -46,3 +46,5 @@
 - Referrals to other resources available as needed
 :url: www.gsgracenter.org
 :what_to_bring: State-Issued ID, Social Security Card, TB Clearance; Medical Clearance
+:__meta__:
+  :version: 0.0.1

--- a/organizations/good-shepherd-gracenter.yml
+++ b/organizations/good-shepherd-gracenter.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: ADA Accessibility Plan in place by June, 2010
+:address: 1310 Bacon St., San Francisco, CA 94134
+:contact_name: Sandra Munoz, Case Manager
+:description: As a Women's Secondary Recovery Program, Good Shepherd Gracenter offers
+  housing, case management and supportive services.  The program is based on 12-step
+  spirituality and a holistic approach. The program’s mission is based on a belief
+  in the dignity and worth of each person as a child of God. Participants are expected
+  to stay at least six months.
+:eligible_population: Women and Transgender Women. May not have criminal convictions
+  for sex or arson offenses. May not be a registered sex offender.
+:email: smunoz@gsgracenter.org
+:faith_based: Yes, the program is faith based.
+:fax: "(415) 337-4668"
+:fees: 
+:languages:
+- Spanish
+- Greek
+- English
+:miscellaneous: |-
+  Notes: No referral needed. Appointment needed – No drop-ins.
+  Client fees: $300/month minimum.
+:name: Good Shepherd   Gracenter
+:phone: "(415) 337-1938"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Shower Facilities
+- Transit Vouchers
+- Community Education and Mediation
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Restorative Justice/Survivor Impact
+- Support with Assessment and Application for Food Stamps, General Assistance, SSI,
+  Credit Repair
+- Job Readiness and Life Skills
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Referrals to other resources available as needed
+:url: www.gsgracenter.org
+:what_to_bring: State-Issued ID, Social Security Card, TB Clearance; Medical Clearance

--- a/organizations/goodwill-industries-of-the-greater-east-bay-homelss-services-program.yml
+++ b/organizations/goodwill-industries-of-the-greater-east-bay-homelss-services-program.yml
@@ -1,0 +1,53 @@
+---
+:accessibility: Wheelchair accessible
+:address: 1931 Center Street, Berkeley, CA  94704-transitional houses are located
+  in Oakland and Berkeley.
+:contact_name: Greg Nottage, Intake Coordinator
+:description: Our Homeless Services Program works specifically with individuals facing
+  homelessness and the multitude of related challenges. This program offers employment
+  and comprehensive support services to homeless individuals and families in Alameda
+  County. This Program is primarily supported by a Housing and Urban Development (HUD)
+  grant, which provides for housing stabilization, case management, and in-house counseling
+  for those facing chronic homelessness as well as community members more recently
+  impacted by the economic downturn. Goodwill provides these support services at our One
+  Stop Homeless Employment Center in downtown Oakland.   Goodwill’s “Bridges to Work”
+  initiative helps our homeless participants secure transitional employment and job
+  training, and, once skills are established, search for competitive employment. 
+  In 2013, our Homeless Services Program served 622 individuals and continues to meet
+  high demand for their services as community members continue to struggle with rising
+  unemployment and subsequent instability in their housing.
+:eligible_population: Men and women ages 18 and older.
+:email: 
+:faith_based: N/A
+:fax: 
+:fees: Medi-Cal/AB-109/Re-Entry Court/Private Pay $30 per session.
+:languages:
+- English
+:miscellaneous: |-
+  One Stop Homeless Center
+  1600 San Pablo Avenue, Oakland, CA 94612
+  (510) 903-3220
+
+  Goodwill Industries of the Greater East Bay 8-5 m-f
+  1301 30th Avenue, Oakland, CA 94601
+  (510) 698-7200
+  info@eastbaygoodwill.org
+  San Antonio Fruitvale Community Learning Center
+  29th Avenue (bet. International & East 12th St.), Oakland, CA 94607
+  (510) 698-7216
+  Direct Services:
+  Options Recovery Service
+  At Options, we do not just treat addiction, we treat the whole person.  Our mission is to break the cycle of addiction which causes homelessness, crime and broken families.  optionsrecovery.org
+
+  Hours: Tuesday/Thursday, 8:30am-7:00pm; Monday/Wednesday/Friday, 8:30am-8:00pm
+  Notes:  No appointments/walk-ins are welcome.
+:name: Goodwill Industries of the greater East Bay   Homelss Services Program
+:phone: "(510) 666-9552"
+:services:
+- Out Patient Alcohol and Drug Treatment/Transitional Housing
+- Options is a day treatment recovery program including 12-step study, self-esteem
+  groups, relaxation training, yoga, anger management, life skills, relapse prevention,
+  smoking cessation, individual counseling, acupuncture and a host of other services
+- Other services include shelter/housing and mental health treatment
+:url: ''
+:what_to_bring: 

--- a/organizations/goodwill-industries-of-the-greater-east-bay-homelss-services-program.yml
+++ b/organizations/goodwill-industries-of-the-greater-east-bay-homelss-services-program.yml
@@ -51,3 +51,5 @@
 - Other services include shelter/housing and mental health treatment
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/hamilton-family-center-first-avenues-program.yml
+++ b/organizations/hamilton-family-center-first-avenues-program.yml
@@ -1,0 +1,96 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 255 Hyde Street, San Francisco
+:contact_name: Intake Specialist
+:description: 'The mission of Hamilton Family Center is to break the cycle of homelessness
+  and poverty. Through a Housing First approach, HFC provides a continuum of housing
+  solutions and comprehensive services that promote self-sufficiency for families
+  and individuals, and foster the potential of children and youth. In July 2006, HFC
+  launched a city wide Housing First Initiative called First Avenues: Housing Solutions
+  for Families. First Avenues’ primary focus is to return families to independent
+  living and to assist families and individuals to maintain their housing. First Avenues
+  assists families with addressing housing barriers, such as; eviction and credit
+  problems, locating and securing rental units, and accessing available resources
+  for rental and move-in assistance, and short-term rental subsidies. Families applying
+  for First Avenues financial assistance grants and/or residing in a San Francisco
+  shelters may access the housing services from a First Avenues Homeless Prevention
+  Case Manager including; Bay Area housing search, linkage to fair market housing,
+  linkage to affordable, subsidized, permanent supportive housing, Housing Authority
+  waitlists, etc, housing application assistance, housing advice and counseling, landlord/tenant
+  assistance, address obstacles such as bad credit and history of eviction, access
+  credit reports, deposit and move-in assistance, application to short term rental
+  subsidies, for those whom are eligible.    www.hamiltonfamilycenter.org'
+:eligible_population: Individuals who are currently homeless or at risk of losing
+  their housing.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: No client fees.
+:languages:
+- English
+- Spanish
+- Cantonese
+:miscellaneous: "Hours: Monday – Friday, 9:00am to 5:00pm\nNotes: Applications for
+  the Rental Subsidy Program can be picked up at the office.  To qualify prospective
+  applicants must: 1) Be homeless or at risk of homelessness in San Francisco. 2)
+  Have a qualifying income.\n3) Must have legal custody of at least one minor child.\nMove-In
+  Assistance\nOnce housing is secured, First Avenues will provide a qualifying family
+  with a grant towards deposit and/or first month’s rent. First Avenues Move-In Assistance
+  grants are one-time only. Deposits can be accessed for housing located both in and
+  outside of San Francisco.\nEligibility Criteria:\n•\tFamily unit with legal custody
+  of minor children\n•\tHomeless, must provide appropriate documentation i.e. Certification
+  of Homelessness\n•\tMoving within or from San Francisco.\n•\tFamily has sufficient
+  resources to pay monthly rent\nRental Subsidy Program:\nThe First Avenues Rental
+  Subsidy Program is targeted towards working families in San Francisco. Families
+  may be in shelter or in housing on the verge of homelessness. The Rental Subsidy
+  Program provides eligible families with monthly rental assistance for3-24 months.
+  Families must demonstrate an ability to increase their income by at least the amount
+  of the subsidy and recertify quarterly for eligibility, need and progress. This
+  subsidy is used to enhance each family’s employment goals and maintain their housing
+  goals as they move towards self-sufficiency. Families pay 50% of their monthly income
+  towards rent and the rental assistance maximum per family is $800 per month. The
+  rental subsidy is only applicable to market rate and affordable housing options;
+  it cannot be applied to subsidized options like housing authority where the family’s
+  rental amount is determined by a percentage of their income. Families enrolled in
+  this program receive home-based support services* for the duration of their financial
+  assistance.\nEligibility Criteria:\n•  Family is living in a shelter or transitional
+  housing program in San Francisco or is housed in San Francisco and at risk of losing
+  their housing;\n•  Have a household member who is working part or full-time, and/or
+  families on Cal Works who are transitioning into work;\n•  If the family did not
+  receive the subsidy they would be paying over 50% of their income toward rent;\n•
+  \ Income must be less than 50% AMI in San Francisco;\n•  Family has the ability
+  to increase their monthly income and take over the full rent by the end of the program
+  term.\nEviction Prevention Program:\nFirst Avenues Eviction Prevention assistance
+  is a one time, maximum $1,500 grant to families and individuals facing imminent
+  eviction and subsequent homelessness. The grant must prevent an eviction and avert
+  the family or individual from entering shelter. First Avenues Eviction Prevention
+  targets households who are at risk of eviction and who would be able to retain their
+  housing with one-time rental assistance. Households receive follow up phone calls
+  to ensure that they have remained stably housed.\nEligibility Criteria:\n•  Must
+  have a legal lease\n•  W-9 from the landlord (or can obtain one from the landlord)\n•
+  \ Eviction Notice (within 30 days)\n•  Ability to pay rent forward.\nHouseholds
+  need to call the Eviction Prevention Specialist at 415-614-9060 ext. 114"
+:name: Hamilton Family Center   First Avenues Program
+:phone: "(415) 614-9060 ext. 108"
+:services:
+- Eviction Prevention Assistance, Rental Move-in Assistance
+- Access to Internet
+- Clothing
+- Food/Prepared Meals
+- Transit Vouchers (youth passes for MUNI)
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Outreach
+- Employment Placement
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Housing & Eviction Defense
+- Couples/Family Counseling
+- Parenting Support/Education
+- Services for Children
+- Referrals to other resources available as needed
+:url: www.myhousing.org
+:what_to_bring: All required documents are listed on the front of the Rental Subsidy
+  Application.

--- a/organizations/hamilton-family-center-first-avenues-program.yml
+++ b/organizations/hamilton-family-center-first-avenues-program.yml
@@ -94,3 +94,5 @@
 :url: www.myhousing.org
 :what_to_bring: All required documents are listed on the front of the Rental Subsidy
   Application.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/hamilton-family-center-hamilton-family-residence-emergency-center.yml
+++ b/organizations/hamilton-family-center-hamilton-family-residence-emergency-center.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 260 Golden Gate Ave., San Francisco, CA 94102
+:contact_name: Any staff member.
+:description: Our mission is to break the cycle of homelessness and poverty. Through
+  a housing-first approach, we provide a continuum of housing solutions and hands-on
+  services that promote self-sufficiency for families and individuals, and foster
+  the potential of children and youth.
+:eligible_population: Must have child under 18 in physical or legal custody or be
+  pregnant in third trimester or in fifth month of high risk pregnancy.
+:email: 
+:faith_based: No.
+:fax: "(415) 292-9951"
+:fees: None.
+:languages:
+- English & Spanish
+:miscellaneous: |-
+  Emergency Center Phone: (415) 292-9930
+  Emergency Bed Call-in #: (415) 292-5228
+  Call-ins for Emergency Beds twice daily:
+  Monday to Friday, 11:00am and 5:00pm
+  415-292-5228
+  Facility Hours: 24 hours, 7 days
+  Notes: Emergency beds are available daily for 1-night stays, and are given away on a first come, first served basis. Emergency Center program also has 60-day stays. Call Emergency Center for more information.
+:name: Hamilton Family Center   Hamilton Family Residence & Emergency Center
+:phone: 
+:services:
+- Emergency Shelter
+- Access to Internet
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Local Phone
+- Shower Facilities
+- Transit Vouchers
+- Mental Health Treatment
+- Medical Care
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- After school programming and activities for children ages 0-18; Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.hamiltonfamilycenter.org
+:what_to_bring: 'State-Issued ID, Social Security Card, Birth Certificate, and TB
+  Clearance. Note: There is a grace period of a few days for individuals who are gathering
+  these documents. Program will assist client in getting these documents.'

--- a/organizations/hamilton-family-center-hamilton-family-residence-emergency-center.yml
+++ b/organizations/hamilton-family-center-hamilton-family-residence-emergency-center.yml
@@ -46,3 +46,5 @@
 :what_to_bring: 'State-Issued ID, Social Security Card, Birth Certificate, and TB
   Clearance. Note: There is a grace period of a few days for individuals who are gathering
   these documents. Program will assist client in getting these documents.'
+:__meta__:
+  :version: 0.0.1

--- a/organizations/hamilton-family-center-the-dudley-apartments.yml
+++ b/organizations/hamilton-family-center-the-dudley-apartments.yml
@@ -51,3 +51,5 @@
 :url: www.hamiltonfamilycenter.org
 :what_to_bring: State issued ID, Social Security Card.  Program will assist clients
   getting these documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/hamilton-family-center-the-dudley-apartments.yml
+++ b/organizations/hamilton-family-center-the-dudley-apartments.yml
@@ -1,0 +1,53 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 172 6th Street, San Francisco, CA  94103
+:contact_name: Mary Brown, Case Manager
+:description: Our mission is to break the cycle of homelessness and poverty.  Through
+  a housing-first approach, we provide a continuum of housing solutions and hands-on
+  services that promote self-sufficiency for families and individuals, and foster
+  the potential of children and youth.  The Dudley Apartments is a 75-unit Permanent
+  Supportive Housing development where Hamilton family Center offers intensive case
+  management services for single adults, seniors, families, and children managing
+  disabilities who have experienced homelessness.
+:eligible_population: Men, women, transgender, pregnant women, women with children,
+  families.  There are extensive restrictions for this program as it works with Mercy
+  Housing providing section 8 units.  Please contact the Dudley Apartments staff for
+  more information.
+:email: mbrown@hamiltonfamilycenter.org
+:faith_based: No.
+:fax: "(415) 861-86447"
+:fees: Client pays 30% of their income toward rent.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Notes: Please call for an appointment.  Referal from a service provider who can supply a certificate of homelessness is required.  A waitlist is managed through Mercy Housing.
+  See listing under Hamilton First Avenue program for other housing options and instructions.
+:name: Hamilton Family Center   The Dudley Apartments
+:phone: "(415) 861-8645 x105"
+:services:
+- Permanent Housing
+- Access to Internet
+- Assistance Getting Driver’s License/Other ID
+- Food/Prepared Meals
+- P.O. Box/Mail Service
+- Shower Facilities
+- Mental Health Treatment
+- Health & Wellness Eductaion
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Housing Placement Assistance
+- Assistance Applying for CalFresh/Food Stamps
+- Assistance Applying for PAES/GA/CalWorks
+- Assessment & Application for SSI
+- Credit Repair
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Eduction
+- Assistance Applying for Health Insurance
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education
+- Services for Children
+:url: www.hamiltonfamilycenter.org
+:what_to_bring: State issued ID, Social Security Card.  Program will assist clients
+  getting these documents.

--- a/organizations/hamilton-family-center-transitional-housing-program.yml
+++ b/organizations/hamilton-family-center-transitional-housing-program.yml
@@ -1,0 +1,47 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1631 Hayes St, San Francisco, CA 94117
+:contact_name: Front Desk
+:description: The Hamilton Family Center Transitionl Housing program seeks to break
+  the cycle of homelessness and poverty. Through a housing-first approach, we provide
+  a continuum of housing solutions and hands-on services that promote self-sufficiency
+  for families and individuals, and foster the potential of children and youth. The
+  Transitional Housing Program offers 20 high-needs families interim housing with
+  comprehensive support services for up to 18 months.
+:eligible_population: Families (any adult/s with children) with at least one child
+  under 18 in physical or legal custody or be in the 3rd trimester or 5th month of
+  high risk pregnancy
+:email: thp.intake@hamiltonfamilycenter.org
+:faith_based: No.
+:fax: "(415) 345-0471"
+:fees: Clients pay 30% of their income towards rent and an additional 20% into savings
+  that is returned to them when they exit the program.
+:languages:
+- English
+- Spanish
+:miscellaneous: 'Notes: Clients are required to have a referral from a social service
+  provider and needs to have a certificate of homelessness.  Appointment required.'
+:name: Hamilton Family Center   Transitional Housing Program
+:phone: "(415) 409-2100 ext 100"
+:services:
+- Access to Internet
+- Assistance getting Driver’s License/ID
+- Clothing
+- Mental Health treatment
+- Health & Wellness Education
+- Intensive Case Management
+- Individual Counseling, Housing Placement Assistance
+- Assistance Applying For CalFresh/Food Stamps
+- Assessment & Application for SSI
+- Credit Repair
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Assistance Applying For Health Insurance
+- Couples/Family Counseling
+- Family RAeunification
+- Parenting Support/Education
+- Services For Children
+:url: www.hamiltonfamilycenter.org
+:what_to_bring: State-Issued ID, Social Security Card; birth certificates for children
+  in physical/ legal custody and back rent notice or certification of homelessness.
+  Program will try to assist client in getting these.

--- a/organizations/hamilton-family-center-transitional-housing-program.yml
+++ b/organizations/hamilton-family-center-transitional-housing-program.yml
@@ -45,3 +45,5 @@
 :what_to_bring: State-Issued ID, Social Security Card; birth certificates for children
   in physical/ legal custody and back rent notice or certification of homelessness.
   Program will try to assist client in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/harbor-house-the-salvation-army.yml
+++ b/organizations/harbor-house-the-salvation-army.yml
@@ -1,0 +1,57 @@
+---
+:accessibility: 
+:address: Call for location.
+:contact_name: Aviva Zuckrow, Director
+:description: Our mission is to create and deliver integrated solutions to profound
+  social problems. Since 1991, The Salvation Army Harbor House has operated housing
+  programs, provided chemical dependency treatment, workforce solutions, and other
+  supportive services to single parent families with children or in reunification,
+  who are homeless.
+:eligible_population: Men, Women, Women with children, All families. May not have
+  conviction for sex offense or be a registered sex offender.
+:email: aviva.zuckrow@usw.salvationarmy.org
+:faith_based: No.
+:fax: 
+:fees: 30% of income-when income is in place. If just coming from prison, no charge
+  until income in place.
+:languages:
+- English
+:miscellaneous: |-
+  Specific Intake Days and Times: Mon-Fri
+  Hours: 8am-4pm
+  Notes: Referral from a case manager or other person in a professional capacity, i. e. parole agent required. By appointment only -- No drop-ins.
+:name: Harbor House The Salvation Army
+:phone: "(415) 503-3029"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Shower Facilities
+- Transit Vouchers
+- Substance Abuse Treatment
+- Dental Care
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Workforce Services
+- Assessment & Application for Food Stamps, Cal WORKS, General Assistance
+- Credit Repair
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Childcare
+- Family Reunification
+- Parenting Support/EducationServices for Children
+- Referrals to other resources available as needed
+:url: www.harborhousesf.org
+:what_to_bring: State-Issued ID, TB Clearance, if Veteran, Form DD214. Program may
+  be able to assist clients in getting these.

--- a/organizations/harbor-house-the-salvation-army.yml
+++ b/organizations/harbor-house-the-salvation-army.yml
@@ -55,3 +55,5 @@
 :url: www.harborhousesf.org
 :what_to_bring: State-Issued ID, TB Clearance, if Veteran, Form DD214. Program may
   be able to assist clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright-360-medical-clinics.yml
+++ b/organizations/healthright-360-medical-clinics.yml
@@ -36,3 +36,5 @@
 - Referrals to other resources available as needed
 :url: www.healthright360.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright-360-medical-clinics.yml
+++ b/organizations/healthright-360-medical-clinics.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Jack Cheng or Maribel Baez
+:description: The mission of HealthRIGHT 360 is to give hope, build health, and change
+  lives for people in need. We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: All adults.
+:email: 
+:faith_based: No.
+:fax: "(415) 746-1941 Locations: 1735 Mission St, 558 Clayton St"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Email:
+  scheduleappointment@healthright360.org
+  Hours: Monday – Friday, 9:00am to 5:00pm (Wednesday until 8pm at 558 Clayton St)
+  Notes: Must schedule appointment and arrive 20 minutes early. Call for drop-in hours.
+:name: HealthRIGHT 360   Medical Clinics
+:phone: "(415) 226-17755"
+:services:
+- Primary and Preventive Health Care
+- Women’s Health
+- Birth Control
+- STD Diagnosis and Treatment
+- Diabetes Treatment
+- Asthma Treatment
+- Chronic Disease Care
+- Opioid Management
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: 

--- a/organizations/healthright-360-outpatient-services.yml
+++ b/organizations/healthright-360-outpatient-services.yml
@@ -1,0 +1,46 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 
+:contact_name: Mario Bandes, OP Director
+:description: The mission of HealthRIGHT 360 is to give hope, build health, and change
+  lives for people in need. We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: Adults 18 and over.
+:email: mbandes@healthright360.org
+:faith_based: No.
+:fax: "(415) 701-7913"
+:fees: Sliding scale.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:45am to 7:00 pm
+  Notes: No referral needed. Drop-ins for orientation welcome. Orientations take occur Monday through Friday  8:45am-9:15am.
+:name: HealthRIGHT 360   Outpatient Services
+:phone: "(415) 226-1775  x 2239"
+:services:
+- Trauma-Informed Treatment for Women
+- Transitional Housing
+- Residential Substance Abuse Services referrals
+- Hygiene/Personal Care Items
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Mentorship
+- Trauma Recovery Services
+- GED & High School Education
+- Application assistance with Food Stamps, GA & SSI
+- Job Readiness/Life Skills
+- Representative Payee Services
+- CJ referrals/ mandated
+- Couples/Family Counseling
+- Family Reunification
+- and Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: Proof of San Francisco Residency, TB Clearance. Program will assist
+  entering clients in getting these.

--- a/organizations/healthright-360-outpatient-services.yml
+++ b/organizations/healthright-360-outpatient-services.yml
@@ -44,3 +44,5 @@
 :url: www.healthright360.org
 :what_to_bring: Proof of San Francisco Residency, TB Clearance. Program will assist
   entering clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright-360-residential-substance-abuse-treatment-services.yml
+++ b/organizations/healthright-360-residential-substance-abuse-treatment-services.yml
@@ -48,3 +48,5 @@
 :url: www.healthright360.org
 :what_to_bring: Proof of San Francisco Residency, TB Clearance. Program will assist
   entering clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright-360-residential-substance-abuse-treatment-services.yml
+++ b/organizations/healthright-360-residential-substance-abuse-treatment-services.yml
@@ -1,0 +1,50 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: Centralized Intake Department, 1735 Mission Street, San Francisco, CA 94103
+:contact_name: Michael Davila, Admissions Director.
+:description: The mission of HealthRIGHT 360 is to give hope, build health, and change
+  lives for people in need. We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: Women, Transgender people, 18 and over, Pregnant Women. May
+  not be a registered sex offender.
+:email: mdavila@healthright360.org
+:faith_based: No.
+:fax: "(415) 701-7913"
+:fees: Sliding scale.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:00am to 5:30pm. Intakes end at 5:00pm daily.
+  Notes: No referral needed. Drop-ins welcome. Please come to Centralized Intake Department.
+:name: HealthRIGHT 360   Residential Substance Abuse Treatment Services
+:phone: "(415) 226-1775"
+:services:
+- Residential Substance Abuse Treatment
+- Transitional Housing
+- Gender Responsive Facilities
+- Trauma-Informed Treatment for Women
+- Hygiene/Personal Care Items
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Mentorship
+- Trauma Recovery Services
+- GED & High School Education
+- Application Assistance with Food Stamps, GA & SSI
+- Job Readiness/Life Skills
+- Representative Payee Services
+- CJ Referrals
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education
+- Clothing
+- Meals
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: Proof of San Francisco Residency, TB Clearance. Program will assist
+  entering clients in getting these.

--- a/organizations/healthright360-fotep-el-monte.yml
+++ b/organizations/healthright360-fotep-el-monte.yml
@@ -47,3 +47,5 @@
   bedding, linens, and hygiene items.  Hygiene items will be provided if a client
   does not have any.  If you do not already have a California ID and Social Security
   Card, the program will assist you in obtai9ning these items.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright360-fotep-el-monte.yml
+++ b/organizations/healthright360-fotep-el-monte.yml
@@ -1,0 +1,49 @@
+---
+:accessibility: Facility is wheelchair accessible.
+:address: 'Locations:  12423 Dahlia Avenue, El Monte, CA 91732'
+:contact_name: Sonia Crites
+:description: The mission of HealthRIGHT360 is to give hope, build health, and change
+  lives for people in need.  We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: Female paroles and up to 2 children under the age of 12 for
+  each participant.
+:email: 
+:faith_based: No.
+:fax: "(626) 401-2109"
+:fees: 
+:languages:
+- English
+- Translation services can be made available
+:miscellaneous: |-
+  Hours: Monday-Friday, 8:00am to 6:00pm
+  Locations:  12423 Dahlia Avenue, El Monte, CA 91732
+  Notes: Admission requires parole agent approval; 2 children under the age of 12 are allowed to stay with their mother.  If the need arises to accommodate more than 2 children this will be assessed on an individual basis.
+  Client fees: Funded through DRP for female parolees..
+  Not Eligible:  Unable to accept anyone with a history of harm to children or required to register as a sex offender.
+:name: HealthRight360   FOTEP El Monte
+:phone: "(626) 258-0300"
+:services:
+- Trauma-Informed Treatment for Women
+- Transitional Housing referrals
+- Substance Abuse Services
+- Hygiene/Personal Care Items
+- Co-occuring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/therapy
+- mentorship
+- Trauma Recovery Services
+- GED & High School Education Referrals
+- Application Assistance with SSI
+- Job Readiness/Life Skills
+- Family Reunification
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: You may bring 7 to 10 days’ worth of clothing, may bring preferred
+  bedding, linens, and hygiene items.  Hygiene items will be provided if a client
+  does not have any.  If you do not already have a California ID and Social Security
+  Card, the program will assist you in obtai9ning these items.

--- a/organizations/healthright360-outpatient-services.yml
+++ b/organizations/healthright360-outpatient-services.yml
@@ -43,3 +43,5 @@
 - Referrals to other resources available as needed
 :url: www.healthright360.org
 :what_to_bring: Proof of SASCA authorization.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/healthright360-outpatient-services.yml
+++ b/organizations/healthright360-outpatient-services.yml
@@ -1,0 +1,45 @@
+---
+:accessibility: Wheelchair and other disabilities accommodated.
+:address: 'Locations:  145 West 22nd Street, Los Angeles, CA 90007'
+:contact_name: Thomas Smith, Intake
+:description: The mission of HealthRIGHT360 is to give hope, build health, and change
+  lives for people in need.  We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: Male/Female for continuum of care funded through SASCA.
+:email: 
+:faith_based: No.
+:fax: "(213) 351-2853"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday-Friday, 7:00am to 3:30pm
+  Locations:  145 West 22nd Street, Los Angeles, CA 90007
+  Notes: Must be on parole with SASCA/Parole authorization
+  Client fees: Funded through SASCA.
+:name: HealthRight360   Outpatient Services
+:phone: "(213) 351-2832"
+:services:
+- Trauma-Informed Treatment for Co-Ed Clients
+- Transitional Housing
+- Sober Living
+- Substance Abuse Services Referrals
+- Hygiene/Personal Care Items
+- Co-occuring Disorder/Dual Diagnosis Treatment
+- health & Wellness Education
+- Anger management
+- Group Counseling/Therapy
+- Individual Counseling/therapy
+- mentorship
+- Trauma recovery services
+- GED & High School Education Referrals
+- Job Readiness/Life Skills
+- Couples/family Counseling
+- Family Reunification
+- Parenting Support/Education Referrals
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: Proof of SASCA authorization.

--- a/organizations/healthright360-residential-treatment-services.yml
+++ b/organizations/healthright360-residential-treatment-services.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: Facility is wheelchair accessible including ADA rooms available.
+:address: 'Locations:  2307 West 6th Street, Los Angeles, CA 90057'
+:contact_name: Thomas Smith, Intake
+:description: The mission of HealthRIGHT360 is to give hope, build health, and change
+  lives for people in need.  We do this by providing compassionate, integrated care
+  that includes primary medical, mental health, and substance use disorder treatment.  Our
+  services aim to relieve the burden of societal problems by promoting wellness, healthy
+  relationships, productive living, and community.
+:eligible_population: Male parolees ages 18 and over.
+:email: 
+:faith_based: No.
+:fax: "(213) 351-2853"
+:fees: 
+:languages:
+- English
+- If you need interpreter please let us know
+:miscellaneous: |-
+  Hours: Monday-Friday, 7:30am to 4:00pm
+  Locations:  2307 West 6th Street, Los Angeles, CA 90057
+  Notes: Admission requires parole agent approval.  If you cannot reach intake please contact Tracy Bracey at (213) 35102829
+  Client fees: Program is funded through CDCR.
+  Not Eligible:  Special registrations are ineligible for admissions.  Please call.
+:name: HealthRight360   Residential Treatment Services
+:phone: "(213) 351-2832"
+:services:
+- Residential Substance Abuse Treatment
+- Trauma-Informed Treatment for Men
+- Transitional Housing
+- Gender Responsive Facilities
+- Transitional Housing Referrals
+- Hygiene/Personal Care Items
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Mentorship
+- Trauma Recovery Services
+- GED & High School Education
+- Application Assistance with SSI, Child Support, Birth Certificates
+- Job Readiness/Life Skills
+- 52 Sessions of CJ or Court Mandated Batters Program
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.healthright360.org
+:what_to_bring: You may bring clothing items (up to 10 days), a portable radio and
+  a cell phone.  If you do not already have a California ID and Social Security Card,
+  the program will assist you in obtai9ning these items.

--- a/organizations/healthright360-residential-treatment-services.yml
+++ b/organizations/healthright360-residential-treatment-services.yml
@@ -49,3 +49,5 @@
 :what_to_bring: You may bring clothing items (up to 10 days), a portable radio and
   a cell phone.  If you do not already have a California ID and Social Security Card,
   the program will assist you in obtai9ning these items.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/holy-family-day-home-infant-toddler-and-pre-k-program-and-family-support-service.yml
+++ b/organizations/holy-family-day-home-infant-toddler-and-pre-k-program-and-family-support-service.yml
@@ -25,3 +25,5 @@
 - Preschool, Infant, and Toddler program
 :url: www.holyfamilydayhome.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/holy-family-day-home-infant-toddler-and-pre-k-program-and-family-support-service.yml
+++ b/organizations/holy-family-day-home-infant-toddler-and-pre-k-program-and-family-support-service.yml
@@ -1,0 +1,27 @@
+---
+:accessibility: 
+:address: 'Mailing Address: 299 Dolores Street, San Francisco, CA 94103'
+:contact_name: 
+:description: Our mission is to provide affordable, high-quality early childhood education
+  and family support services in a stable, nurturing environment, thereby providing
+  children of working families skills and hope for lifelong development. Seventy percent
+  of our families are either homeless, in CalWorks Program or are the working poor.
+:eligible_population: All individuals and family members with an infant, toddler or
+  pre-kindergarten age child. Individuals must reveal criminal conviction for violent
+  or sex offenses, as well as registration as sex offender status.
+:email: intake@holyfamilydayhome.org
+:faith_based: No.
+:fax: "(415) 861-8926"
+:fees: 
+:languages: []
+:miscellaneous: |-
+  Infant, Toddler & Preschool
+  Mailing Address: 299 Dolores Street, San Francisco, CA 94103
+  Notes: Call, email or write for more information.
+:name: Holy Family Day Home   Infant, Toddler and Pre-K Program and Family Support
+  Service
+:phone: "(415) 861-5361"
+:services:
+- Preschool, Infant, and Toddler program
+:url: www.holyfamilydayhome.org
+:what_to_bring: 

--- a/organizations/homeless-advocacy-project-hap.yml
+++ b/organizations/homeless-advocacy-project-hap.yml
@@ -37,3 +37,5 @@
 :url: www.sfbar.org/volunteer/homeless_article.aspx
 :what_to_bring: Any documents related to your case (eviction papers; social security
   notices)
+:__meta__:
+  :version: 0.0.1

--- a/organizations/homeless-advocacy-project-hap.yml
+++ b/organizations/homeless-advocacy-project-hap.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: 
+:address: 1360 Mission Street Suite 201, San Francisco, CA  94102 (between 9th and
+  10th Streets)
+:contact_name: 
+:description: The Homeless Advocacy Project (HAP) may be able to help you if you have
+  legal issues and are homeless, or threatened with homelessness, especially if you
+  have a disability or minor children living with you. HAP also provides supportive
+  social services to its legal clients to address underlying psychosocial needs. We
+  primarily assist clients with federal disability and other benefit issues; eviction
+  prevention; and immigration documentation.
+:eligible_population: Homeless or at risk of homelessness, with priority to individuals
+  who have mental health disabilities and families.
+:email: 
+:faith_based: No.
+:fax: "(415) 703-8639"
+:fees: None if low-income.
+:languages:
+- Spanish
+- Vietnamese
+- Mandarin
+:miscellaneous: |-
+  Hours: HAP is closed on Monday. Tuesday - Friday, 9am to 5pm. Intake for new clients on Tuesday 1:30pm to 4:00pm.
+  Notes: No referrals needed. Please drop in during Tuesday intake hours.
+:name: Homeless Advocacy Project (HAP)
+:phone: "(415) 575-3130"
+:services:
+- HAP is only able to provide assistance with certain types of legal issues
+- 'These include: Applications for Supplemental Security Income (SSI – federal disability
+  benefits) and issues related to SSI applications'
+- Eviction defense, especially if you are accused of causing a nuisance or your landlord
+  has obtained a default judgment against you
+- Immigration documentation, if you are in the country legally but have lost your
+  immigration documents or have not taken the steps needed to get proper immigration
+  documents
+- Brief advice and referrals to other projects or agencies that can help you
+:url: www.sfbar.org/volunteer/homeless_article.aspx
+:what_to_bring: Any documents related to your case (eviction papers; social security
+  notices)

--- a/organizations/homeless-children-s-network-hcn.yml
+++ b/organizations/homeless-children-s-network-hcn.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 3450 3rd Street, Unit 1C, San Francisco, CA 94124
+:contact_name: Kathy O'Shea, Program Director
+:description: Early Periodic Screening, Diagnosis, and Treatment
+:eligible_population: Serves homeless individuals from birth to age 17 with mental
+  health diagnosis that meets medical necessity, such as Adjustment Disorder, Depression,
+  or PTSD. May not have criminal conviction for sex offense or be a registered sex
+  offender. Current abuse cases are referred to CPS.
+:email: kathy@hcnkids.org
+:faith_based: No.
+:fax: "(415) 437-3994"
+:fees: None.
+:languages:
+- English
+- Spanish
+- ASL
+- Japanese
+:miscellaneous: |-
+  In collaboration with a network of homeless services providers, HCN seeks to decrease the trauma of homelessness and domestic violence, to increase the strength and effectiveness of the HCN Collaborative, and to provide early childhood education and consultation to shelter-based child care and family child care providers. HCN provides flexible, well-coordinated and culturally competent services to homeless and formerly homeless children and their families. Funding and services provided through Early Periodic Screening, Diagnosis and Treatment Program (EPSDTP). www.hcnkids.org
+  Hours: Monday - Friday 9:00am to 6:00pm
+  Notes: No referral needed. Please call or write for an appointment. No drop-ins.
+:name: Homeless Children's Network (HCN)
+:phone: "(415) 437-3990"
+:services:
+- Up to Two Years of Mental Health Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Outreach
+- Trauma Recovery Services
+- Victim/Survivor Services
+- Couples/Family Counseling
+- Parenting Support/Education
+- Services for Children
+- Facilitation of Visits in Jails and Prisons
+- Referrals to other resources available as needed
+:url: www.hcnkids.org
+:what_to_bring: Medi-Cal ID card.

--- a/organizations/homeless-children-s-network-hcn.yml
+++ b/organizations/homeless-children-s-network-hcn.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: www.hcnkids.org
 :what_to_bring: Medi-Cal ID card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/homeless-prenatal-program.yml
+++ b/organizations/homeless-prenatal-program.yml
@@ -47,3 +47,5 @@
 :url: www.homelessprenatal.org
 :what_to_bring: Proof of residency is required for housing deposits. Program will
   assist entering clients in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/homeless-prenatal-program.yml
+++ b/organizations/homeless-prenatal-program.yml
@@ -1,0 +1,49 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 2500 18th Street, San Francisco, CA  94110
+:contact_name: 
+:description: In partnership with our families, we work to break the cycle of childhood
+  poverty. By seizing the motivational opportunity created by pregnancy and parenthood,
+  HPP joins with families to help them recognize their strengths and trust in their
+  capacity to transform their lives.
+:eligible_population: Men, Women, Transgender people with a child under 18 yrs old,
+  Pregnant women.
+:email: 
+:faith_based: No.
+:fax: "(415) 546-6778"
+:fees: No fee to clients.
+:languages:
+- Spanish
+- English
+- French
+- Tagalog
+- Cantonese
+- Mandarin
+:miscellaneous: |-
+  Hours: Monday – Thursday, 9:00am to 5:00pm; Friday, 9am-4pm. Closed from 12-1pm daily. Intake hours vary by day.
+  Notes: No referral needed. Drop-ins are welcome for intake.
+:name: Homeless Prenatal Program
+:phone: "(415) 546-6756"
+:services:
+- Hotel Vouchers for pregnant women in the last trimester and DV clients when no shelter
+  beds are available
+- Rental & Move-in Assistance
+- Access to Internet
+- Assistance Getting Driver’s License/Other ID
+- Clothing
+- Food/Prepared Meals
+- Health & Wellness Education
+- Intensive Case Management
+- Outreach
+- English as a Second Language
+- Assessment & Application for Food Stamps, SSI
+- Credit Repair
+- Money Management/Personal Financial Education/Personal Income tax preparation
+- Housing Advocacy (refer out for eviction defense)
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.homelessprenatal.org
+:what_to_bring: Proof of residency is required for housing deposits. Program will
+  assist entering clients in getting this.

--- a/organizations/homeward-bound-of-marin-family-center-emergency-shelter.yml
+++ b/organizations/homeward-bound-of-marin-family-center-emergency-shelter.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Lower units are wheelchair accessible.
+:address: 430 Mission Avenue, San Rafael, CA 94901
+:contact_name: Resource Counselor
+:description: Homeward Bound operates the only emergency shelter for homeless families
+  in Marin County, which serves as the entry point for our Family Services Program.
+   Resource Counselors organize educational and fun activities for children, such
+  as a Teen Activity Group for weekly outings, trips to the beach, pizza/game nights,
+  etc., that enrich their lives and offer a sense of community. Families create action
+  plans that might include improving parenting skills, finding consistent child care,
+  accessing health care, pursuing new educational goals, counseling, job training
+  and securing long-term housing.
+:eligible_population: Must be a Marin resident, must be a parent with a minor child(ren).
+:email: 
+:faith_based: 'No'
+:fax: 
+:fees: None
+:languages:
+- English
+- spanish
+:miscellaneous: |-
+  Hours: Open (please call).
+  Notes: Call for availability.
+:name: Homeward Bound of Marin   Family Center – Emergency Shelter
+:phone: "(415) 457-2115"
+:services:
+- Shelter
+- Support for Job and Housing Search
+- Food Assistance
+- Referals to Services like Credit Repair, Tax Help, and Financial Literacy
+- Families with children under 5 years old have access to child care with Head Start
+:url: hbofm.org/Homeless-Families.html
+:what_to_bring: 

--- a/organizations/homeward-bound-of-marin-family-center-emergency-shelter.yml
+++ b/organizations/homeward-bound-of-marin-family-center-emergency-shelter.yml
@@ -31,3 +31,5 @@
 - Families with children under 5 years old have access to child care with Head Start
 :url: hbofm.org/Homeless-Families.html
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/homeward-bound-of-marin-services-for-homeless-adult.yml
+++ b/organizations/homeward-bound-of-marin-services-for-homeless-adult.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 190 Mill Street, San Rafael, CA  94901
+:contact_name: Resource Counselor
+:description: The Mill Street Center is the "front door" of our Adult Services Program,
+  the 55-bed Mill Street Center in San Rafael is the county's only night-to-night
+  emergency shelter for homeless individuals. It serves both men and women in separate
+  dormitory-style rooms. A network of volunteers from three dozen churches and community
+  groups shares a monthly rotation to provide a home-cooked hot meal to Mill Street
+  residents. This significant gift has endured since the center opened more than 25
+  years ago.  As space becomes available, committed residents "graduate" to New Beginnings
+  Center, a second-step shelter that allows residents to stay up to 6 months.
+:eligible_population: Must be a Marin resident, must be unaccompanied adult at least
+  18 years of age.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Yes, $3 per night.  If unable to pay please speak to program manager.
+:languages:
+- English
+:miscellaneous: |-
+  url: hbofm.org/Homeless-Adults.html
+  Hours: Intake:  Call Monday-Friday at 8:00am.  For questions call anytime.
+  Notes: Call for availability.
+:name: Homeward Bound of Marin   Services For Homeless Adult
+:phone: "(415) 457-9651 or (800) 428-1488"
+:services:
+- Emergency Shelter
+- Counseling
+- Food Assistance/Prepared Meals
+- Referrals to services such as credit repair, job training, recovery support or medical
+  care
+:url: hbofm.org/Homeless-Adults.html
+:what_to_bring: 

--- a/organizations/homeward-bound-of-marin-services-for-homeless-adult.yml
+++ b/organizations/homeward-bound-of-marin-services-for-homeless-adult.yml
@@ -32,3 +32,5 @@
   care
 :url: hbofm.org/Homeless-Adults.html
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/horizons-unlimited-of-san-francisco-inc-outpatient-substance-abuse-treatment-program.yml
+++ b/organizations/horizons-unlimited-of-san-francisco-inc-outpatient-substance-abuse-treatment-program.yml
@@ -45,3 +45,5 @@
 :url: www.horizons-sf.org
 :what_to_bring: Proof of San Francisco Residency. Program will assist entering clients
   in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/horizons-unlimited-of-san-francisco-inc-outpatient-substance-abuse-treatment-program.yml
+++ b/organizations/horizons-unlimited-of-san-francisco-inc-outpatient-substance-abuse-treatment-program.yml
@@ -1,0 +1,47 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 440 Potrero Avenue, San Francisco, CA 94110
+:contact_name: Shirley Maciel, Director
+:description: The purpose of the substance abuse outpatient treatment program is to
+  provide culturally affirming and linguistically sensitive, strength-based, family-focused
+  and biopsychosocial intervention strategies to support and assist dual diagnosis
+  Latino and other youth and young adults, who have demonstrated emotional and behavioral
+  problems that impede their ability to function in their home, school, community
+  and mainstream society. Horizons’ primary goal is to engage, educate and inspire
+  youth.
+:eligible_population: Men, Women, ages 12-25, involved in criminal justice system.
+:email: shirley16maciel@gmail.com
+:faith_based: No.
+:fax: "(415) 487-6724"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Main Phone:  (415) 487-6700
+  Specific Intake Days and Times: Monday-Friday, based on appointment.
+  Hours: Monday – Thursday, 10:00am to 7:00pm; Fridays, 10:00am to 6:30pm
+  Notes: Clients can get a referral off our website.  Appointment preferred.
+:name: Horizons Unlimited of San Francisco, Inc.   Outpatient Substance Abuse Treatment
+  Program
+:phone: "(415) 487-6702"
+:services:
+- Access to Internet
+- Food/Prepared Meals
+- Phone/Voicemail
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Job Readiness/Life Skills
+- Culturally appropriate referrals to legal services
+- Referrals to other resources available as needed
+:url: www.horizons-sf.org
+:what_to_bring: Proof of San Francisco Residency. Program will assist entering clients
+  in getting this.

--- a/organizations/housing-rights-committee-of-san-francisco.yml
+++ b/organizations/housing-rights-committee-of-san-francisco.yml
@@ -31,3 +31,5 @@
 :url: www.hrcsf.org
 :what_to_bring: Please bring any relevant papers, including eviction notices or other
   landlord/property manager notices.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/housing-rights-committee-of-san-francisco.yml
+++ b/organizations/housing-rights-committee-of-san-francisco.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 417 South Van Ness Avenue, San Francisco, CA 94103
+:contact_name: Counselor
+:description: We provide “self-help” tenants’ rights counseling. Clients are provided
+  with information on laws affecting their rights as tenants, as well as resources
+  and referrals. For public housing and Section 8 renters, we offer case management
+  and advocacy. We provide referrals to attorneys as necessary. We will help with
+  applications for Section 8 and Public Housing, as well as rent board petitions.
+:eligible_population: All renters of public and private housing.
+:email: info@hrcsf.org
+:faith_based: No.
+:fax: "(415) 703-8639"
+:fees: None.
+:languages:
+- English
+- Spanish
+- Cantoniese
+- Mandarin
+- Russian by special arrangement
+:miscellaneous: |-
+  Counseling Hours: Monday – Thursday from 1:00pm-5:00pm
+  Notes: No referrals needed. Please call or drop in during counseling hours.
+:name: Housing Rights Committee of San Francisco
+:phone: "(415) 703-8634"
+:services:
+- 'Counseling/Advocacy—Housing Applications to Public Housing & Section 8. Please
+  note: no direct legal services'
+- Program does not provide housing or rental assistance
+- Referrals to other services provided, as appropriate
+:url: www.hrcsf.org
+:what_to_bring: Please bring any relevant papers, including eviction notices or other
+  landlord/property manager notices.

--- a/organizations/hyde-street-community-services-inc-tenderloin-outpatient-clinic.yml
+++ b/organizations/hyde-street-community-services-inc-tenderloin-outpatient-clinic.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 815 Hyde Street, Suite 100, San Francisco, CA
+:contact_name: On duty staff
+:description: The mission of the Hyde Street Community Services, Inc., is to provide
+  comprehensive integrated behavioral services to adult residents of San Francisco
+  who are in need of these services to achieve and maintain the maximum quality of
+  life and greatest degree of independence possible.  We provide behavorial health
+  services to an adult population in San francsico to improve the quality of life
+  for those with chronic and severe behavioral health issues.
+:eligible_population: We welcome all residents of San Francisco who do not have private
+  insurance.
+:email: info@hydestreetcs.org
+:faith_based: No.
+:fax: "(415) 292-7140"
+:fees: The Clinic accepts MediCal, MediCare, Healthy San Francisco.  Clients may be
+  charged according to the state UMDAP scale.
+:languages:
+- English
+- Spanish
+- Vietnnamese
+- Chinese
+- Arab
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: Clients may drop-in to apply for services.
+:name: Hyde Street Community Services, Inc.   Tenderloin Outpatient Clinic
+:phone: "(415) 673-5700"
+:services:
+- Mental Health Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Trauma Recovery Services
+- Victim/Survivor Services
+- Assessment & Application for SSI Program
+- Referrals to other resources available as needed
+:url: www.hydestreetcs.org
+:what_to_bring: 

--- a/organizations/hyde-street-community-services-inc-tenderloin-outpatient-clinic.yml
+++ b/organizations/hyde-street-community-services-inc-tenderloin-outpatient-clinic.yml
@@ -39,3 +39,5 @@
 - Referrals to other resources available as needed
 :url: www.hydestreetcs.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/instituto-familiar-de-la-raza.yml
+++ b/organizations/instituto-familiar-de-la-raza.yml
@@ -28,3 +28,5 @@
 :url: www.ifrsf.org
 :what_to_bring: Proof of San Francisco residency. Program will assist clients in obtaining
   this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/instituto-familiar-de-la-raza.yml
+++ b/organizations/instituto-familiar-de-la-raza.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 2919 Mission Street, San Francisco, CA 94110
+:contact_name: Adriana Guzman, Intake Specialist
+:description: Substance abuse and related treatment services.
+:eligible_population: Individuals with mental health diagnosis. Must not be a danger
+  to others. Must not have private medical insurance.
+:email: info@ifrsf.org
+:faith_based: No.
+:fax: "(415) 647-3662"
+:fees: None if client has Medi-Cal/Medicare. Very low sliding scale based on income.
+  No Private Insurance accepted.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 7:00pm; Saturday, 9:00am to 2:00pm
+  Drop-in Hours:  Tuesday 2pm-4pm; Wednesday-Friday 12pm-2pm
+  Notes: No referral needed. The first step to access services is to come during our drop-in hours (no appointment necessary).
+:name: Instituto Familiar de la Raza
+:phone: "(415) 229-0500"
+:services:
+- Substance Abuse Treatment
+- Counseling
+- Mental Health Treatment
+- Parenting Support
+- Referrals to other resources available as needed
+:url: www.ifrsf.org
+:what_to_bring: Proof of San Francisco residency. Program will assist clients in obtaining
+  this.

--- a/organizations/jelani-inc.yml
+++ b/organizations/jelani-inc.yml
@@ -1,0 +1,45 @@
+---
+:accessibility: Only the Quesada Ave. address is wheelchair- and other disability-accessible.
+:address: 
+:contact_name: Norman Mathis, Intake Coordinator.
+:description: Residential drug treatment program for families.
+:eligible_population: All Individuals and families, including adults with children,
+  and pregnant women. Must not be convicted of sex offense or arson.
+:email: nmathis@jelaniinc.org
+:faith_based: No.
+:fax: "(415) 822-5943"
+:fees: 80% of public assistance received.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  url: www.jelaniinc.org
+  Facility Hours: 24 hours/7 days. Intake hours: Monday – Friday, 9:00am-5:00pm.
+  Locations:
+  Jelani House Prenatal Program
+  1601 Quesada Avenue, San Francisco, CA
+  Jelani House Family Program
+  1638 Kirkwood Avenue, San Francisco, CA
+  Notes: Referrals from family agencies or criminal justice system.
+:name: Jelani, Inc.
+:phone: "(415) 822-5945"
+:services:
+- Alcohol/Drug Treatment
+- Access to Benefits (SSI, GA, TANF, et al)
+- Accompany to Court Dates
+- Anger Management
+- Childcare
+- Co-Occurring Disorder/Dual Diagnosis
+- Counseling
+- Family Reunification
+- Life Skills
+- Parenting Support
+- Perinatal Services
+- Residential Housing
+- Services for Children
+- Trauma Recovery Services
+- Referrals to other resources available as needed
+:url: www.jelaniinc.org
+:what_to_bring: Social Security Card; Proof of Residence; TB Clearance. Preferable,
+  but not completely necessary at intake. Some assistance may be available to help
+  gather these documents.

--- a/organizations/jelani-inc.yml
+++ b/organizations/jelani-inc.yml
@@ -43,3 +43,5 @@
 :what_to_bring: Social Security Card; Proof of Residence; TB Clearance. Preferable,
   but not completely necessary at intake. Some assistance may be available to help
   gather these documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/jericho-project.yml
+++ b/organizations/jericho-project.yml
@@ -1,0 +1,53 @@
+---
+:accessibility: ADA compliant
+:address: 'Locations: 470 Valley Drive, Brisbane CA 94005'
+:contact_name: Nicholas Caluya
+:description: The staff of Jericho Project has determined through professional research
+  and numerous years of personal experience that a structured lifestyle is critical
+  to long-term recovery.  We believe that it is essential to provide each individual
+  with a regular schedule of activities designed to promote stable and responsible
+  living.  Jericho Project is an education center for addicts and ex-convicts.  Our
+  philosophy is that the drugs were not the main problem, but a symptom of the problem.
+  The problem has always been honesty. We work on developing a sense of morals and
+  values that can help keep an individual focused and clean. Our philosophy focuses
+  on healing the body, mind, and spirit. Our Vocational Training department prepares
+  residents for careers in construction, retail, transportation, warehousing and administrative
+  careers.  We also have a state of the art fitness gym where residents are trained
+  by our certified trainers or a General Physical Trainer.
+:eligible_population: Men ages 18 and older.
+:email: nickcaluya@jerichoproject.net
+:faith_based: 
+:fax: "(415) 715-1333"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  url: www.jericho-project.org
+  Facility Hours: 24 hours/7 days. Intake hours: Monday – Friday, 9:00am-5:00pm.
+  Locations: 470 Valley Drive, Brisbane CA 94005
+  Notes: Telephone interviews are available Monday thru Friday between
+  8am and 8pm. Collect calls are accepted (415) 467-9836
+:name: Jericho Project
+:phone: "(415) 656-1700"
+:services:
+- Assistance Getting Driver’s License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Medical Care
+- Anger Management
+- Mentorship
+- Basic/Remedial Education
+- GED & High School Diploma
+- Reading/Literacy
+- Vocational Education
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Inmate & Parolee Legal Voting Outreach & Education
+- Referrals to other resources available as needed
+:url: www.jericho-project.org
+:what_to_bring: Program will assist clients with necessary documents.

--- a/organizations/jericho-project.yml
+++ b/organizations/jericho-project.yml
@@ -51,3 +51,5 @@
 - Referrals to other resources available as needed
 :url: www.jericho-project.org
 :what_to_bring: Program will assist clients with necessary documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/jewish-vocational-services-jvs.yml
+++ b/organizations/jewish-vocational-services-jvs.yml
@@ -40,3 +40,5 @@
 - Referrals to other resources available as needed
 :url: www.jvs.org
 :what_to_bring: Authorization to work in the United States.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/jewish-vocational-services-jvs.yml
+++ b/organizations/jewish-vocational-services-jvs.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities accommodated.
+:address: 225 Bush Street, Suite 400 - West Lobby, San Francisco, CA 94104
+:contact_name: Alicia Velez-Rivers, Intake Coordinator
+:description: At JVS, we can help you with the skills and resources you need to find
+  the right job. Our job search assistance program is specially tailored to meet your
+  particular employment needs. We work with job seekers that truly represent the broad
+  diversity of San Francisco, and we work with some of the best Bay Area companies
+  in healthcare, administration, reatil and technology.  Our Technology Center helps
+  people improve their job related computer skills and provides online job search
+  opportunities. You can search for a job; improve your typing speed and Microsoft
+  Office skills with self-paced tutorials; use our software and print library to explore
+  your career options; build your resume, cover letter, and basic skills; and study
+  for the GED, NCLEX-PN, and NCLEX-RN.
+:eligible_population: All individuals who are clean and sober and comply with a work-focused
+  professional facility.
+:email: avelez-rivers@jvs.org
+:faith_based: No.
+:fax: "(415) 391-3617"
+:fees: None.
+:languages:
+- Russian
+- English
+- Cantonese
+- Spanish
+- 'Note: Non-native speakers are welcome to access the Technology Center facilities
+  although the job search resources are primarily in English'
+:miscellaneous: |-
+  Technology Center Contact Person: Jennifer Volk, TAC Coordinator
+  Hours: Monday-Friday, 9:00am to 5:00pm.
+  Notes: No referral needed. Get started online at www.jvs.org/welcome or attend a drop-in Welcome Session (every Wednesday at 1:00pm.
+:name: Jewish Vocational Services (JVS)
+:phone: "(415) 782-6282"
+:services:
+- Employment Placement
+- Employment Retention
+- Employment Training
+- Job Readiness
+- Access to Internet
+- Referrals to other resources available as needed
+:url: www.jvs.org
+:what_to_bring: Authorization to work in the United States.

--- a/organizations/jireh-technologies-inc.yml
+++ b/organizations/jireh-technologies-inc.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 2070 North Broadway Stuite 4082, Walnut Creek, CA 94596
+:contact_name: IT Director
+:description: As a social enterprise venture, Jireh Technologies, Inc. (Jireh Tech)
+  serves as a public benefit 501(c)3 organization that was incorporated in February
+  2004. As social entrepreneurs, the Jireh Tech management team is engaged in creating
+  a sustainable model of mitigating the digital divide and utilizing information and
+  communications technology as a tool for community development.
+:eligible_population: Everyone welcome.
+:email: mail@jirehtech.com
+:faith_based: No, but the organization is housed within a faith-based Christian facility.
+:fax: 
+:fees: 
+:languages:
+- English
+- some Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 10:00am-6:00pm.
+  Notes: No referral needed. Appointments are preferred but drop-ins are acceptable.
+  Client fees: No fee to clients.
+:name: Jireh Technologies, Inc.
+:phone: "(925) 338-1832"
+:services:
+- 8-12 week digital literacy course which teaches and assesses basic computing concepts
+  and skills so that people can use computer technology in everyday life
+- 'Program also provides: Access to Internet'
+- Assistance Getting Driver’s License/Other ID
+- Job Readiness/Life Skills
+- Referrals to other resources available as needed
+:url: www.jirehtech.org
+:what_to_bring: State-issued ID and TB clearance. Program will assist entering clients
+  in getting this.

--- a/organizations/jireh-technologies-inc.yml
+++ b/organizations/jireh-technologies-inc.yml
@@ -31,3 +31,5 @@
 :url: www.jirehtech.org
 :what_to_bring: State-issued ID and TB clearance. Program will assist entering clients
   in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/jobtrain-employment-services.yml
+++ b/organizations/jobtrain-employment-services.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.jobtrainworks.org/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/jobtrain-employment-services.yml
+++ b/organizations/jobtrain-employment-services.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1200 O’Brien Drive, Menlo Park, CA 94025 
+:contact_name: JobTrain
+:description: JobTrain transforms lives and communities in Silicon Valley. We help
+  the Valley’s most in need reclaim their lives from poverty and unemployment by preparing
+  them for successful, sustainable
+:eligible_population: San Mateo County residents have priority.  Must be 18 years
+  of age by the time vocational training is completed.
+:email: info@jobtrain.org
+:faith_based: No.
+:fax: "(650) 330-6401"
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  careers in high-demand and emerging fields.  JobTrain is committed to helping those who are most in need to succeed. Our purpose is to improve the lives of people in our community through assessment, attitude and job skills training, and high potential career placement. Full-time vocational training programs include: Culinary Arts, Laborers Construction Fundamentals Training Program, Medical Assistant, Business Administration Skills, Professional Health Care Worker, and Project Build (Construction, Green Technology and Carpenter Pre-Apprenticeship). Students also benefit from Upgrade Trainings, which helps them to advance in their careers. Offerings include GED preparation, Academic Skills for Employment, ESL, and Computer Literacy. Our programs are provided for little or no cost to students.  www.jobtrainworks.org/
+  Hours: Monday-Friday 8:00am-5:00pm
+  Notes: No appointment, drop-ins welcome for intake process.  We serve San Mateo County residents first.  Come visit our One Stop job search help workshops!  We also have a Single Stop on site for tax, legal, and nutrition help.
+:name: "JobTrain\tEmployment Services"
+:phone: "(650) 330-6429"
+:services:
+- Vocational Training
+- Employment Readiness
+- Life Skills
+- Access to Internet
+- GED Preparation
+- ESL
+- Computer Literacy
+- Referrals to other resources available as needed
+:url: www.jobtrainworks.org/
+:what_to_bring: 

--- a/organizations/la-casa-de-las-madres.yml
+++ b/organizations/la-casa-de-las-madres.yml
@@ -1,0 +1,45 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: 
+:description: La Casa offers a comprehensive continuum of support services for survivors
+  of domestic violence. La Casa offers safety-first, empowerment and client-centered
+  services. It offers crisis response, emergency shelter, and ongoing counseling and
+  resource advocacy. Ending or escaping domestic violence is a process. Services are
+  confidential. Individuals do not have to leave the abusive partner before accessing
+  support.
+:eligible_population: Women; Transgender Women; Women w/ Children; Pregnant Women;
+  Teens, Age 11-24; if facing domestic violence.
+:email: 
+:faith_based: No.
+:fax: "(415) 503-0301 Email: info@lacasa.org"
+:fees: Free and confidential.
+:languages:
+- English
+- Spanish
+- Mandarin
+- Farsi
+- ''
+- Others
+:miscellaneous: |-
+  24-Hour Hotline: (877) 503-1850
+  Hours: Monday – Friday, 8:30am to 5:00pm
+  Address: 1663 Mission Street, Suite 225, San Francisco, CA 94103 or 850 Bryant Street, 5th Floor SVU, San Francisco, CA 94103
+  Notes: No referral needed. Drop-ins available. Shelter location is confidential.
+:name: La Casa de las Madres
+:phone: "(415) 503-0500"
+:services:
+- Emergency Shelter
+- Legal Assistance/Advocacy
+- Accompany to Court Dates
+- Help/Vouchers to Get State ID
+- Parenting Support
+- Services for Children
+- Counseling
+- Life Skills
+- Mentoring
+- Trauma Recovery
+- Victim Services
+- Referrals to other resources available as needed
+:url: www.lacasadelasmadres.org
+:what_to_bring: 

--- a/organizations/la-casa-de-las-madres.yml
+++ b/organizations/la-casa-de-las-madres.yml
@@ -43,3 +43,5 @@
 - Referrals to other resources available as needed
 :url: www.lacasadelasmadres.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/la-raza-centro-legal.yml
+++ b/organizations/la-raza-centro-legal.yml
@@ -27,3 +27,5 @@
 - Referrals to other services provided, as appropriate
 :url: www.lrcl.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/la-raza-centro-legal.yml
+++ b/organizations/la-raza-centro-legal.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 474 Valencia Street, Suite 295
+:contact_name: 
+:description: La Raza Centro Legal is community-based legal organization dedicated
+  to empowering Latino, immigrant and low-income communities of SF to advocate for
+  their civil and human rights. We combine legal services and advocacy to build grassroots
+  power and alliances toward creating a movement for a just society.
+:eligible_population: All individuals and family members.
+:email: 
+:faith_based: No.
+:fax: "(415) 255-7593"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: Monday –Thursday from 10am-12pm and 1pm-4pm; Fridays from 10am-12pm.
+  San Francisco, CA  94103
+  Notes: No referrals needed. Please call for appointment. Drop-ins are allowed, but appointments are preferred.
+:name: La Raza Centro Legal
+:phone: "(415) 575-3500"
+:services:
+- Employment Law, solely regarding SF-specific labor laws
+- Immigration and Senior Law (Immigration in San Francisco and San Mateo County, senior
+  law in San Francisco only)
+- Referrals to other services provided, as appropriate
+:url: www.lrcl.org
+:what_to_bring: 

--- a/organizations/lavender-youth-recreation-information-center-lyric.yml
+++ b/organizations/lavender-youth-recreation-information-center-lyric.yml
@@ -38,3 +38,5 @@
 - Referrals to other resources available as needed
 :url: www.lyric.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/lavender-youth-recreation-information-center-lyric.yml
+++ b/organizations/lavender-youth-recreation-information-center-lyric.yml
@@ -1,0 +1,40 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 127 Collingwood St, San Francisco, CA 94114
+:contact_name: Youth Advocates
+:description: LYRIC is an organization for lesbian, gay, bisexual, transgender, queer
+  and questioning youth, ages 24 and younger. LYRIC’s mission is to build community
+  and inspire positive social change through education enhancement, career training,
+  health promotion and leadership development with LGBTQQ youth, their families, and
+  allies of all races, classes, genders and abilities. LYRIC works to meet youth where
+  they are and support them in getting what they need.
+:eligible_population: All individuals (Men, Women, Transgender people), up to 24 years
+  old, Pregnant women, Women with children.
+:email: lyricinfo@lyric.org
+:faith_based: No.
+:fax: "(415) 703-6153"
+:fees: 'No'
+:languages:
+- English
+- Spanish
+- French
+:miscellaneous: |-
+  Hours: Monday – Friday, 10:00am to 6:00pm
+  Notes: No referral needed. Drop-ins welcome.
+:name: Lavender Youth Recreation & Information Center (LYRIC)
+:phone: "(415) 703-6150"
+:services:
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Hygiene/Personal Care Items
+- Health & Wellness Education
+- Community Education & Mediation
+- Outreach
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Referrals to other resources available as needed
+:url: www.lyric.org
+:what_to_bring: 

--- a/organizations/lawyers-committee-for-civil-rights-second-chance-legal-clinic.yml
+++ b/organizations/lawyers-committee-for-civil-rights-second-chance-legal-clinic.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible.
+:address: West Bay Community Center, 1290 Fillmore Street, San Francisco, CA 94115
+:contact_name: Clinic Coordinator
+:description: The Second Chance Legal Clinic assists clients who are working to overcome
+  barriers to employment and housing because of their criminal records.   www.lccr.com/programs/racial-justice/direct-services/second-chance-legal-clinic/
+:eligible_population: All individuals.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Clinic held last Tuesday of every month at 6 pm. Questions about clinic answered Monday through Friday from 9:00am-5:00pm.
+  Mailing Address: 131 Steuart Street, Suite 400, San Francisco, CA 94105
+  Notes: To receive the best legal advice, we encourage walk-in clients to come with a recent RAP sheet. Please contact Lawyers’ Committee to find out how to get a RAP sheet.  Drop-in okay.  No referral required.
+:name: Lawyers' Committee for Civil Rights   Second Chance Legal Clinic
+:phone: "(415) 814-7610"
+:services:
+- Clean Slate/Conviction Expungement
+- Employment Law
+- Housing and Eviction Defense
+- Voting and Outreach Education
+- Occupational licensing – applications and denials
+- Criminal background reports – errors and violations
+- Public and private housing – applications and denials
+- Employment – applications, terminations and denials
+- Assistance with Driver’s License Citations and Suspensions
+:url: www.lccr.com
+:what_to_bring: 

--- a/organizations/lawyers-committee-for-civil-rights-second-chance-legal-clinic.yml
+++ b/organizations/lawyers-committee-for-civil-rights-second-chance-legal-clinic.yml
@@ -30,3 +30,5 @@
 - Assistance with Driver’s License Citations and Suspensions
 :url: www.lccr.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/leaders-in-community-alternatives-adrc-north.yml
+++ b/organizations/leaders-in-community-alternatives-adrc-north.yml
@@ -35,3 +35,5 @@
 - Referrals to other services as appropriate
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/leaders-in-community-alternatives-adrc-north.yml
+++ b/organizations/leaders-in-community-alternatives-adrc-north.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1215 Del Paso Blvd., Sacramento, CA  95815
+:contact_name: Christopher Timpson
+:description: The ADRC North is a partnership between the Sacramento Probation Department
+  and Leaders in Community Alternatives that bridges probation supervision services
+  with comprehensive case management, barrier removal, employment and income benefits
+  acquisition assistance.  In addition to the services LCA has on-site at the ADRC,
+  LCA utilizes Sacramento County Probation's existing contracts for education, vocational
+  and mental health services.  The goals of the ADRC are to reduce recidivism and
+  build self-sufficiency skills in the clients we serve.   lcaservices.com
+:eligible_population: Referred by Probation.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday-Friday, 8:00am-8:30pm
+  Notes: All clients must be referred by probation.
+:name: Leaders in Community Alternatives   ADRC North
+:phone: "(916) 876-4042"
+:services:
+- Case Management
+- Education (literacy services, high school and GED instruction)
+- Employment Readiness
+- Job Placement
+- Job Readiness/Life Skills
+- Vocational Training
+- Anger Management
+- Behavioral Health Assessments and Treatment
+- Cognitive Behavioral Services
+- Referrals to other services as appropriate
+:url: ''
+:what_to_bring: 

--- a/organizations/leaders-in-community-alternatives-inc-lca-electronic-monitoring.yml
+++ b/organizations/leaders-in-community-alternatives-inc-lca-electronic-monitoring.yml
@@ -27,3 +27,5 @@
 - Parolee Monitoring
 :url: www.lcaservices.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/leaders-in-community-alternatives-inc-lca-electronic-monitoring.yml
+++ b/organizations/leaders-in-community-alternatives-inc-lca-electronic-monitoring.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: 
+:address: 160 Franklin St., Oakland, CA  94607
+:contact_name: Intake
+:description: LCA allows participants to serve their time in the community working,
+  supporting family and receiving treatment while still being accountable.
+:eligible_population: All individuals involved in the juvenile or criminal justice
+  system, in custody and in community programs or alternative custody programs.
+:email: 
+:faith_based: No.
+:fax: "(415) 546-4147 or (800) 925-8049"
+:fees: 
+:languages:
+- English
+- Spanish
+- Tagalog
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 5:30pm
+  Referrals: May self-refer, or be referred by Court, supervising authority, or community based program.
+:name: Leaders in Community Alternatives, Inc. (LCA)   Electronic Monitoring
+:phone: "(415) 525-5587 or (800) 944-1170"
+:services:
+- Electronic Monitoring
+- GPS Monitoring and Tracking
+- Continuous Alcohol Monitoring
+- Substance Abuse Testing
+- Parolee Monitoring
+:url: www.lcaservices.com
+:what_to_bring: 

--- a/organizations/leaders-in-community-alternatives-transitional-day-reporting-center-tdrc.yml
+++ b/organizations/leaders-in-community-alternatives-transitional-day-reporting-center-tdrc.yml
@@ -1,0 +1,72 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 400 Broadway, Oakland, CA  94604
+:contact_name: Roth Johnson
+:description: The ADRC North is a partnership between the Sacramento Probation Department
+  and Leaders in Community Alternatives  that bridges probation supervision services
+  with comprehensive case management, barrier removal, employment and income benefits
+  acquistion assistance.  In addition to the services LCA has on-site at the ADRC,
+  LCA utilizes Sacramento County Probation's existing contracts for education, vocational
+  and mental health services.  The goals of the ADRC are to reduce recidivism and
+  build self-sufficiency skills in the clients we serve. The new Transitional Day
+  Reporting Center (TDRC) is a community corrections reenrty center that bridges probation
+  supervision services with comprehensive case management, barrier removal, and income
+  benefits acquistion assistance.  In addition to the services LCA will have on-site
+  at the TDRC, LCA will utilize Alameda County probation Department’s existing contracts
+  for employment, vocational services and housing.  We also plan to utilize current
+  contracts of the Alameda County behavioral health Care Services for substance abuse
+  and mental health treatment.  The foals of the TDRC are to reduce recidivism, build
+  self-sufficiency skills, for a thriving healthy community.
+:eligible_population: Clients of the Alameda County Adult Probation Department
+:email: rjohnson@lcaservices.com
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday –Friday, 8am-5pm
+  Notes:  Please call for more information.
+:name: Leaders In Community Alternatives   Transitional Day Reporting Center (TDRC)
+:phone: "(510) XXX-XXXX"
+:services:
+- Access to Internet
+- Assistance Getting Driver’s License/Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Transit Vouchers
+- Substance Abuse Treatment
+- Alcohol Monitoring and Substance Abuse Testing
+- Health & Wellness Education
+- Std/Sti Prevention
+- Anger Management
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Restorative Justice/Survivor Impact
+- Trauma Recovery Services
+- Housing Placement Assistance
+- Cognitive Behavorial Therapy
+- Basic/Remedial Education
+- GED & High School Education
+- Reading/Literacy
+- Vocational Education
+- Assistance applying for CalFresh/Food Stamps
+- Assistance applying for PAES/GA/CalWorks
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Assistance applying for Health Insurance
+- Clean Slate/ Conviction Expungement Services
+- Voting Outreach & Education
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education
+:url: ''
+:what_to_bring: 

--- a/organizations/leaders-in-community-alternatives-transitional-day-reporting-center-tdrc.yml
+++ b/organizations/leaders-in-community-alternatives-transitional-day-reporting-center-tdrc.yml
@@ -70,3 +70,5 @@
 - Parenting Support/Education
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/legal-services-for-prisoners-with-children-all-of-us-or-none.yml
+++ b/organizations/legal-services-for-prisoners-with-children-all-of-us-or-none.yml
@@ -36,3 +36,5 @@
   discrimination
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/legal-services-for-prisoners-with-children-all-of-us-or-none.yml
+++ b/organizations/legal-services-for-prisoners-with-children-all-of-us-or-none.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+:address: 
+:contact_name: Alex Berliner, Manuel La Fontaine, Organizers
+:description: All Of Us Or None (AOUON), a project of Legal Services for Prisoners
+  with Children, is a grassroots organization led by formerly-imprisoned people committed
+  to fighting for the human dignity of currently and formerly-incarcerated people,
+  and their respective family members, as well as against the systemic discrimination
+  facing them while in captivity and upon their release. AOUON strengthens the voices
+  of people most affected by the punishment (judicial) system and the growth of the
+  prison-industrial complex. Through their grassroots organizing, AOUON is building
+  a powerful political movement to win full restoration of their human and civil rights.  prisonerswithchildren.org
+:eligible_population: All individuals and family members, in and out of custody.
+:email: alex@prisonerswithchildren.org; manuel@prisonerswithchildren.org
+:faith_based: No.
+:fax: 552-3150
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday - Friday, 9:00am to 5:00pm
+  Notes: Please call organiers for more information.
+  All individuals and family members.
+:name: Legal Services for Prisoners with Children   All of Us or None
+:phone: "(415) 255-7036 x330, x328"
+:services:
+- Some Access to Internet
+- Mentorship
+- Post-Incarceration Support
+- Assist with writing support letters for people facing charges or the Parole Board
+- Coordinate annual event to connect family members inside with their children, grandchildren,
+  and families on the outside through our Community Giveback
+- Referrals to other resources available as needed
+- Coordinate with other organizations to raise awareness of our struggle against systemic
+  discrimination
+:url: ''
+:what_to_bring: 

--- a/organizations/legal-services-for-prisoners-with-children-california-coalition-for-women-prisoners-ccwp.yml
+++ b/organizations/legal-services-for-prisoners-with-children-california-coalition-for-women-prisoners-ccwp.yml
@@ -40,3 +40,5 @@
 - Referrals to other resources available as needed
 :url: www.womenprisoners.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/legal-services-for-prisoners-with-children-california-coalition-for-women-prisoners-ccwp.yml
+++ b/organizations/legal-services-for-prisoners-with-children-california-coalition-for-women-prisoners-ccwp.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+:address: 
+:contact_name: Samantha Rogers and Hafsah Al-Amin, Program Coordinators
+:description: CCWP is a grassroots social justice organization, with members inside
+  and outside prison, that challenges the institutional violence imposed on women,
+  transgender people, and communities of color by the prison industrial complex (PIC).
+  We see the struggle for racial and gender justice as central to dismantling the
+  PIC and we prioritize the leadership of the people, families, and communities most
+  impacted in building this movement.  www.prisonerswithchildren.org
+:eligible_population: All individuals and family members, in and out of custody.
+:email: samantha@womenprisoners.org; hafsah@womenprisoners.org
+:faith_based: No.
+:fax: "(415) 552-3150"
+:fees: None.
+:languages:
+- English
+- In addition
+- Compañeras Program hightlights
+- supports issues of Spanish speakers
+:miscellaneous: |-
+  Hours:  Monday – Friday from 9:00am – 5:00pm
+  Notes: No referrals needed. Not a formal service site, but individuals can make appointments to come for support and referrals to other resources.
+:name: Legal Services for Prisoners with Children   California Coalition for Women
+  Prisoners (CCWP)
+:phone: "(415) 255-7036 x4"
+:services:
+- Assistance finding emergency shelter
+- Assistance finding permanent housing prior to or upon release
+- Some Access to Internet
+- Mentorship
+- Outreach to a wide cross-section of people including students, domestic violence
+  workers, community service providers, and others
+- Other Post-Incarceration Support
+- Restorative Justice/ Survivor Impact efforts with violent offenders in San Francisco
+  Jails
+- Coordinate with All Of Us or None to spread the word about clean slate efforts
+- Assist with Inmate & Parolee Legal Issues
+- Coordinate annual event for family members to visit prisoners
+- Referrals to other resources available as needed
+:url: www.womenprisoners.org
+:what_to_bring: 

--- a/organizations/legal-services-for-prisoners-with-children.yml
+++ b/organizations/legal-services-for-prisoners-with-children.yml
@@ -34,3 +34,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/legal-services-for-prisoners-with-children.yml
+++ b/organizations/legal-services-for-prisoners-with-children.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+:address: 1540 Market Street, Suite 490
+:contact_name: 
+:description: We generally do not represent people in court or other legal matters.
+  We are committed to training people to advocate for their own rights. prisonerswithchildren.org
+:eligible_population: 
+:email: info@prisonerswithchildren.org
+:faith_based: No.
+:fax: 
+:fees: None. Voluntary donations accepted.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday - Friday, 9:00am to 5:00pm
+  San Francisco, CA 94102
+  Notes: No referrals needed. Call or write first for an appointment.
+  Genders/Family Composition/Ages Served:
+  All individuals and family members.
+:name: Legal Services for Prisoners with Children
+:phone: "(415) 255-7036"
+:services:
+- Pregnancy information for incarcerated women
+- Inmate & Parolee Legal Issues for California prisoners and their families
+- Support letters for older women in state prison
+- Family law manuals/advice
+- Workshops on family law issues
+- Prison advocacy, including support letters for incarcerated people who are experiencing
+  problems in custody, such as lack of or substandard medical care, sexual harrassment
+  or retaliation, problems with visits, etc
+- "; Family Reunification counseling"
+- Support and advice for family members visiting loved ones in jail or prison
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/lutheran-social-services-of-northern-california-forensic-housing-program.yml
+++ b/organizations/lutheran-social-services-of-northern-california-forensic-housing-program.yml
@@ -34,3 +34,5 @@
 :url: lssnorcal.org/what_we_do/san-francisco-programs/supportive-housing/forens.html
 :what_to_bring: letter of HIV+ diagnosis, income verification and care plan must be
   provided at or by intake appointment.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/lutheran-social-services-of-northern-california-forensic-housing-program.yml
+++ b/organizations/lutheran-social-services-of-northern-california-forensic-housing-program.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: Not wheelchair accessible.
+:address: Kinney Hotel, 410 Eddy St., San Francisco, CA  94109
+:contact_name: Frank Perez, Program Manager
+:description: The Forensic Housing Program is a HOPWA-funded transitional housing
+  program for homeless HIV+ men and women (including transgender men and women) who’ve
+  been incarcerated at the county, state or federal level within the past 12 months.  The
+  program provides short term emergency shelter and transitional housing of up to
+  18 months while participants receive coordinated case management support to help
+  stabilize their lives. 
+:eligible_population: HIV+ men and women (including transgender men and women) who’ve
+  been incarcerated at the county, state or federal level within the past 12 months.
+:email: fperez@lssnorcal.org
+:faith_based: No.
+:fax: "(415) 351- 1228"
+:fees: 30% of monthly net income plus additional mandatory 20% monthly savings.
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  url: lssnorcal.org/what_we_do/san-francisco-programs/supportive-housing/forens.html
+  Hours: Monday-Friday, 9am-5pm
+  Notes: Clients must be referred by a primary case manager who will continue to provide services; referral process includes submitting program paperwork, letter of HIV+ diagnosis, income verification (if client already has income) and care plan. Client must be willing to follow rules and participate in program designed to provide stabilization and ensure transition into permanent housing
+:name: Lutheran Social Services of Northern California   Forensic Housing Program
+:phone: "(415) 351-1337"
+:services:
+- Transitional Housing
+- Case Management
+- Additional program services include housing advocacy, money management services,
+  linkages to HIV prevention, access to benefits counseling/advocacy, workshops/groups
+  focused on teaching basic life skills, access to medical, access to oral health
+  care, and access to behavioral health services targeting post-incarcerated individuals
+  living with HIV/AIDS in the city and county of San Francisco, CA
+:url: lssnorcal.org/what_we_do/san-francisco-programs/supportive-housing/forens.html
+:what_to_bring: letter of HIV+ diagnosis, income verification and care plan must be
+  provided at or by intake appointment.

--- a/organizations/mission-council-on-alcohol-abuse-for-the-spanish-speaking-inc.yml
+++ b/organizations/mission-council-on-alcohol-abuse-for-the-spanish-speaking-inc.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 154-A Capp Street, San Francisco, CA 94110
+:contact_name: Intake Coordinator
+:description: Mission Council on Alcohol Abuse for the Spanish Speaking, Inc., a non-profit
+  organization, has been committed to the prevention and treatment of alcohol and
+  other drug-related problems for individuals, families, and groups of underserved
+  members of San Francisco communities by providing leadership and community care
+  needs in a safe and culturally relevant setting.
+:eligible_population: All individuals and family members, 18 and older.
+:email: jla@missioncouncil.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Intake, Monday – Friday, 3:00pm to 5:00pm
+  Notes: No referral needed.
+:name: Mission Council on Alcohol Abuse for the Spanish Speaking, Inc.
+:phone: "(415) 826-6767, (415) 920-0721"
+:services:
+- Culturally Specific Assessments
+- Outpatient Counseling
+- Individual/Group Counseling
+- Drug and Alcohol Education Classes
+- Drug and Alcohol Testing
+- Alcoholics Anonymous
+- Narcotics Anonymous
+- Employment Services Referrals
+- Housing Referrals
+- Collaboration with the San Francisco Drug Court
+- Domestic Violence Counseling
+- Dual Diagnosis Assessment and Counseling
+- Referrals to other resources available as needed
+:url: www.missioncouncil.org
+:what_to_bring: 

--- a/organizations/mission-council-on-alcohol-abuse-for-the-spanish-speaking-inc.yml
+++ b/organizations/mission-council-on-alcohol-abuse-for-the-spanish-speaking-inc.yml
@@ -36,3 +36,5 @@
 - Referrals to other resources available as needed
 :url: www.missioncouncil.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/mission-hiring-hall-employment-services.yml
+++ b/organizations/mission-hiring-hall-employment-services.yml
@@ -37,3 +37,5 @@
 :url: www.missionhiringhall.org
 :what_to_bring: CA ID; Social Security Card; Proof of SF Residency. Program will assist
   client in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/mission-hiring-hall-employment-services.yml
+++ b/organizations/mission-hiring-hall-employment-services.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 3080 16th Street, san Francisco, CA  94103
+:contact_name: Front Desk
+:description: Mission Hiring Hall’s (MHH) purpose is to meet the immediate and long-term
+  employment needs of San Francisco’s employers and its low- and moderate-income,
+  unemploeyed and underemployed residents. MHH offers a variety of employment services/programs
+  including the CityBuild Academy, Construction Administration and Professional Services
+  Academy, Hospitality Initiative, and Homeless Employment Services.
+:eligible_population: All individuals 18 years and older.  Must be a San Francisco
+  resident.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+- Tagalog
+- Cantonese
+- Mandarin
+- Russian
+:miscellaneous: |-
+  Hours: Monday – Thursday, 9:00am to 5:00pm; Friday 9:00am to 4:30pm
+  Notes:  Orientations/Registration is the first step to receiving services. Intakes are Monday at 9:30am
+:name: Mission Hiring Hall   Employment Services
+:phone: "(415) 626-1919 x100"
+:services:
+- Employment Placement
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Access to Internet
+- Assistance with Resumes
+- CityBuild Academy, CAPSA & STEP
+- Referrals to other resources available as needed
+:url: www.missionhiringhall.org
+:what_to_bring: CA ID; Social Security Card; Proof of SF Residency. Program will assist
+  client in getting these.

--- a/organizations/mission-neighborhood-health-center-clinica-esperanza.yml
+++ b/organizations/mission-neighborhood-health-center-clinica-esperanza.yml
@@ -43,3 +43,5 @@
 :url: www.mnhc.org
 :what_to_bring: Proof of SF Residency. Program will assist entering clients in getting
   this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/mission-neighborhood-health-center-clinica-esperanza.yml
+++ b/organizations/mission-neighborhood-health-center-clinica-esperanza.yml
@@ -1,0 +1,45 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 240 Shotwell Street, San Francisco, CA  94110
+:contact_name: Allison Rojas
+:description: To provide culturally and linguistically appropriate services to under-served
+  members of the community that reside primarily in the Mission District, with an
+  emphasis on Spanish-speaking and bilingual clients. Our services of HIV care, treatment
+  and prevention, and support to those infected and affected by HIV seeks to improve
+  the lives and health of the community.
+:eligible_population: All individuals and family members, 18 and older.
+:email: allisonrojas@mnhc.org
+:faith_based: No.
+:fax: "(415) 552-0529"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Intake, Monday – Friday, 3:00pm to 5:00pm
+  Notes: No referral needed. Drop-ins allowed between 3-5pm, M-F.
+:name: Mission Neighborhood Health Center   Clinica Esperanza
+:phone: "(415) 552-1013"
+:services:
+- Emergency Shelter
+- Permanent Housing
+- Rental Move-in Assistance
+- Transitional Housing
+- Clothing vouchers
+- Food vouchers
+- Shower Facilities referrals
+- Transit Vouchers for case management or health-related appointments as needed
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Medical Care
+- Dental Care
+- Health & Wellness Education
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: www.mnhc.org
+:what_to_bring: Proof of SF Residency. Program will assist entering clients in getting
+  this.

--- a/organizations/mission-neighborhood-resource-center.yml
+++ b/organizations/mission-neighborhood-resource-center.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.mnhc.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/mission-neighborhood-resource-center.yml
+++ b/organizations/mission-neighborhood-resource-center.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible; other accommodations made as needed.
+:address: 165 Capp Street (between 16th& 17th), San Francisco, CA 94110
+:contact_name: Any intake staff
+:description: Harm reduction drop-in center in the Mission district, targeting the
+  homeless and those at risk in the neighborhood with a focus on Latino immigrants.
+  Peer-led and professionally-supported staff. Entry point to single-adult shelter
+  system; showers and laundry room; provides bilingual case management, mental health
+  support, groups, community building and organizing; part-time medical clinic, including
+  TB screening, urgent care, primary care, acupuncture, and HIV counseling and testing.
+  Women’s program on Thursday nights (6-8pm) provides dinner, hygiene kits, needle
+  exchange, and social support for women.
+:eligible_population: All individuals and family members.
+:email: info@mnhc.org
+:faith_based: No.
+:fax: "(415) 863-1882"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday - Friday, 7:00am to 7:00pm; Women only: Thursday, 6:00pm to 8:00pm (biological and transgender females)
+  Notes: No referral needed. Drop-in only.
+:name: Mission Neighborhood Resource Center
+:phone: "(415) 552-1013"
+:services:
+- Access to Benefits (SSI, GA, TANF, etc
+- "); Case Management"
+- Co-occurring Disorder/Dual Diagnosis
+- Healthcare
+- Mental Health Treatment
+- Phone/Voicemail
+- Showers
+- Support Groups
+- Referrals to other resources available as needed
+:url: www.mnhc.org
+:what_to_bring: 

--- a/organizations/mz-shirliz-transitional-inc-clean-sober-transitional-housing.yml
+++ b/organizations/mz-shirliz-transitional-inc-clean-sober-transitional-housing.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessibility.
+:address: 'Office location:  1447 El Camino Real, Redwood City, CA 94063'
+:contact_name: Shirley Lamarr
+:description: Mz. Shirliz offers transitional housing and supportive services for
+  people in recovery from substance abuse/addiction and those who are trying to rebuild
+  their lives post-incarceration.
+:eligible_population: Must be at least 18 years of age, and not have a conviction
+  for a sex offense or arson.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Office location:  1447 El Camino Real, Redwood City, CA 94063
+  Hours: 8:00am-5:00pm
+  Notes: Please call first.  Drop-ins okay if it is a non-medical emergency.
+:name: Mz. Shirliz Transitional Inc.   Clean & Sober Transitional Housing
+:phone: "(650) 218-8256"
+:services:
+- Transitional Housing
+- Supportive Services
+- Crisis Center
+- Individual and group Counseling
+- Job Training
+- Job Retention Support
+- Referral to other resources, including residential treatment, available as needed
+:url: www.mzshirliz.org
+:what_to_bring: 

--- a/organizations/mz-shirliz-transitional-inc-clean-sober-transitional-housing.yml
+++ b/organizations/mz-shirliz-transitional-inc-clean-sober-transitional-housing.yml
@@ -30,3 +30,5 @@
 - Referral to other resources, including residential treatment, available as needed
 :url: www.mzshirliz.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/nanny-s-sober-living.yml
+++ b/organizations/nanny-s-sober-living.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: 
+:address: 1686 Oakdale Avenue, San Francisco, CA 94124
+:contact_name: Suritha Jackson
+:description: To help men and women maintain recovery while taking on everyday life
+  challenges to self independence.
+:eligible_population: Men and women, 18 years and older. Cannot serve child sex offenders
+  or minors; cannot serve individuals with a criminal conviction for gang-related
+  offense, arson, or are registered sex offenders.
+:email: nannys.sober.living@gmail.com
+:faith_based: No.
+:fax: "(415) 401-0500"
+:fees: Varies, depending on income.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Vary. Please call or write first.
+  Notes: No referral needed. No drop-ins. Please call or write for appointment.
+:name: Nanny’s Sober Living
+:phone: "(415) 240-7526"
+:services:
+- Transitional Housing
+- Assistance Getting Driver’s License or other ID
+- Food/Prepared Meals/ Hygiene/Personal Care Items
+- Phone/Voicemail
+- Shower Facilities
+- Group Counseling/ Therapy
+- Individual Counseling/Therapy
+- Family Reunification
+- Referrals to other resources
+:url: ''
+:what_to_bring: TB Clearance. Program will assist client in getting this.

--- a/organizations/nanny-s-sober-living.yml
+++ b/organizations/nanny-s-sober-living.yml
@@ -30,3 +30,5 @@
 - Referrals to other resources
 :url: ''
 :what_to_bring: TB Clearance. Program will assist client in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/napa-county-health-and-human-services-agency-alcohol-and-drug-services.yml
+++ b/organizations/napa-county-health-and-human-services-agency-alcohol-and-drug-services.yml
@@ -46,3 +46,5 @@
 - Mail, Laundry, Computers, and Referrals to Other Service
 :url: www.countyofnapa.org/pages/departmentcontent.aspx?id=4294967796
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/napa-county-health-and-human-services-agency-alcohol-and-drug-services.yml
+++ b/organizations/napa-county-health-and-human-services-agency-alcohol-and-drug-services.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible
+:address: 1301 4th Street, Napa, CA  94559
+:contact_name: Staff
+:description: Access, Treatment Authorization, and Quality Services.  If you are seeking
+  substance abuse, addiction treatment services or information on local treatment
+  resources for yourself, a family member or a friend please contact us. Our services
+  follow evidence based practices including NiaTx, Motivational Enhancement, and Motivational
+  Interviewing and are provided in both English and Spanish.
+:eligible_population: Must be at least 18 years old and a Napa County resident to
+  receive services.
+:email: canv@can-v.org (for additional information)
+:faith_based: No.
+:fax: "(707) 253-6156"
+:fees: None – must contribute back for services by helping out with some chores.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Overview of Services:
+  Screening and Comprehensive Assessments 
+  Determination of appropriate treatment placement based on client needs 
+  Consultation and Education materials 
+  Referrals and linkages to other services within the agency and community 
+  Outreach and Engagement services 
+  Community presentations, upon request 
+   
+  Eligibility:
+  Eligibility requirements differ among the various contracted treatment providers. 
+  Cost of Services:
+  In all treatment agencies, a sliding scale fee, approved by the County Alcohol & Drug Administrator, is applied to services rendered. 
+  Contact:
+  Alcohol and Drug Services Centralized Access Line 
+  MONDAY through FRIDAY 8:00am to 5:00 pm, except holidays 
+  Location of Services: 
+  2344 Old Sonoma Road Bldg C, Napa, CA  94559
+  Direct Services:
+  Community Action of Napa Valley   Hope Center
+  The Hope Resource Center is a drop-in facility that provides basic services such as showers, restrooms, mail, phones and laundry for homeless adults throughout the day. A second tier of services, including medical care, job development, housing assistance, and mental health outreach and assessment are also provided through Community Action Napa Valley (CANV) and other participating agencies.   canv.net-flow.com
+  Intake Hours:  8:00am-4:30pm
+  Notes: Must be at least 18 years old and a Napa County resident to receive services.
+:name: Napa County Health and Human Services Agency   Alcohol and Drug Services
+:phone: "(707) 253-4063 "
+:services:
+- Coordinated assessment for access to Adult Shelter, Showers, Restrooms
+- Mail, Laundry, Computers, and Referrals to Other Service
+:url: www.countyofnapa.org/pages/departmentcontent.aspx?id=4294967796
+:what_to_bring: 

--- a/organizations/new-skin-adult-tattoo-removal.yml
+++ b/organizations/new-skin-adult-tattoo-removal.yml
@@ -1,0 +1,26 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1060 Willow Street, San Jose, CA  95125
+:contact_name: 
+:description: New Skin Adult Tattoo Removal program is a non-profit that removes visible
+  tattoos at a low cost for adults that may hinder them from gainful employment and
+  a peace of mind lifestyle.
+:eligible_population: All individuals and all ages. Clients under the age 18 years
+  old must be accompanied by a parent or guardian. 
+:email: adam.king@newskinadulttattooremoval.org
+:faith_based: No.
+:fax: "(415) 552-0529"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Each Month: 2nd Saturday 8am-4pm; 3rd Saturday & Sunday 2pm-5pm
+  Notes: No referral needed. Drop-ins allowed between 3-5pm, M-F.
+  Client fees: $80 for 3 minutes or $100 for 5 minutes.
+:name: New Skin   Adult Tattoo Removal
+:phone: "(408) 899-9695"
+:services:
+- Tattoo removal
+:url: www.newskinatr.org
+:what_to_bring: All forms are provided by New Skin Adult Tattoo Removal

--- a/organizations/new-skin-adult-tattoo-removal.yml
+++ b/organizations/new-skin-adult-tattoo-removal.yml
@@ -24,3 +24,5 @@
 - Tattoo removal
 :url: www.newskinatr.org
 :what_to_bring: All forms are provided by New Skin Adult Tattoo Removal
+:__meta__:
+  :version: 0.0.1

--- a/organizations/our-common-ground-substance-abuse-treatment-facility.yml
+++ b/organizations/our-common-ground-substance-abuse-treatment-facility.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: Wheelchair accessibility.
+:address: OCG Adult Services, 2560 Pulgas Avenue, Palo Alto, CA  94303.
+:contact_name: Richard Pecoraro, Intake Director
+:description: Our Common Ground (OCG) is a treatment program for adults with substance
+  abuse and mental health problems. We help people who realize they cannot do it alone
+  – that they need the support, encouragement and challenge from other like-minded
+  individuals who are working toward meaningful and productive lives, without drugs.
+  Our nurturing environment helps each individual take responsibility for his or her
+  own life and build skills for long term substance abuse recovery, rehabilitation
+  and emotional and physical success. Many come back later and tell us about their
+  happiness and success as parents, workers, students and contributing members of
+  their communities due to the rehabilitation therapy they have received in our treatment
+  center.
+:eligible_population: Must be at least 18 years of age, and not have a conviction
+  for a sex offense or arson.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Phone:  (650) 325-9544
+  Hours: Monday-Friday, 9:00am-5:00pm
+  Notes: Please call for appointment.  We offer  Residential Treatment, Day Treatment, Outpatient Treatment.
+:name: Our Common Ground   Substance Abuse Treatment Facility
+:phone: "(866) 325-6466"
+:services:
+- Residential Treatment
+- Evidence-Based Treatment
+- Case Management
+- Educational and Vocational Preparation
+- Conflict resolution
+- Anger Management
+- Family/Individual Counseling
+- Supportive Services
+- Referral to other resources available as needed
+:url: www.ocgworks.org/
+:what_to_bring: 

--- a/organizations/our-common-ground-substance-abuse-treatment-facility.yml
+++ b/organizations/our-common-ground-substance-abuse-treatment-facility.yml
@@ -39,3 +39,5 @@
 - Referral to other resources available as needed
 :url: www.ocgworks.org/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/our-father-s-sober-living-environment.yml
+++ b/organizations/our-father-s-sober-living-environment.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Not wheelchair accessible.
+:address: 1641 LaSalle Ave. San Francisco, CA 94124
+:contact_name: Keesha Henry, Program Director
+:description: Our Father’s SLE (OFSLE) provides service-structured, low-cost transitional
+  housing to recovering men who have become displaced as a result of substance abuse
+  and addiction.  Located in the Bayview Community, our home is designed to assist
+  recovering men at the transitional and community re-entry phases of their recovery
+  and our length of stay ranges from 6 months up to 1 year.
+:eligible_population: Adult men, 18 years or older, with special outreach to veterans,
+  seniors, parolees, and GBQT who have become homeless as a result of substance abuse/addiction.
+:email: keeshahenry@gmail.com
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Days and Hours: Monday-Friday, 9:00am to 5:00pm for intakes.
+  Notes: Appointments required.
+  Client fees: Shared rooms are $600/month.
+:name: Our Father’s Sober Living Environment
+:phone: "(415) 926-0258"
+:services:
+- Transitional Housing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/ Mail Service
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Community Education & Mediation
+- Outreach
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: www.cleanlounge.info
+:what_to_bring: California ID and any letters of recommendation or personal references
+  to support your application to our program.

--- a/organizations/our-father-s-sober-living-environment.yml
+++ b/organizations/our-father-s-sober-living-environment.yml
@@ -35,3 +35,5 @@
 :url: www.cleanlounge.info
 :what_to_bring: California ID and any letters of recommendation or personal references
   to support your application to our program.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/path-supportive-services-interim-transitional-housing.yml
+++ b/organizations/path-supportive-services-interim-transitional-housing.yml
@@ -35,3 +35,5 @@
 :url: www.epath.org/site/main.html
 :what_to_bring: CA ID, Social Security Card, updated TB test, verification of income.  Program
   will assist clients getting these documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/path-supportive-services-interim-transitional-housing.yml
+++ b/organizations/path-supportive-services-interim-transitional-housing.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair and other disabilities accommodated.
+:address: 'Address:  Central Facility, 340 North Madison Avenue, Los Angeles, CA  90004'
+:contact_name: Receptionist
+:description: People Assisting The Homeless (PATH) is a family of agencies working
+  together to end homelessness for individuals, families, and communities throughout
+  Southern California. We strive to do this by prioritizing housing while providing
+  customized supportive services for people in need. Our agencies each address homelessness
+  in a different way—supportive services, permanent housing development, support for
+  homeless families, and community engagement—all of which ultimately help the people
+  we serve make it home.
+:eligible_population: Homeless individuals, families, veterans.
+:email: path@epath.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday-Friday, 8:00am to 12:00pm, and 12:30pm to 4:00pm.
+  Address:  Central Facility, 340 North Madison Avenue, Los Angeles, CA  90004
+  Notes: Please call for information.
+     
+  Client fees: None.
+:name: PATH   Supportive Services/Interim & Transitional Housing
+:phone: "(323) 644-2216"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Substance Abuse Treatment
+- Transitional Employment
+- Supportive Housing
+- Referrals to other resources available as needed
+:url: www.epath.org/site/main.html
+:what_to_bring: CA ID, Social Security Card, updated TB test, verification of income.  Program
+  will assist clients getting these documents.

--- a/organizations/pathfinders-of-san-diego-recovery-services.yml
+++ b/organizations/pathfinders-of-san-diego-recovery-services.yml
@@ -31,3 +31,5 @@
 - Based on the Big Book of Alcoholics Anonymous
 :url: pathfindersrecovery.org/wordpress/
 :what_to_bring: Valid ID and current TB test.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/pathfinders-of-san-diego-recovery-services.yml
+++ b/organizations/pathfinders-of-san-diego-recovery-services.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: 
+:address: 
+:contact_name: Steve Sapp
+:description: Pathfinders is a non-profit organization dedicated to maintaining residential
+  centers which address the needs of individuals recovering from the disease of alcoholism
+  and co-occurring disorders, assisting their families in dealing with the effects
+  of alcoholism, and providing services to the community in its effort to reduce alcohol-related
+  problems.
+:eligible_population: Men  18 years and older,  no active warrants, no upcoming court
+  dates,  no arson or sex crimes. May not work for the first 4 to 6 months of the
+  program.
+:email: recovery@pathfindersofsd.com
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Intake Hours: Monday-Friday, 9:00am to 11:00am (except the last two and first two business days of each month and holidays.
+  Address:  2980 Cedar Street,
+  San Diego, CA 92102
+  Notes: No appointment necessary.
+      
+  Client fees: sliding scale—food stamps accepted as partial rent payment.
+:name: Pathfinders of San Diego   Recovery Services
+:phone: "(619) 239-7370"
+:services:
+- Residential Recovery program for male alcoholics
+- Designed to be a 9 month program
+- Based on the Big Book of Alcoholics Anonymous
+:url: pathfindersrecovery.org/wordpress/
+:what_to_bring: Valid ID and current TB test.

--- a/organizations/phatt-chance-community-services.yml
+++ b/organizations/phatt-chance-community-services.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: 
+:address: San Francisco. Easily accessible by public transportation.
+:contact_name: Intake/House Manager
+:description: Phatt Chance Community Services, Inc., (PCCS) is a nonprofit organization
+  that provides transitional short and long-term housing and other basic support services
+  to individuals reintegrating to society after incarceration, homelessness, and those
+  with mental health concerns. PCCS provides a safe, clean & sober living environment,
+  basic psychosocial services, as well as aftercare for clients in various stages
+  of drug and/or alcohol abuse recovery. PCCS utilizes a reintegration model that
+  provides minimum structure paired with maximum accountability, which allows program
+  participants to pursue employment, continued education, counseling services and
+  other off-site responsibilities when appropriate. The duration of clients’ stay
+  at Phatt Chance Community Services depends entirely on the individual needs of each
+  client.
+:eligible_population: Male only, 18 years and older.
+:email: phattchancecommunity@gmail.com
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Intake Hours: Monday through Friday, 8 am to 4 pm and by appointment
+  Mailing Address: Phatt Chance Community Services, Inc., 2443 Fillmore Street #216,
+  San Francisco, CA 94115
+ 
+  Client fees: Based on individual service needs.
+  Notes: Long-term and short-term housing for men of any race, sexual orientation, ethnicity and faith.
+:name: Phatt Chance Community Services
+:phone: "(415) 822-9922"
+:services:
+- Transitional Housing
+- Clean & Sober Living
+- Mental Health Assessment
+- Substance Abuse Education
+- Relapse Prevention and Intervention
+- Treatment Referrals
+- In-house Peer Support Groups
+- Self-Esteem and Community Building
+- Life Skills Training
+:url: http://phattchance.org
+:what_to_bring: 

--- a/organizations/phatt-chance-community-services.yml
+++ b/organizations/phatt-chance-community-services.yml
@@ -41,3 +41,5 @@
 - Life Skills Training
 :url: http://phattchance.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/positive-directions-equals-change.yml
+++ b/organizations/positive-directions-equals-change.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/positive-directions-equals-change.yml
+++ b/organizations/positive-directions-equals-change.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1663 Newcomb Ave., San Francisco, CA 94124
+:contact_name: Cedric Akbar, Executive Director.
+:description: Our mission is to inspire personal and social responsibility in the
+  African American community through advocacy, education and results-oriented service.
+  Outpatient substance abuse treatment program certified by the State, based on 12-step
+  recovery principles, combined with non-traditional treatment modalities that address
+  the whole individual. Other services include life skills, re-socialization training,
+  parenting education groups, anger management/violence prevention, relapse prevention,
+  drug education, HIV/AIDS awareness, and harm reduction education.
+:eligible_population: All individuals and family members.
+:email: cantgetright94124@yahoo.com
+:faith_based: No.
+:fax: "(415) 401-0175"
+:fees: Call for fee schedule.
+:languages:
+- English
+:miscellaneous: |-
+  Hours:  Monday-Friday, 10:00am to 5:00pm
+  Notes: No referral needed. Drop-in preferred.
+:name: Positive Directions Equals Change
+:phone: "(415) 401-0199"
+:services:
+- Anger Management
+- Case Management
+- Counseling
+- Life Skills
+- Literacy/Basic Education
+- Mentoring
+- Substance Abuse Treatment
+- Trauma Recovery
+- Victim Services
+- Violence Prevention
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/positive-resource-center-prc-employment-services.yml
+++ b/organizations/positive-resource-center-prc-employment-services.yml
@@ -49,3 +49,5 @@
 - Referrals to other resources available as needed
 :url: www.positiveresource.org
 :what_to_bring: Program will assist client in getting necessary documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/positive-resource-center-prc-employment-services.yml
+++ b/organizations/positive-resource-center-prc-employment-services.yml
@@ -1,0 +1,51 @@
+---
+:accessibility: Wheelchair accessible. Facilities approved by CARF and CA DoR.
+:address: 785 Market Street, 10th Floor, San Francisco, CA 94103
+:contact_name: Joe Ramirez-Forcier, Managing Director
+:description: Positive Resource Center’s Employment Services Program provides vocational
+  rehabilitation and job search services to people with HIV/AIDS or with Mental Health
+  Disabilities. Our Employment Services Program assists clients who are considering
+  temporary work, self-employment, permanent part-time or full-time work, or training
+  and education opportunities. Positive Resource Center is the only employment service
+  provider in the San Francisco Bay Area that has specifically developed its program
+  for people who are facing multiple employment barriers. PRC Employment Services
+  supports a whole person approach, using harm reduction, and supports a self-efficacy
+  model to support people with disabilities to live independent lives.
+:eligible_population: All individuals with HIV/Mental Health/other disabilities.
+:email: joer@positiveresource.org
+:faith_based: No.
+:fax: "(415) 777-1770"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm. Orientation is every Weds at 2:00pm.
+  Notes: No referral needed for HIV+ clients  Clients with disabilities can attend the orientation.
+:name: Positive Resource Center   PRC Employment Services
+:phone: "(415) 972-0831"
+:services:
+- Access to Internet
+- Job Search Center
+- Anger Management
+- Conflict Management
+- Stress Management
+- Time Management
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Vocational Counseling
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Vocational Education
+- Assessment & Application for Food Stamps, General Assistance
+- Legal advise and benefits representation
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Referrals to other resources available as needed
+:url: www.positiveresource.org
+:what_to_bring: Program will assist client in getting necessary documents.

--- a/organizations/prepared-lunches-hygiene-personal-care-items-intensive-case-management-post-incarceration-support-bas.yml
+++ b/organizations/prepared-lunches-hygiene-personal-care-items-intensive-case-management-post-incarceration-support-bas.yml
@@ -56,3 +56,5 @@
 :url: www.sfgoodwill.org
 :what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency. Program
   will assist client in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/prepared-lunches-hygiene-personal-care-items-intensive-case-management-post-incarceration-support-bas.yml
+++ b/organizations/prepared-lunches-hygiene-personal-care-items-intensive-case-management-post-incarceration-support-bas.yml
@@ -1,0 +1,58 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1500 Mission Street, San Francisco, CA 94103
+:contact_name: 
+:description: Goodwill Industries of San Franciso, San Mateo and Marin Counties  One
+  Stop Career Link Center, Reentry Navigator and Other Services
+:eligible_population: All individuals who obtain a One Stop Card may access services.
+  All individuals with involvement in the criminal justice system may meet with the
+  Reentry Navigator.
+:email: IPerez@sfgoodwill.org
+:faith_based: No.
+:fax: "(415) 575-2170"
+:fees: No cost to participants.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Goodwill Industries supports people from all walks of life so that they can enhance their vocational development and return to the workforce. It helps to remove barriers to self sufficiency and to restore dignity to participants through training and job placements. The Reentry Navigator program helps formerly incarcerated individuals navigate citywide resources and to provide job readiness training, job development, and job placement assistance. www.sfgoodwill.org
+  One Stop Career Link Center
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: Attend a One Stop Orientation. Orientations are offered Monday – Friday at 10:00am.
+  Reentry Navigator: Isabel Navigator
+  Hours: Please call to make an appointment.
+  Notes: No referral needed.
+:name: Prepared Lunches; Hygiene/Personal Care Items; Intensive Case Management; Post-Incarceration
+  Support; Basic/Remedial Education; GED & High School Education; Vocational Education;
+  Employment Training and Placement; Employment Retention; Job Readiness/Life Skills;
+  Money Management/Personal Financial Education. Referrals to other resources available
+  as needed.
+:phone: "(415) 575-4570"
+:services:
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing Vouchers
+- Transit Vouchers
+- Intensive Case Management
+- Outreach
+- Post-Incarceration Support
+- English as a Second Language
+- GED & High School Education
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Clean Slate/Conviction Expungement Services
+- Inmate & Parolee Legal Issues
+- Phone/Voicemail
+- Vocational Education
+- Hotel Vouchers
+- Housing Resources
+- Retail/Warehouse Operation Training
+- Criminal Justice Navigator
+- Bus Tokens
+- Referrals to other resources available as needed
+:url: www.sfgoodwill.org
+:what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency. Program
+  will assist client in getting these.

--- a/organizations/prison-law-office.yml
+++ b/organizations/prison-law-office.yml
@@ -42,3 +42,5 @@
 - housing & eviction defense
 :url: www.prisonlaw.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/prison-law-office.yml
+++ b/organizations/prison-law-office.yml
@@ -1,0 +1,44 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated, please
+  contact.
+:address: 1917 5th Street, Berkeley, CA 94710
+:contact_name: Aiashi Khalid
+:description: The Prison Law Office strives to improve the living conditions of California
+  state prisoners by providing free legal services.  The Prison Law Office represents
+  individual prisoners, engages in class action and other impact litigation, educates
+  the public about prison conditions, and provides technical assistance to attorneys
+  throughout the country.
+:eligible_population: California state prisoners, and occasionally to California state
+  parolees.
+:email: info@rootandrebound.org
+:faith_based: No.
+:fax: "(510) 666-4903"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  . www.lrcl.org
+  Hours: Monday-Friday
+  Notes:  If you or a family member have an issue that you believe we can assist with, please free to contact our office.  Letters concerning individual prisoners and prison conditions can be addressed to:
+  Prison Law Office
+  General Delivery
+  San Quentin, CA  94964
+  Do to the large number of inquiries, we cannot accept telephone calls from prisoners and their families.
+  Services: For over 35 years this nonprofit public interest law firm has been in the forefront of legal efforts to enforce the Constitution and other laws inside the walls of California's prisons. With a small staff of attorneys and support personnel, the Prison Law Office represents individual prisoners, engages in class action and other impact litigation, educates the public about prison conditions, and provides technical assistance to attorneys throughout the country. (The office generally does not handle criminal appeals or habeas corpus petitions challenging criminal convictions.) 
+  California's prisons remain dangerously overcrowded at 147% of design capacity with over 122,000 prisoners crammed into 33 institutions, plus another 12,000 prisoners housed out-of-state and in community facilities. Basic necessities of life, such as medical and mental health care, are often lacking. Prisoners with disabilities are not recognized as disabled, and many are not provided reasonable accommodations as required by the Americans with Disabilities Act. Through both individual and impact litigation, the Prison Law Office has changed many California Department of Corrections and Rehabilitation policies and practices, and has alleviated many of the cruel and unusual conditions that have been inflicted upon tens of thousands of state prisoners.
+  Direct Services:
+  Root & Rebound    Legal Advocacy & Direct Services
+  Root & Rebound’s mission is to reduce barriers and maximize opportunities for people returning from prison and jail in the Bay Area, throughout California, and beyond.  Though our Legal Advocacy and Direct Services Program we work with clients to identify barriers that make reintergation most challenging and address these needs by providing legal sericvices in-house and by collaborating with service providers across the bay Area to provide extra legal services.  www.rootandrebound.org
+  Intake Hours: Monday –Friday, 1pm-4pm
+  Notes: Walk-ins at our Berkeley office.
+:name: Prison Law Office
+:phone: "(415) 280-2621"
+:services:
+- post-incarceration support
+- clean slate/conviction expungement services
+- inmate and parolee legal issues
+- employment law/discrimination
+- family law
+- housing & eviction defense
+:url: www.prisonlaw.com
+:what_to_bring: 

--- a/organizations/progress-foundation.yml
+++ b/organizations/progress-foundation.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Avenues, Clay and Ashbury are wheelchair accessible.
+:address: Various Locations. Main Office is 368 Fell Street, San Francisco, CA 94102
+:contact_name: 
+:description: Progress Foundation offers medication education, symptom management
+  (mental health), case management, and referrals to other resources.
+:eligible_population: All individuals and families, including seniors (age 60 and
+  older) with an Axis I mental health disorder. Must not be registered sex offender,
+  must not have a criminal conviction for arson.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Sliding scale; free for individuals with no income.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  General Information:  Main Office:  (415) 861-0828; La Amistad (415) 285-8100; Clay Street: (415) 776-4647; Progress House: (415) 668-1511; Seniors: (415) 821-0697; Ashbury (women & children): (415) 775-6194; Supported Living Program: Phone: (415) 752-3416 Fax: (415) 752-3483
+  Residential Treatment Facility Hours: 24 hours/7 days
+  Supported Living Office: 9:00am to 5:00pm, case manager on-call at all times.
+  Notes: Referral required from any case manager, therapist or psychiatrist.
+:name: Progress Foundation
+:phone: 
+:services:
+- Access to Benefits (SSI, GA, TANF, et al)
+- Accompany to Court Dates
+- Anger Management
+- Co-occurring Disorder/Dual Diagnosis
+- Counseling
+- Family Reunification
+- Food/Meals
+- Healthcare
+- Life Skills
+- Parenting Support
+- Phone/Voicemail
+- Residential/Housing
+- Showers
+- Transit Vouchers
+- Trauma Recovery
+- Referrals to other resources available as needed
+:url: www.progressfoundation.org
+:what_to_bring: Proof of San Francisco residency; TB Clearance; a physical within
+  the past 12 months. Program can assist with physical and TB tests.

--- a/organizations/progress-foundation.yml
+++ b/organizations/progress-foundation.yml
@@ -41,3 +41,5 @@
 :url: www.progressfoundation.org
 :what_to_bring: Proof of San Francisco residency; TB Clearance; a physical within
   the past 12 months. Program can assist with physical and TB tests.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/project-90-substance-abuse-treatment-services-san-jose.yml
+++ b/organizations/project-90-substance-abuse-treatment-services-san-jose.yml
@@ -33,3 +33,5 @@
 - Hygiene/Personal Care Items
 :url: www.projectninety.org
 :what_to_bring: State-Issued ID
+:__meta__:
+  :version: 0.0.1

--- a/organizations/project-90-substance-abuse-treatment-services-san-jose.yml
+++ b/organizations/project-90-substance-abuse-treatment-services-san-jose.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 561 South 9th Street, San Jose, CA 95112
+:contact_name: Intake Department
+:description: Project 90 is a human services organization dedicated to meeting the
+  needs of individuals, families and our communities through comprehensive alcohol
+  and drug recovery.
+:eligible_population: Men and Women, ages 18 and older.  Must not have conviction
+  for arson or sex offense.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday-Friday, 9am to 5pm
+  Notes: All clients must be referred through Gateway.  Please contact Gateway at 800-488-9919.
+  Client fees: Sliding scale.
+:name: Project 90       Substance Abuse Treatment Services San Jose
+:phone: "(408) 885-1291"
+:services:
+- Residential Substance Abuse Treatment
+- Co-occuring Disorders/Dual Diagnosis Treatment
+- Health and Wellness Education
+- Anger Management
+- Case Management
+- Trauma Recovery Services
+- Mentorship
+- Therapy
+- Clothing
+- Meals
+- Hygiene/Personal Care Items
+:url: www.projectninety.org
+:what_to_bring: State-Issued ID

--- a/organizations/project-90-substance-abuse-treatment-services.yml
+++ b/organizations/project-90-substance-abuse-treatment-services.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 'Locations:  Corporate Office, 720 South B Street, San Mateo, CA 94401'
+:contact_name: Intake Department
+:description: Project 90 is a human services organization dedicated to meeting the
+  needs of individuals, families and our communities through comprehensive alcohol
+  and drug recovery.
+:eligible_population: Men ages 18 and older.  Must not have conviction for arson or
+  sex offense.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday-Friday, 9am to 5pm
+  Locations:  Corporate Office, 720 South B Street, San Mateo, CA 94401
+  Notes: Drop-in okay.  Interviews to get accepted on to the waitlist occur every Tuesday at 11:00am and every Friday at 11:45am at 416 2nd Avenue, San Mateo, CA  94401
+  Client fees: Sliding scale.
+:name: Project 90   Substance Abuse Treatment Services
+:phone: "(650) 579-7881"
+:services:
+- Residential Substance Abuse Treatment
+- Co-occuring Disorders/Dual Diagnosis Treatment
+- Health and Wellness Education
+- Anger Management
+- Case Management
+- Trauma Recovery Services
+- Mentorship
+- Therapy
+- Clothing
+- Meals
+- Hygiene/Personal Care Items
+:url: www.projectninety.org
+:what_to_bring: State-Issued ID

--- a/organizations/project-90-substance-abuse-treatment-services.yml
+++ b/organizations/project-90-substance-abuse-treatment-services.yml
@@ -34,3 +34,5 @@
 - Hygiene/Personal Care Items
 :url: www.projectninety.org
 :what_to_bring: State-Issued ID
+:__meta__:
+  :version: 0.0.1

--- a/organizations/proyecto-common-touch-get-out-the-jail-vote-ca.yml
+++ b/organizations/proyecto-common-touch-get-out-the-jail-vote-ca.yml
@@ -1,0 +1,31 @@
+---
+:accessibility: May be arranged.
+:address: 
+:contact_name: Tommy Escarcega, Director
+:description: Empowerment by knowledge and mission to distribute and make this relevant
+  information available and accessible in or out of custody.
+:eligible_population: Women, Transgender
+:email: tommyescarcega@yahoo.com
+:faith_based: No.
+:fax: "(510) 845-4622"
+:fees: None. Donations accepted.
+:languages:
+- English
+- Spanish
+- some Portuguese
+:miscellaneous: |-
+  Hours: Call for hours
+  Mailing Address: 830 Allston Way, Berkeley, CA  94710
+  Notes: No referral needed. Call during business hours or write for appointment at other times.
+:name: Proyecto Common Touch   Get Out The Jail Vote/CA
+:phone: "(510) 409-1662"
+:services:
+- Voter Education
+- Voter Registration
+- Phone/Voicemail - We will accept a determined number of messages and allow some
+  phone use for related business
+- Inmate & Parolee Legal Issues
+- Voting Outreach & Education
+- Referrals to other resources available as needed
+:url: www.proyectocommontouch.org
+:what_to_bring: 

--- a/organizations/proyecto-common-touch-get-out-the-jail-vote-ca.yml
+++ b/organizations/proyecto-common-touch-get-out-the-jail-vote-ca.yml
@@ -29,3 +29,5 @@
 - Referrals to other resources available as needed
 :url: www.proyectocommontouch.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/recovery-survival-network-rsn-family-of-friends-sober-living-network.yml
+++ b/organizations/recovery-survival-network-rsn-family-of-friends-sober-living-network.yml
@@ -1,0 +1,64 @@
+---
+:accessibility: Some facilities accommodate people with mobility impairments.
+:address: 3032-16th St., San Francisco, CA  94110
+:contact_name: Lou Gordon, Executive Director; Kevin Henley, Program Manager
+:description: 'Our Mission: to help those who want to help themselves. Our goals:
+  provide intensive case management coupled with clean and sober housing to help transition
+  participants into self-sufficiency.'
+:eligible_population: Men, Women, Transgender people. Individuals required to register
+  as a sex offender are accepted on a case by case basis.  Clients need a referral.
+:email: rsn2000@gmail.com
+:faith_based: No.
+:fax: "(415) 552-8444"
+:fees: Clean and sober living housing rate is $1000.00 per month.
+:languages:
+- English (translation for Spanish
+- Mandarin
+- Cantonese)
+:miscellaneous: |-
+  url: www.rsn2000.org
+  24 hour emergency hotline: 888-USE-NONE
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Locations:
+  3032-16th St., San Francisco, CA  94110
+  3143-16th St., San Francisco, CA 94110
+  68-6th St., San Francisco, CA 94103
+  1312 Utah St., San Francisco, CA 94110
+  1657 Market St., San Francisco, CA 94103
+  30 Sycamore St., San Francisco, CA 94110
+  2697 Mission St., San Francisco, CA 94110
+  3308 Mission St., San Francisco, CA 94110
+  Notes: RSN transitional housing requires a referral from SFAPD, Superior Court, or the SF Sheriff’s Department.  Appointments preferred.
+:name: Recovery Survival Network (RSN)   Family of Friends Sober Living Network
+:phone: "(415) 552-1111"
+:services:
+- Stabilization Housing
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occuring Disorder/Dual Diagnosis Treatment
+- Anger management
+- Community Education & Mediation
+- Intensive Case Management
+- Individual Counseling/Therapy (Peer-to-Peer only)
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Restorative Justice/Survivor Impact
+- Employment Training
+- Employment Placement
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Family Reunification
+- Visits of Family Members in Jails & Prisons
+- Referrals to other resources available as needed
+:url: www.rsn2000.org
+:what_to_bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance.
+  Program will assist entering clients in getting these.

--- a/organizations/recovery-survival-network-rsn-family-of-friends-sober-living-network.yml
+++ b/organizations/recovery-survival-network-rsn-family-of-friends-sober-living-network.yml
@@ -62,3 +62,5 @@
 :url: www.rsn2000.org
 :what_to_bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance.
   Program will assist entering clients in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/redwood-gospel-mission-men-s-shelter-and-women-s-shelter.yml
+++ b/organizations/redwood-gospel-mission-men-s-shelter-and-women-s-shelter.yml
@@ -45,3 +45,5 @@
 - Money Management/Personal Financial Education)
 :url: www.srmission.org/index.php
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/redwood-gospel-mission-men-s-shelter-and-women-s-shelter.yml
+++ b/organizations/redwood-gospel-mission-men-s-shelter-and-women-s-shelter.yml
@@ -1,0 +1,47 @@
+---
+:accessibility: Limited Accommodations.
+:address: 101 6th Street, Santa Rosa, CA, 95401
+:contact_name: ''
+:description: The Redwood Gospel Mission offers a men's emergency shelter.  The Men's
+  Mission is for men experiencing homelessness. There is a Transitional Savings Program,
+  where guests can remain at the Mission for six months to save money while they put
+  their lives back together and form a plan to leave homelessness behind. The Redwood
+  Gospel also offers an emergency shelter for women.  The Rose serves women with children
+  (girls of all ages, boys ages 11 and under) experiencing homelessness  There is
+  a Transitional Savings Program, where guests can remain at the Rose for six months
+  to save money while they put their lives back together and learn the skills necessary
+  to put homelessness behind them.
+:eligible_population: Must be at least 18 years old to receive services, unless emancipated.
+:email: 
+:faith_based: Yes.
+:fax: 
+:fees: None
+:languages:
+- NA
+:miscellaneous: |-
+  Contact Person:
+  Men’s Mission
+  Intake/ Richard Sundahl
+  The Rose (Women’s Shelter)
+  Intake/ Chris Keys
+  Hours: 24 Hours/day
+  Notes: Drop-ins welcome.
+:name: Redwood Gospel Mission   Men’s Shelter and Women’s Shelter
+:phone: "(707) 542-4817"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Local Phone
+- Shower Facilities
+- Mental Health Treatment
+- Medical Care
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education)
+:url: www.srmission.org/index.php
+:what_to_bring: 

--- a/organizations/reentry-today.yml
+++ b/organizations/reentry-today.yml
@@ -21,3 +21,5 @@
 :url: ''
 :what_to_bring: No documents needed prior to entry. Program will assist with documentation
   after intake.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/reentry-today.yml
+++ b/organizations/reentry-today.yml
@@ -1,0 +1,23 @@
+---
+:accessibility: 
+:address: 1094 Gilman Street, San Francisco, CA 94124
+:contact_name: Chris Jones
+:description: Transitional housing and supportive services for people in recovery
+  from substance abuse/addiction.
+:eligible_population: All individuals and family members.
+:email: cj122252@yahoo.com
+:faith_based: No.
+:fax: "(415) 658-7592"
+:fees: "$700/month"
+:languages:
+- English
+:miscellaneous: "Hours: Monday – Friday, 9:00am-5:00pm\nNotes: No referral needed.
+  Appointment required.\nDirect Services:\t Transitional Housing; Anger Management;
+  Individual Counseling, Relapse Prevention; Substance Abuse Treatment; Job Readiness.
+  \ Referrals to other resources available as needed."
+:name: Reentry Today
+:phone: "(415) 724-0311"
+:services: []
+:url: ''
+:what_to_bring: No documents needed prior to entry. Program will assist with documentation
+  after intake.

--- a/organizations/renaissance-entrepreneurship-center.yml
+++ b/organizations/renaissance-entrepreneurship-center.yml
@@ -29,3 +29,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/renaissance-entrepreneurship-center.yml
+++ b/organizations/renaissance-entrepreneurship-center.yml
@@ -1,0 +1,31 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 275 5th Street, San Francisco, CA 94103
+:contact_name: April Gilbert, Program Director (SOMA)
+:description: Our goal is to assist re-entry clients explore entrepreneurship, because
+  we understand that it is hard to get a job once you have a record.  rencenter.org
+:eligible_population: All individuals.
+:email: agilbert@rencenter.org
+:faith_based: No.
+:fax: "(415) 541-8589"
+:fees: Sliding Scale.  Varied depending on program.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Orientations offered twice monthly.  Call for details.
+:name: Renaissance Entrepreneurship Center
+:phone: "(415) 541-8580"
+:services:
+- Business Planning
+- Start-up Training
+- Business Marketing Training
+- Mentorship
+- Credit Repair
+- Life Skills
+- Money Management/Personal Financial Education
+- Employment Law
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/rosen-bien-galvan-grunfeld-llp.yml
+++ b/organizations/rosen-bien-galvan-grunfeld-llp.yml
@@ -25,3 +25,5 @@
 - Litigation
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/rosen-bien-galvan-grunfeld-llp.yml
+++ b/organizations/rosen-bien-galvan-grunfeld-llp.yml
@@ -1,0 +1,27 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: 
+:description: Rosen, Bien, Galvan & Grunfeld LLP has a unique practice blending public
+  interest and private sector litigation.  The firm represents individuals and companies
+  in complex trial and appellate litigation
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: "(415) 433-7140"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  in state and federal courts.  Practice areas include:  Constitutional and civil rights; class action; work-place disputes in cases of discrimination, harassment, wrongful termination, non-competition agreements and wage and hour enforcement; commercial litigation. www. rbgg.com
+  Hours: Monday –Friday, 8:30am-5:30pm
+  Mailing Address: PO Box 390, San Francisco, CA 94104-0390
+  Notes: No dop-ins.  Clients seen by appoinmnet only.
+:name: Rosen, Bien, Galvan & Grunfeld LLP
+:phone: "(415) 433-6830"
+:services:
+- Legal Representation
+- Litigation
+:url: ''
+:what_to_bring: 

--- a/organizations/rubicon-programs-financial-opportunity-center.yml
+++ b/organizations/rubicon-programs-financial-opportunity-center.yml
@@ -35,3 +35,5 @@
 - Referrals to other services as appropriate
 :url: www.rubiconprograms.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/rubicon-programs-financial-opportunity-center.yml
+++ b/organizations/rubicon-programs-financial-opportunity-center.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible
+:address: 101 Broadway, Richmond, CA  94808
+:contact_name: Rubicon Main Line
+:description: Rubicon’s mission is to transform East Bay communities by equipping
+  low-income people to break the cycle of poverty. Rubicon finds support that’s right
+  for each individual – a personalized, comprehensive collection of services that
+  includes job placement, housing, legal services, and financial literacy. We place
+  low-income East Bay residents in jobs and housing and get them access to legal services
+  and healthcare.
+:eligible_population: Homeless, AB109 and Second Chance Probation, and Parents returning
+  home within last 180 days
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday-Thursday: 8:30-5:00pm Friday: 8:30-12:00pm
+  Notes: Please call for upcoming Information Session and enrollment dates. If you are supervised underAB109 or Second Chance probation, please contact your assigned Officer for a referral.
+:name: Rubicon Programs   Financial Opportunity Center 
+:phone: "(510) 412-1725"
+:services:
+- Employment Readiness
+- Financial Literacy and Income Support
+- Healthcare Enrollment
+- Housing Assistance
+- Vocational Training Placement
+- Job Placement
+- Parenting (partner on-site)
+- Anger Management (partner on-site), Education (literacy and GED services partner
+  on-site), VITA Tax Preparation services
+- Referrals to other services as appropriate
+:url: www.rubiconprograms.org
+:what_to_bring: 

--- a/organizations/saint-john-s-program-for-real-change.yml
+++ b/organizations/saint-john-s-program-for-real-change.yml
@@ -52,3 +52,5 @@
 :url: www.valleyrecoveryca.com
 :what_to_bring: CA ID, Social Security Card, Program will assist clients getting these
   documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/saint-john-s-program-for-real-change.yml
+++ b/organizations/saint-john-s-program-for-real-change.yml
@@ -1,0 +1,54 @@
+---
+:accessibility: ADA Compliant.
+:address: 'P.O. Box 2443, Fair Oaks Blvd. #369, Sacramento, CA 95825'
+:contact_name: Intake
+:description: We provide more than shelter and food. We provide the ability to rise
+  above devastating, negative elements and achieve job-readiness and self-sustainability.
+  Entry into the program is limited, and each step is extremely rigorous. But those
+  who see it through end up with rewarding, happy, and productive lives – for themselves,
+  and for their children. saintjohnsprogram.org
+:eligible_population: Women at least 18 years of age and women with children.
+:email: dburke@summitbhc.com
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: 8:00am-5:00pm
+  Notes: No drop-ins.  We maintain a waitlist so please call for information.
+  Client fees: None
+  Direct Service: Emergency Shelter; Transitional Housing;  Access to Internet; Food/Prepared Meals; Hygiene/Personal Care Items; Childcare; Job Readiness Training; Transitional Employment; Job Placement; Education and GED Certification; Shower Facilities; Substance Abuse Treatment; Domestic Violence Counseling; Medical Care. Referrals to other resources available as needed.
+  Valley Recovery Center of California
+  At Valley Recovery Center, we believe that a healthy recovery plan involves both the client and the family in conjunction with a strong continuing of care plan. We tailor our approach to each client by identifying his or her particular needs and creating a specific, individualized treatment plan. www.valleyrecoveryca.com
+  Hours: 24 Hour residential program.
+  Notes: Call to speak with an admissions counselor for a screening and assessment. We are JHACO/by the joint commission. www.valleyrecoverycalifornia.com.
+  We accept private insurance/Private Pay with payment options. EAP and managed care. Obama care, workman’s comp cases.
+  Client fees: We accept private insurance/Private Pay with payment options. EAP and managed care. Obama care, workman’s comp cases.
+  Direct Service: Substance Abuse Treatment; Residential Treatment; Medically Managed Detox; Dual Diagnosis Residential Treatment.  Referrals to other resources available as needed.
+  Volunteers of America   Men’s A Street Shelter
+  Volunteers of America of Sacramento offers emergency shelter to men.  The length of stay at our shelter is 30 days plus two 30 day extensions for a total of 90 days.  We also offer referrals for additional housing options.   www.voa.org
+  Intake Hours: 8:00pm-6:00am
+  Notes: Must be at location by 8:00pm.  Beds are filled on a first come, first served, basis.  For other services call (916) 265-3400.
+  Client fees: None
+  Direct Service: Emergency Shelter; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities. Referrals to other resources available as needed.
+  Alpha Project   Homeless Services
+  Alpha Project’s mission is to empower individuals, families, and communities by providing work, recovery, housing and support services to people who are motivated to change their lives and achieve self-sufficiency. With a tax deductible donation, you may choose which program you would like to contribute to. Each and every program we offer provides hope, opportunities, and new beginnings to those that are less fortunate.   Alpha Project offers emergency shelter, transitional housing, residential substance abuse treatment and other services. www.alphaproject.org
+  Main Office Phone: (619) 542-1877
+  Hours: Monday-Friday, 9:00am to 5:00pm
+  Locations:  3737 Fifth Avenue, San Diego, CA  92103
+  Notes: Winter Shelter (619) 542-1877; Supportive Housing (619) 696-6500; Transitional Housing (619) 542-1877; No drop-ins, please call for appointment and info on other programs.
+  Client fees: None.
+:name: Saint John’s Program for Real Change
+:phone: "(916) 453-1482"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Substance Abuse Treatment
+- Transitional Employment
+- Supportive Housing
+- Referrals to other resources available as needed
+:url: www.valleyrecoveryca.com
+:what_to_bring: CA ID, Social Security Card, Program will assist clients getting these
+  documents.

--- a/organizations/salvation-army-adult-rehabilitation-center.yml
+++ b/organizations/salvation-army-adult-rehabilitation-center.yml
@@ -30,3 +30,5 @@
 - Life Skills
 :url: bakersfield.satruck.org/rehabilitation-program
 :what_to_bring: State-Issued ID, Social Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/salvation-army-adult-rehabilitation-center.yml
+++ b/organizations/salvation-army-adult-rehabilitation-center.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: No.
+:address: 200 19th St, Bakersfield CA 99301
+:contact_name: Brian Austin
+:description: The Salvation Army’s Adult Rehabilitation Centers provide spiritual,
+  social and emotional assistance for men and women who have lost the ability to cope
+  with their problems and provide for themselves.  Each center offers residential
+  housing, work, and group and individual therapy, all in a clean, wholesome environment.
+  The physical and spiritual care that program participants receive prepares them
+  to re-enter society and return to gainful employment. Many of those who have been
+  rehabilitated are reunited with their families and resume a normal life.
+:eligible_population: Must be an adult male and healthy enough to work. Drug & Alcohol
+  Free Environment. No SSI, Unemployment, or Disability Recipients.
+:email: brian.austin@usw.salvationarmy.org
+:faith_based: Yes.
+:fax: 
+:fees: None.
+:languages:
+- English
+:miscellaneous: 'Notes: No referrals needed. Drop-ins allowed. Minimum 6 month program.'
+:name: Salvation Army   Adult Rehabilitation Center
+:phone: "(800) 728-7825 or (661) 325-8626 ext. 138"
+:services:
+- Residential Treatment
+- Employment Training
+- Therapy
+- Clothing
+- Hygiene/Personal Care Items
+- Food/Prepared Meals
+- Life Skills
+:url: bakersfield.satruck.org/rehabilitation-program
+:what_to_bring: State-Issued ID, Social Security Card.

--- a/organizations/san-diego-rescue-mission-residential-treatment-transitional-housing-emergency-shelter-for-men-women-a.yml
+++ b/organizations/san-diego-rescue-mission-residential-treatment-transitional-housing-emergency-shelter-for-men-women-a.yml
@@ -1,0 +1,46 @@
+---
+:accessibility: Wheelchair  and other disabilities accommodated.
+:address: 
+:contact_name: Main Office
+:description: Since 1955 San Diego Rescue Mission has helped restore hope for San
+  Diego’s homeless, hungry, addicted, and abused individuals. The Rescue Mission’s
+  comprehensive programs meet basic needs, then go further. With God’s grace and the
+  kindness and generosity of San Diegans, we dedicate ourselves every day to finding
+  long-term solutions to the problem of homelessness. 
+:eligible_population: All individuals 18 years of age or older, Mothers with children
+  (children up to age 16—for emergency shelter), for the woman and children center
+  (children up to age 12).
+:email: sdrminfo@sdrescue.org
+:faith_based: Yes.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Men's Center:
+  Michael Castaneda (619) 818-1826
+  Women & Children's Center: 
+  Crystal Robinson (619) 819-1807
+  2nd Ave. Transitional Housing: 
+  Stephanie Rimer (619) 819-1722
+  Recuperative Care Unit: 
+  Chris Cessna (619) 819-1760
+  Nueva Vida Haven: 
+  Karen Keith (619) 819-1845
+  Hours: Office Hours:  Monday-Friday, 9:00am to 5:00pm; Shelter Hours:  24 hrs/7 days a week
+  Address:  PO Box 80427, San Diego, CA 92138.
+  Notes: No referral needed.  Please call for information.
+      
+  Client fees: Emergency shelter (No Fee); Transitional Housing (Sliding Scale).
+:name: San Diego Rescue Mission   Residential Treatment/Transitional Housing/Emergency
+  Shelter for Men, Women and Children
+:phone: "(619) 687-3720"
+:services:
+- Emergency Shelter
+- Transitional Housing
+- Substance Abuse Treatment
+- Recovery for homeless after hospitalization
+- " Referrals to other resources available as needed"
+:url: www.sdrescue.org/
+:what_to_bring: CA ID, Social Security Card are helpful but not required.

--- a/organizations/san-diego-rescue-mission-residential-treatment-transitional-housing-emergency-shelter-for-men-women-a.yml
+++ b/organizations/san-diego-rescue-mission-residential-treatment-transitional-housing-emergency-shelter-for-men-women-a.yml
@@ -44,3 +44,5 @@
 - " Referrals to other resources available as needed"
 :url: www.sdrescue.org/
 :what_to_bring: CA ID, Social Security Card are helpful but not required.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-behavioral-health-access-center-bhac-community-behavioral-health-services-department-of.yml
+++ b/organizations/san-francisco-behavioral-health-access-center-bhac-community-behavioral-health-services-department-of.yml
@@ -1,0 +1,79 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1380 Howard Street, 1st Floor, San Francisco, CA 94103
+:contact_name: Maisha Bolden
+:description: The Behavioral health Access Center (BHAC) acts as an entry point into
+  the substance abuse and mental health system-of-care in San Francisco.  BHAC can
+  assess and authorize placement into different levels of care, depending on need.  Services
+  include residential treatment, intensive outpatient services, outpatient services,
+  and other services that assist in reducing barriers to care.  Residents of San Francisco
+  are eligible for services at BHAC.
+:eligible_population: All adults.
+:email: help@aasf.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Translation services available upon request
+:miscellaneous: |-
+  For substance abuse or mental health treatment referrals, call (415) 503-4730 or toll free 1-800-750-2727.
+  Languages: English, Spanish, Tagalog, Cantonese, Mandarin, Arabic, Japanese, Vietnamese.
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  California HIV/AIDS Hotline
+  If you have a question about HIV/AIDS or STDs, call the California HIV/AIDS hotline. A trained phone counselor is available to help you in English or in Spanish.
+  Toll Free in California:
+  (800) 367-AIDS (2437)
+  (888) 225-AIDS (2437) (TTY)
+  In San Francisco and outside California:
+  (415) 863-AIDS (2437)
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  (until 9:00pm on Tuesdays)
+  Website: www.aidshotline.org
+  Mailing Address:
+  California AIDS Hotline
+  995 Market Street, #200
+  San Francisco, CA  94103
+  Email Address:
+  Contact-us@AIDSHotline.org
+  Direct Services:
+  Alcoholics Anonymous
+  Alcoholics Anonymous is a fellowship of men and women who share their experience, strength and hope with each other that they may solve their common problem and help others to recover from alcoholism. The only requirement for membership is a desire to stop drinking. There are no fees, and there are more than 700 meetings in the area. A complete listing is available at www.aasf.org or through the Intercounty Fellowship of Alcoholics Anonymous:
+  (415) 674-1821 (from SF)
+  (415) 499-0400 (from Marin)
+  Mobile Devices: www.aasf.org/m
+  San Francisco, CA  94109
+  Oficina Central Hispana:
+  (415) 554-8811
+  Direct Services:
+  Narcotics Anonymous
+  Narcotics Anonymous makes no distinction between drugs, including alcohol. Membership is free, and the group is not affiliated with any organizations outside of NA. Some meetings have specific focuses or may be particularly appropriate for certain people. Meeting schedules, information on wheelchair accessibility, and special foci, are available online, at www.sfna.org/meeting_schedule.html, and by calling the NA Helpline, (415) 621-8600.
+  Mailing Address:
+  San Francisco Area of Narcotics Anonymous
+  Area Service Office
+  The West Bay Conference Center
+  1290 Fillmore Street #B
+  San Francisco, CA 94115
+  Help Line Phone Number: (415) 621-8600
+  Website: www.sfna.org
+  Direct Services:
+  Food Addicts in Recovery Anonymous (FA)
+  Food Addicts in Recovery Anonymous (FA) is a twelve step program offering a solution for anyone suffering from any form of food addiction including overheating, bulimia, under-eating or food obsession. There are over 30 meetings throughout the San Francisco Bay Area. For more information please visit our web-site at www.foodaddicts.org. 
+  E-mail: fa@foodaddicts.org
+  Direct Services:
+  Bayview Hunters Point Foundation for Community Improvement Substance Abuse Program
+  The mission is to build a community that is empowered, clean, safe and healthy. The Methadone Maintenance Program embraces the San Francisco Department of Public Health’s principles of harm reduction and cultural competency to provide the highest quality of treatment services for our clients. www.bayviewci.org
+  Specific Intake Days and Times: Monday, Wedensday, Friday 6:30am-9:30am
+  Hours: Monday – Friday, 6:00am to 2:00pm, Saturday and Sunday, 7:00am to 10:00am
+  Notes: No referral needed.
+:name: San Francisco Behavioral Health Access Center (BHAC), Community Behavioral
+  Health Services, Department of Public Health
+:phone: "(800) 600-6028"
+:services:
+- Methadone
+- Substance Abuse Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Group and Individual Counseling/Therapy
+:url: www.aidshotline.org
+:what_to_bring: State-issued ID; Social Security Card; Proof of SF Residency.

--- a/organizations/san-francisco-behavioral-health-access-center-bhac-community-behavioral-health-services-department-of.yml
+++ b/organizations/san-francisco-behavioral-health-access-center-bhac-community-behavioral-health-services-department-of.yml
@@ -77,3 +77,5 @@
 - Group and Individual Counseling/Therapy
 :url: www.aidshotline.org
 :what_to_bring: State-issued ID; Social Security Card; Proof of SF Residency.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-conservation-corps.yml
+++ b/organizations/san-francisco-conservation-corps.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.sfcc.org
 :what_to_bring: Will assist individuals get the required documents for orientation.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-conservation-corps.yml
+++ b/organizations/san-francisco-conservation-corps.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 102 Fort Mason, San Francisco, CA  94123
+:contact_name: Jeff Bostic, Recruitment Manager
+:description: The San Francisco Conservation Corps (SFCC) is a non-profit job and
+  academic training organization serving young people ages 18-26.
+:eligible_population: All individuals and family members, ages 18-26.
+:email: jbostic@sfcc.org
+:faith_based: No.
+:fax: "(415) 771-4299"
+:fees: No fees.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 7:30am to 4:30pm
+  Notes: Weekly info/interview session every Tuesday at 2:30pm.
+:name: San Francisco Conservation Corps
+:phone: "(415) 928-7417 x310"
+:services:
+- Employment Placement
+- Assistance/Guidance Regarding Benefits (SSI, GA, TANF, etc
+- "); Counseling"
+- Employment Retention
+- Employment Training
+- High School Diploma
+- Help/Vouchers to Get State ID
+- Life Skills
+- Literacy/Basic Education
+- Mentoring
+- Transit Vouchers
+- Referrals to other resources available as needed
+:url: www.sfcc.org
+:what_to_bring: Will assist individuals get the required documents for orientation.

--- a/organizations/san-francisco-department-of-child-support-services.yml
+++ b/organizations/san-francisco-department-of-child-support-services.yml
@@ -27,3 +27,5 @@
 - Health Insurance Orders
 :url: www.sfgov.org/dcss
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-child-support-services.yml
+++ b/organizations/san-francisco-department-of-child-support-services.yml
@@ -1,0 +1,29 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 617 Mission Street, San Francisco, CA 94105
+:contact_name: Mary Mora, Child Support Officer/COAP Coordinator
+:description: Compromise of Arrears Program (COAP)
+:eligible_population: All individuals with an open child support case with child support
+  arrears owed to the State.
+:email: 
+:faith_based: No.
+:fax: "(415) 356-2773  Email: mary.mora@sfgov.org"
+:fees: None.
+:languages:
+- English
+- Spanish
+- Cantonese
+:miscellaneous: |-
+  The Department's mission is to empower parents to provide for the economic and medical support needs of their children. COAP is a program for eligible noncustodial parents to reduce past-due child support (arrears) debt owed to the State.  This debt is owed because the State supported the family while the dependent children were on public assistance (welfare) or in foster care.  If you qualify for COAP you may offer to pay an amount that is less than the full amount you owe.  Any reduction in your arrears and interest owed will be based on your income and assets.  Arrears may be paid in a lump sum or in monthly installments over 36 months, depending on the individual circumstances.  www.sfgov.org/dcss or www.facebook.com/sfdcss
+  Hours: Monday – Friday, 8:00am to 5:00pm
+  Notes: No referral needed. Drop-ins are welcome.
+:name: San Francisco Department of Child Support Services
+:phone: "(415) 356-2871"
+:services:
+- Intensive Case Management
+- Family Law
+- Establishment of Paternity
+- Child Support Orders
+- Health Insurance Orders
+:url: www.sfgov.org/dcss
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-child-support-services_dup.yml
+++ b/organizations/san-francisco-department-of-child-support-services_dup.yml
@@ -1,0 +1,31 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 
+:contact_name: George J. Smith, III Public Relations Assistant
+:description: Customer Service Outreach (Community & Jail Outreach Program)
+:eligible_population: All individuals with an open child support case. Any parent
+  of a minor child can open a case.
+:email: GeorgeJ.Smith@sfgov.org
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+- Cantonese
+:miscellaneous: |-
+  The Department's mission is to empower parents to provide for the economic needs of their children. The Community and Jail Outrech  Program holds workshops with various groups in the community, including treatment facilities, to educate and assist noncustodial parents with their child support cases, obligations and issues. The Jail Outreach Program assists incarcerated non-custodial parents with outstanding child support issues that arise as a result of their incarceration.  www.sfgov.org/dcss or www.facebook.com/sfdcss
+  FAX:  (415) 356-2773
+  Hours: Monday – Friday, 8:00am to 5:00pm
+  Locations: 617 Mission Street, San Francisco, CA 94105; 3120 Mission Street, San Francisco, CA 94110
+  Notes: No referral needed. Drop-ins are welcome.
+:name: San Francisco Department of Child Support Services
+:phone: "(415) 356-2950"
+:services:
+- Intensive Case Management
+- Outreach
+- Child Support Orders, Health Insurance Orders
+- Post-Incarceration Support
+- Family law
+:url: www.sfgov.org/dcss
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-child-support-services_dup.yml
+++ b/organizations/san-francisco-department-of-child-support-services_dup.yml
@@ -29,3 +29,5 @@
 - Family law
 :url: www.sfgov.org/dcss
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-child-support-services_dup_dup.yml
+++ b/organizations/san-francisco-department-of-child-support-services_dup_dup.yml
@@ -28,3 +28,5 @@
 - Education Regarding Child Support Obligations and Resources Available for Employment
 :url: www.sfgov.org/dcss
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-child-support-services_dup_dup.yml
+++ b/organizations/san-francisco-department-of-child-support-services_dup_dup.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 
+:contact_name: Tyrone Owens, Child Support Officer, C-NET Coordinator
+:description: Noncustodial Parent Employment & Training Program (C-NET)
+:eligible_population: An individual with an open child support case. Any parent of
+  a minor child can open a case.
+:email: tyrone.owens@sfgov.org
+:faith_based: No.
+:fax: "(415) 356-2774"
+:fees: None.
+:languages:
+- English
+- Spanish
+- Cantonese
+:miscellaneous: |-
+  The C-NET program was developed to assist custodial and noncustodial parents with resolving barriers to employment, parenting, and their child support obligations. www.sfgov.org/dcss or www.facebook.com/sfdcss
+  Hours: Monday - Friday, 7:00am to 4:00pm
+  Locations: 617 Mission Street, San Francisco, CA 94105; 3120 Mission Street, San Francisco, CA 94110
+  Notes: No referral needed. No appointment necessary. Drop-ins are welcome.
+:name: San Francisco Department of Child Support Services
+:phone: "(415) 356-2945"
+:services:
+- Access to Internet
+- Releases of Driver’s License or other professional licenses, if suspended due to
+  Child Support Enforcement Activities
+- Outreach
+- Education Regarding Child Support Obligations and Resources Available for Employment
+:url: www.sfgov.org/dcss
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-central-city-older-adult-clinic.yml
+++ b/organizations/san-francisco-department-of-public-health-central-city-older-adult-clinic.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 90 Van Ness Avenue, San Francisco, CA 94102
+:contact_name: Officer of the Day
+:description: Central City Older Adult Clinic provides mental health services to clients
+  60 years of age or older who reside in the Civic Center, South of Market, and the
+  Tenderloin areas of the city. Services include medication management, crisis intervention,
+  dual diagnosis treatment, consultation and case management services.
+:eligible_population: Men, Women, Transgender people, 60 years of age and older, who
+  live the South of Market or Tenderloin areas of San Francisco, or are homeless.
+:email: 
+:faith_based: No.
+:fax: "(415) 558-5959"
+:fees: 
+:languages:
+- English
+- Spanish
+- Tagalog
+- Cantonese
+:miscellaneous: |
+  Clinic Hours: Monday – Friday, 8:30am to 5:00pm
+  Notes: No referral needed. Drop-in.
+  Client fees: City and County Billing based on set fees – Medi-Care/Medi-Cal share of cost.
+:name: San Francisco Department of Public Health   Central City Older Adult Clinic
+:phone: "(415) 558-5900"
+:services:
+- Assistance Getting Drivers License or Other ID
+- Transit Vouchers
+- Mental Health Treatment
+- Substance Abuse Tratment for Co-occurring Disorder/Dual Diagnosis
+- Medical Care
+- Intensive Case Management
+- Individual and Group Counseling/Therapy (time-limited)
+- Anger Management
+- Outreach
+- Assistance with Assessment & Application for SSI
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-central-city-older-adult-clinic.yml
+++ b/organizations/san-francisco-department-of-public-health-central-city-older-adult-clinic.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-child-crisis-services.yml
+++ b/organizations/san-francisco-department-of-public-health-child-crisis-services.yml
@@ -31,3 +31,5 @@
 - Crisis Case Management Referrals to other resources available as needed
 :url: ''
 :what_to_bring: Clients must exhibit psychiatric emergencies.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-child-crisis-services.yml
+++ b/organizations/san-francisco-department-of-public-health-child-crisis-services.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 3801 Third Street, Building B, Suite 400, San Francisco, CA 94124
+:contact_name: 
+:description: To provide acute mobile psychiatric crisis evaluation and intervention
+  for children and youth in San Francisco, regardless of insurance, up to age 18.  We
+  are strongly committed to delivering family focused and consumer driven care, and
+  developing a safety network within San Francisco county.
+:eligible_population: All individuals up to age 18 who have psychiatric or mental
+  health emergencies.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Sliding scale. Accept MediCal, private insurance, Healthy Families, Healthy
+  Kids.
+:languages:
+- English
+- Spanish
+- Chinese
+- Taglog
+- Vietnamese
+- Other languages can  be accommodated
+:miscellaneous: |-
+  Hours: Monday - Thursday, 8:30am to 9:00pm; Friday, 8:30am to 7:00pm; After hours, on-call mobile team
+  Notes: No referral needed. Please call first.
+:name: San Francisco Department of Public Health   Child Crisis Services
+:phone: "(415) 970-3800"
+:services:
+- Psychiatric Inpatient Hospital Bed
+- Mental Health Treatment
+- Crisis Case Management Referrals to other resources available as needed
+:url: ''
+:what_to_bring: Clients must exhibit psychiatric emergencies.

--- a/organizations/san-francisco-department-of-public-health-chinatown-north-beach-mental-health-services.yml
+++ b/organizations/san-francisco-department-of-public-health-chinatown-north-beach-mental-health-services.yml
@@ -42,3 +42,5 @@
 :url: ''
 :what_to_bring: Medi-Cal card, Medicare card, Healthy San Francisco card or other
   insurance information, if applicable.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-chinatown-north-beach-mental-health-services.yml
+++ b/organizations/san-francisco-department-of-public-health-chinatown-north-beach-mental-health-services.yml
@@ -1,0 +1,44 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 729 Filbert Street, San Francisco, CA 94133
+:contact_name: On-Duty Clinician or “OD”
+:description: Chinatown North Beach Mental Health Services offers an array of outpatient
+  mental health services to adolescents, adults and older adults. Many clients served
+  are immigrants or refugee survivors of war. The program operates from the basic
+  philosophy that services need to be accessible and culturally appropriate. A harm
+  reduction approach is offered to help persons who have both substance abuse and
+  mental health issues. Goals are to help people in their recovery from psychiatric
+  illness, and co-occurring disorders when present, building on the strengths of the
+  individual and family and supporting persons to have productive lives in the community.
+:eligible_population: San Francisco resident
+:email: 
+:faith_based: No.
+:fax: "(415) 352-2050"
+:fees: 
+:languages:
+- English
+- Mandarin
+- Vietnamese
+- Cantonese
+:miscellaneous: |
+  Clinic Hours: Monday – Friday, 8:30am to 5:00pm; Drop-in hours Monday ­– Friday 9:00am to 11:00am; Wednesday and Friday 1:00pm to 3:00pm
+  Notes: No referral needed. Okay to drop-in.
+  Client fees: Sliding scale.
+:name: San Francisco Department of Public Health   Chinatown North Beach Mental Health
+  Services
+:phone: "(415) 352-2000"
+:services:
+- Assessment
+- Individual Therapy/Counseling
+- Clinical Case Management
+- Medication Services
+- Urgent Care
+- Crisis Outreach
+- Family intervention
+- Acupuncture
+- Group Services
+- Adult Socialization Program
+- Mental Health Services
+:url: ''
+:what_to_bring: Medi-Cal card, Medicare card, Healthy San Francisco card or other
+  insurance information, if applicable.

--- a/organizations/san-francisco-department-of-public-health-mission-mental-health.yml
+++ b/organizations/san-francisco-department-of-public-health-mission-mental-health.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: 
+:address: 2712 Mission Street, San Francisco, CA 94110
+:contact_name: Nora Zapata Krey, LCSW
+:description: Mission Mental Health is an outpatient mental health clinic that provides
+  services to adults age 18 and older.
+:eligible_population: Men, Women, Transgender people, 18 and older. Program does not
+  serve convicted sex offenders whose offense involved a child or minor.
+:email: 
+:faith_based: No.
+:fax: "(415) 401-2741"
+:fees: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients.
+  In some situations, clients may have a co-payment based on income or requirement
+  of their coverage provider.
+:languages:
+- English
+- Spanish
+- 'Accessibility: Wheelchair accessible'
+- Other disabilities area accommodated
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 11:00am.  Intakes are on a first come basis.
+  Notes: No referral needed. Drop-in during intake hours.
+:name: San Francisco Department of Public Health   Mission Mental Health
+:phone: "(415) 401-2700"
+:services:
+- Medication
+- Case Management
+- Harm Reduction Groups
+- Seeking Safety Groups
+- Dialectical Behavior Therapy Groups
+:url: ''
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-mission-mental-health.yml
+++ b/organizations/san-francisco-department-of-public-health-mission-mental-health.yml
@@ -30,3 +30,5 @@
 - Dialectical Behavior Therapy Groups
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-mobile-crisis-treatment-team.yml
+++ b/organizations/san-francisco-department-of-public-health-mobile-crisis-treatment-team.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: 
+:address: 
+:contact_name: 
+:description: To provide acute mobile psychiatric crisis evaluation and intervention
+  for adults in San Francisco, regardless of insurance.  We are strongly committed
+  to delivering family focused and consumer driven care, and developing a safety network
+  within San Francisco County.
+:eligible_population: All individuals over the age of 18 who have psychiatric or mental
+  health emergencies.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Sliding scale. Accept MediCal, private insurance
+:languages:
+- English
+- Spanish
+- Chinese
+- Taglog
+- Vietnamese
+- Other languages can  be accommodated
+:miscellaneous: |-
+  Hours: Monday - Friday, 8:30am to 11:00pm.  Saturday 12:00pm-8:00pm
+  Notes: No referral needed. Please call for assistance.
+:name: San Francisco Department of Public Health   Mobile Crisis Treatment Team
+:phone: "(415) 970-4000"
+:services:
+- Psychiatric Inpatient Hospital bed
+- Mental Health Treatment
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: Clients must exhibit psychiatric emergencies.

--- a/organizations/san-francisco-department-of-public-health-mobile-crisis-treatment-team.yml
+++ b/organizations/san-francisco-department-of-public-health-mobile-crisis-treatment-team.yml
@@ -30,3 +30,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: Clients must exhibit psychiatric emergencies.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-south-of-market-mental-health-services.yml
+++ b/organizations/san-francisco-department-of-public-health-south-of-market-mental-health-services.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities area accommodated.
+:address: South of Market Mental Health Services, 760 Harrison Street, San Francisco,
+  CA 94107
+:contact_name: Officer of the Day
+:description: 'The Department of Public Health focuses on disease prevention and health
+  promotion of communities throughout San Francisco. We work to achieve the vision
+  of healthy people in healthy communities by performing the following functions:
+  Employ a systematic approach to identify the health conditions and needs of communities;
+  Determine priorities, and develop policies and programs that address the health
+  conditions and needs of communities; Assure that quality health resources and services
+  are available to all San Francisco communities.'
+:eligible_population: Men, Women, Transgender people, 18 and older. Program does not
+  serve convicted sex offenders whose offense involved a child or minor.
+:email: 
+:faith_based: No.
+:fax: "(415) 836-1737"
+:fees: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients.
+  In some situations, clients may have a co-payment based on income or requirement
+  of their coverage provider.
+:languages:
+- English
+- Tagalog
+- Spanish
+- Cantonese
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 5:00pm. Intake on Monday, Tuesday, Thursday and Friday, 8:30am to 10:30am. Wednesday, 1:00pm to 2:30pm.
+  Notes: No referral needed. Drop-in during intake hours.
+:name: San Francisco Department of Public Health   South of Market Mental Health Services
+:phone: "(415) 836-1700"
+:services:
+- Mental Health Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Medical Care
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Assessment & Application for SSI
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-south-of-market-mental-health-services.yml
+++ b/organizations/san-francisco-department-of-public-health-south-of-market-mental-health-services.yml
@@ -39,3 +39,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-southeast-mission-geriatric-services.yml
+++ b/organizations/san-francisco-department-of-public-health-southeast-mission-geriatric-services.yml
@@ -30,3 +30,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-southeast-mission-geriatric-services.yml
+++ b/organizations/san-francisco-department-of-public-health-southeast-mission-geriatric-services.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities area accommodated.
+:address: 3905 Mission Street, San Francisco, CA 94112
+:contact_name: Front Desk
+:description: The goal of Southeast Mission Geriatric Services is to identify and
+  serve individuals 60 years and older who, without mental health intervention and
+  treatment, are at risk of hospitalization or institutionalization.
+:eligible_population: Individuals over the age of 60 who have several mental disorders
+  and those who are dually diagnosed who reside primarily but not exclusively in the
+  Southeast area of San Francisco.
+:email: 
+:faith_based: No.
+:fax: "(415) 337-2415"
+:fees: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients.
+  In some situations, clients may have a co-payment based on income or requirement
+  of their coverage provider.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 5:00pm.
+  Notes: No referral needed. Call in advance for appointment.
+:name: San Francisco Department of Public Health   Southeast Mission Geriatric Services
+:phone: "(415) 337-2400"
+:services:
+- Mental Health Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Case Management
+- In-Home and Clinic Based Intervention and Therapy
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-sunset-mental-health-clinic.yml
+++ b/organizations/san-francisco-department-of-public-health-sunset-mental-health-clinic.yml
@@ -33,3 +33,5 @@
 - Wellness and Recovery Program
 :url: ''
 :what_to_bring: Health insurance information and list of current medications.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-sunset-mental-health-clinic.yml
+++ b/organizations/san-francisco-department-of-public-health-sunset-mental-health-clinic.yml
@@ -1,0 +1,35 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities area accommodated.
+:address: 1990 41st Ave., San Francisco, CA 94116
+:contact_name: Jane Ma, LCSW or Officer of the Day
+:description: Sunset Mental Health Clinic welcomes individuals and families who request
+  assistance with mental health, substance abuse, and co-occurring disorders and to
+  ensure the provision of integrated, quality, linguistically-appropriate, culturally
+  competent services and support.
+:eligible_population: Residents of San Francisco who meet medical necessity.
+:email: 
+:faith_based: 'No'
+:fax: "(415) 753-0164"
+:fees: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and Healthy Worker.
+  Sliding scale for uninsured clients.
+:languages:
+- English
+- Cantonese
+- Mandarin
+- Russian
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 5:00pm. Drop-in hours 9:00am to 11:00am.
+  Notes: Best to call in for an appointment to avoid waiting.
+:name: San Francisco Department of Public Health   Sunset Mental Health Clinic
+:phone: "(415) 753-7400"
+:services:
+- Assessment
+- Crisis Intervention
+- Case Management
+- Individual Therapy
+- Medication Services
+- Group Therapy
+- Wellness and Recovery Program
+:url: ''
+:what_to_bring: Health insurance information and list of current medications.

--- a/organizations/san-francisco-department-of-public-health-transitional-youth-services.yml
+++ b/organizations/san-francisco-department-of-public-health-transitional-youth-services.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Intake Coordinator
+:description: Provide direct clinical services, including individual/group/family
+  therapy, medication monitoring and case management to mentally ill youth. TAY strives
+  to empower and educate youth to increase their level of independence and functioning.
+:eligible_population: Men, Women, Transgender people, 16-25 years old, including individuals
+  involved in the criminal justice system.
+:email: 
+:faith_based: No.
+:fax: "(415) 695-6961"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: 'Notes: No drop-ins. Please call for referral information.'
+:name: San Francisco Department of Public Health   Transitional Youth Services
+:phone: "(415) 642-4522"
+:services:
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/san-francisco-department-of-public-health-transitional-youth-services.yml
+++ b/organizations/san-francisco-department-of-public-health-transitional-youth-services.yml
@@ -28,3 +28,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-with-open-arms-a-second-chance-act-program.yml
+++ b/organizations/san-francisco-department-of-public-health-with-open-arms-a-second-chance-act-program.yml
@@ -59,3 +59,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: TB Clearance. Program will assist entering clients in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-department-of-public-health-with-open-arms-a-second-chance-act-program.yml
+++ b/organizations/san-francisco-department-of-public-health-with-open-arms-a-second-chance-act-program.yml
@@ -1,0 +1,61 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1735 Mission Street, San Francisco, CA 94103
+:contact_name: Program Director
+:description: With Open Arms, a San Francisco Initiative for Women, offers case management
+  services for women sentenced to state prison or county jail, including drug treatment,
+  mental health services, trauma recovery, housing, benefits enrollment, child reunificaiton,
+  child behavioral health assistance, job training and immediate placement, legal
+  assistance, continuing education opportunities, social support, and family strengthening
+  and empowerment. The program represents a collaborative effort by Healthright360,
+  Homeless Prenatal Program, Lawyers’ Committee for Civil Rights, SF Clean City, San
+  Francisco Adult Probation Department, and San Francisco Parole.
+:eligible_population: You may be eligible if you are a woman in SF County Jail who
+  has been sentenced to State Prison or to serve a local prison sentence under PC
+  § 1170(h)5(a) or (b); you are currently incarcerated in a state prison and will
+  be released to San Francisco on parole or post-release community supervision (PRCS);
+  you are currently on parole or PRCS in San Francisco. Transgender women welcome.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday-Friday, 8:00am to 4:30pm
+  Notes: May self refer, or be referred by parole, probation, or community based organization.
+:name: San Francisco Department of Public Health   With Open Arms a Second Chance
+  Act Program
+:phone: "(415) 449-0501"
+:services:
+- "(only for program participants) Transitional Housing"
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Shower Facilities
+- Storage Facilities
+- Transit Tokens
+- Health & Wellness Education
+- Case Management
+- Anger Management
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Vocational Education
+- Assessment & Application for Food Stamps, General Assistance, and SSI
+- Employment Training
+- Employment Placement
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Inmate & Parolee Legal Issues
+- Voting Outreach & Education
+- Family Reunification
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: TB Clearance. Program will assist entering clients in getting this.

--- a/organizations/san-francisco-human-services-agency-san-francisco-rental-assistance-program.yml
+++ b/organizations/san-francisco-human-services-agency-san-francisco-rental-assistance-program.yml
@@ -1,0 +1,27 @@
+---
+:accessibility: 
+:address: 
+:contact_name: Darlene Fernandez-Ash, Rental Assistance Coordinator
+:description: Provide back rent or security deposit to low income San Francisco residents
+  meeting criteria.
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: "(415) 557-6033"
+:fees: None.
+:languages: []
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Mailing Address: P.O. Box 7988, San Francisco, CA 94120, worker #ZB34
+  Notes: After verifying need and eligibility based on phone or mail inquiry, clients are referred to a community agency that can help them complete a rental assistance application. No drop-ins.
+  Primary Community Served: Low-income (80% AMI or below) families with minor children in their custody; adults (verifiably disabled, senior 55+), emancipated foster youth, veterans, victim of recent violence. Must be San Francisco resident.
+:name: San Francisco Human Services Agency   San Francisco Rental Assistance Program
+:phone: "(415) 557-6484"
+:services:
+- Assistance with back rent
+- security deposit
+- critical family needs
+- Referrals to other services as needed
+:url: www.sfhsa.org
+:what_to_bring: State-Issued ID; Social Security Card; Birth Certificates (for children);
+  Proof of Income; Lease Agreement; and other supporting documentation, as needed.

--- a/organizations/san-francisco-human-services-agency-san-francisco-rental-assistance-program.yml
+++ b/organizations/san-francisco-human-services-agency-san-francisco-rental-assistance-program.yml
@@ -25,3 +25,5 @@
 :url: www.sfhsa.org
 :what_to_bring: State-Issued ID; Social Security Card; Birth Certificates (for children);
   Proof of Income; Lease Agreement; and other supporting documentation, as needed.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-network-ministries-housing-corporation-san-francisco-safehouse.yml
+++ b/organizations/san-francisco-network-ministries-housing-corporation-san-francisco-safehouse.yml
@@ -62,3 +62,5 @@
 - Referrals to other resources available as needed
 :url: www.sfsafehouse.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-network-ministries-housing-corporation-san-francisco-safehouse.yml
+++ b/organizations/san-francisco-network-ministries-housing-corporation-san-francisco-safehouse.yml
@@ -1,0 +1,64 @@
+---
+:accessibility: 
+:address: Confidential location.
+:contact_name: Kristen Moore, Case Manager
+:description: SafeHouse is an 18-month transitional housing program for women; we
+  provide gender-specific responses to chronic homlessness for women in the commwercial
+  sex industry.  Our clean and sober living community tempowers homeless women exiting
+  prostitution gain the skills and resources they need to grow and become independent
+  and self-sufficient members of society. Services include case management, substance
+  abuse treatment, individual and group therapy, money management and financial education,
+  vocational testing and guidance and assistance in finding permanent housing when
+  leaving SafeHouse.
+:eligible_population: Women who are currently homeless, have a history of work in
+  the sex industry, and have been clean and sober for at least 30 days. May not have
+  a criminal conviction for arson or be a registered sex offender.
+:email: casemanager@sfsafehouse.org
+:faith_based: No.
+:fax: "(415) 643-1293"
+:fees: 30% of any government assistance and/or 20% of any earned income.
+:languages:
+- English
+:miscellaneous: |-
+  Facility Hours: 24 hours/7 days; Intake Monday – Friday, 8:00am to 5:00pm
+  Mailing Address:  P.O. Box 40369, San Francisco, CA  94140
+  Notes: Clients can self-refer, or be referred by a provider; if the program beds are full, SafeHouse maintains a waitlist, and contacts prospective clients for intake..
+:name: San Francisco Network Ministries Housing Corporation   San Francisco SafeHouse
+:phone: "(415) 643-7861"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Phone/Voicemail
+- Shower Facilities
+- Storage Facilities
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Dental Care
+- Health & Wellness Education
+- menu planning and nutritionist weekly
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Trauma Recovery Services
+- Victim/Survivor Services
+- Basic/Remedial Education
+- College & Graduate Education
+- GED & High School Education
+- Assessment & Application for Food Stamps, General Assistance, SSI
+- Credit Repair
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Internship Program
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.sfsafehouse.org
+:what_to_bring: 

--- a/organizations/san-francisco-office-of-citizen-complaints.yml
+++ b/organizations/san-francisco-office-of-citizen-complaints.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: '25 Van Ness Avenue, #700, San Francisco, CA  94002'
+:contact_name: 
+:description: The mission of the Office of Citizen Complaints is to promptly, fairly
+  and impartially investigate complaints of police misconduct. In addition to complaint
+  investigation, the office provides a volunteer mediation program, performs policy
+  analysis for recommendations to the Police Commission, and runs community outreach
+  efforts.
+:eligible_population: All individuals and family members who wish to make a complaint
+  regarding a sworn San Francisco Police Department officer.
+:email: 
+:faith_based: No.
+:fax: "(415) 241-7733"
+:fees: 
+:languages:
+- Spanish
+- Cantonese
+- Tagalog
+- Russian
+:miscellaneous: |-
+  Hours: Monday to Friday, 8:00am - 5:00pm
+  Notes: No referrals needed. Drop-ins allowed.
+:name: San Francisco Office of Citizen Complaints
+:phone: "(415) 241-7711"
+:services:
+- Mediation and Investigation of complaints against SF Police Officers
+- Referrals to other resources available as needed
+:url: www.sfgov3.org/index.aspx?page=419
+:what_to_bring: 

--- a/organizations/san-francisco-office-of-citizen-complaints.yml
+++ b/organizations/san-francisco-office-of-citizen-complaints.yml
@@ -28,3 +28,5 @@
 - Referrals to other resources available as needed
 :url: www.sfgov3.org/index.aspx?page=419
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-office-of-the-district-attorney-back-on-track-initiative.yml
+++ b/organizations/san-francisco-office-of-the-district-attorney-back-on-track-initiative.yml
@@ -32,3 +32,5 @@
 - referrals to other resources as needed
 :url: www.sfdistrictattorney.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-office-of-the-district-attorney-back-on-track-initiative.yml
+++ b/organizations/san-francisco-office-of-the-district-attorney-back-on-track-initiative.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 850 Bryant Street, 3rd Floor, San Francisco, CA  94103
+:contact_name: Ranon Ross, Back on Track Manager
+:description: The San Francisco District Attorney’s Back on Track Initiative is a
+  court-driven program for offenders ages 18-30 who are charged with their first adult
+  felony drug sales offense.   Defendants accepted into Back on Track spend a minimum
+  of one year attending progress hearings and commit to complete community service,
+  obtain their high school diploma/GED, and find employment.  We partner with Criminal
+  Justice Specialists at Goodwill Industries, who both monitor individuals’ progress
+  and assist with job training, job placement and other critical supports.  Successful
+  participants have their cases dismissed and arrest records sealed.
+:eligible_population: Young adults in the criminal justice system. There are additional
+  requirements; please call for more information.
+:email: ranon.ross@sfgov.org
+:faith_based: No.
+:fax: "(415) 553-9700"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |2-
+   www.sfdistrictattorney.org
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: Referrals are required for program; call for referrals.
+
+  Client fees: None.
+:name: San Francisco Office of the District Attorney   Back on Track Initiative
+:phone: "(415) 553-9665"
+:services:
+- Referrals into Back on Track program
+- referrals to other resources as needed
+:url: www.sfdistrictattorney.org
+:what_to_bring: 

--- a/organizations/san-francisco-office-of-the-district-attorney-victim-services-division.yml
+++ b/organizations/san-francisco-office-of-the-district-attorney-victim-services-division.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 850 Bryant Street, 3rd Floor, San Francisco, CA  94103
+:contact_name: Jackie Ortiz
+:description: The Victim Services Division of the District Attorney’s Office provides
+  comprehensive advocacy and support to victims of crime and witnesses to crime. Our
+  Victim Advocates provide services in English, Cantonese, Mandarin, Spanish, and
+  Vietnamese. We start by assessing each victim’s needs.  This can mean crisis intervention,
+  counseling, accompanying a victim to court, assistance with victim compensation,
+  making funeral arrangements, intervening with employers and creditors when victims
+  cannot work, and providing many other services needed to restore a crime victim’s
+  life.  Our Victim Services staff is diverse and committed to providing culturally
+  competent services.
+:eligible_population: Victims of crime; victims’ family members; witnesses to crime
+:email: jacqueline.ortiz@sfgov.org
+:faith_based: No.
+:fax: "(415) 553-9700"
+:fees: None.
+:languages:
+- English
+- Cantonese
+- Mandarin
+- Spanish
+- ''
+- Vietnamese; other translation available
+:miscellaneous: |
+  Hours: Monday – Friday 9:00 am – 5:00 pm
+  Notes: Individuals who are currently on probation or parole are not eligible to receive
+  State Victim Compensation Funds during the period of their probation or parole.
+:name: San Francisco Office of the District Attorney   Victim Services Division
+:phone: "(415) 553-9044"
+:services:
+- Assistance with "Victim Compensation Program" claims
+- crisis intervention and emergency assistance
+- help navigating the criminal justice system
+- resources and referrals
+- restitution and property return
+- witness relocation
+- transportation
+- and more
+:url: www.sfdistrictattorney.org
+:what_to_bring: 

--- a/organizations/san-francisco-office-of-the-district-attorney-victim-services-division.yml
+++ b/organizations/san-francisco-office-of-the-district-attorney-victim-services-division.yml
@@ -40,3 +40,5 @@
 - and more
 :url: www.sfdistrictattorney.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-office-of-the-public-defender-clean-slate-program.yml
+++ b/organizations/san-francisco-office-of-the-public-defender-clean-slate-program.yml
@@ -46,3 +46,5 @@
 :what_to_bring: Must obtain copy of RAP Sheet from Identification Bureau, Hall of
   Justice, 850 Bryant Street, Room 475, San Francisco, CA 94103 (can request by mail
   or in person, Monday – Friday, 8:00am-3:00pm).
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-office-of-the-public-defender-clean-slate-program.yml
+++ b/organizations/san-francisco-office-of-the-public-defender-clean-slate-program.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: San Francisco, CA 94103
+:contact_name: 
+:description: Clean Slate is a program of the San Francisco Public Defender’s Office
+  that can help people “clean up” their criminal records.
+:eligible_population: All people with a criminal arrest and/or conviction, or juvenile
+  matter, from the County of San Francisco. Do not need to be a former client of the
+  Public Defender, but must meet financial eligibility criteria.
+:email: 
+:faith_based: 
+:fax: "(415) 553-9646"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Clean Slate Phone: (415) 553-9337
+  Main Phone: (415) 553-1671
+  Application: Applicants must complete the one-page “Clean Slate Program Application” which can be obtained at the Public Defender’s office or by viewing the website: www.sfpublicdefender.org. Applicants will also need a copy of their RAP sheet, available from the SFPD Identification Bureau for free. Send applications to:
+  PUBLIC DEFENDER’S OFFICE
+  Attn: Clean Slate Program
+  555 Seventh Street, 2ndFloor
+  San Francisco, CA 94103
+  Notes: No appointment required. Walk-in clinics are listed below:
+  Client fees: None.
+  Free Walk-in Clinic Hours and Locations:
+  2nd and 4th Monday of the month, 10:30am-12:30pm: Arriba Juntos, 1850 Mission St. (English and Spanish)
+  Every Tuesday, 9am-11am: Office of the Public Defender, 555 Seventh St.
+  4th Wednesday of the month, 3pm-5pm: Village Community Center, 1099 Sunnydale Ave.
+  1st Thursday of the month, 9am-11am: Southeast Community Center, 1800 Oakdale Ave.
+  1st Thursday of the month, 9am-11am: Ella Hill Hutch Community Center, 1050 McAllister Street, SF
+  1st and 3rd Monday of the month: 10am-11am, Community Justice Center, 555 Polk St., 2nd Floor
+:name: San Francisco Office of the Public Defender   Clean Slate Program
+:phone: 
+:services:
+- Dismissal of convictions
+- Prop 47 reductions
+- seal and destroy arrest records (subject to capacity limits)
+- Certificate of Rehabilitation
+- early termination of probation
+- and reduction of felony conviction to misdemeanor
+- Representation at court dates
+- Referrals to other services as appropriate
+:url: http://sfpublicdefender.org/services/clean-slate/
+:what_to_bring: Must obtain copy of RAP Sheet from Identification Bureau, Hall of
+  Justice, 850 Bryant Street, Room 475, San Francisco, CA 94103 (can request by mail
+  or in person, Monday – Friday, 8:00am-3:00pm).

--- a/organizations/san-francisco-office-of-the-public-defender-reentry-unit.yml
+++ b/organizations/san-francisco-office-of-the-public-defender-reentry-unit.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 555 Seventh Street, San Francisco, CA 94103
+:contact_name: Simin Shamji, Manager of Reentry Unit
+:description: Children of Incarcerated Parents Social Worker and Adult Social Workers
+  work with current and former clients of the Public Defender.
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: "(415) 553-9810"
+:fees: None.
+:languages:
+- English
+- Spanish
+- ''
+- other languages accommodated as needed
+:miscellaneous: |-
+  Specific Intake Days and Times:
+  Hours: Monday – Friday, 8:00am to 5:00pm
+  Notes: Referral required from Public Defender Attorney. By appointment only.
+:name: San Francisco Office of the Public Defender   Reentry Unit
+:phone: "(415) 553-1671"
+:services:
+- Assistance with access to Benefits (SSI, GA, TANF, et al)
+- Accompany to Court Dates
+- Counseling
+- Parenting Support
+- Help/Vouchers to Get State ID, etc
+- "; Legal Assistance/Advocacy"
+- Referrals to Treatment, Housing, Medical and Other Services
+:url: www.sfpublicdefender.org
+:what_to_bring: 

--- a/organizations/san-francisco-office-of-the-public-defender-reentry-unit.yml
+++ b/organizations/san-francisco-office-of-the-public-defender-reentry-unit.yml
@@ -30,3 +30,5 @@
 - Referrals to Treatment, Housing, Medical and Other Services
 :url: www.sfpublicdefender.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-pretrial-diversion-inc-court-accountable-homeless-services-cahs.yml
+++ b/organizations/san-francisco-pretrial-diversion-inc-court-accountable-homeless-services-cahs.yml
@@ -32,3 +32,5 @@
 - Referrals to other resources available as needed
 :url: www.sfpretrial.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-pretrial-diversion-inc-court-accountable-homeless-services-cahs.yml
+++ b/organizations/san-francisco-pretrial-diversion-inc-court-accountable-homeless-services-cahs.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 115 10th St., San Francisco, CA 94103
+:contact_name: 
+:description: To continually strive to provide the highest quality of pre- and post-release
+  court alternatives.  Providing Court-referred clients with immediate access to services
+  while maintaining a strong awareness of community safety and restorative justice.
+:eligible_population: Individuals, 18 and older, referred by Superior Court
+:email: 
+:faith_based: No.
+:fax: "(415) 626-3871"
+:fees: None.
+:languages:
+- English
+- Spanish
+- ''
+- Chinese
+- Additional languages served by interpreter
+:miscellaneous: |-
+  Hours: Monday-Friday, 8:30am-5:00pm
+  Notes: Superior Court referral needed. Once referred, clients may drop in.
+:name: San Francisco Pretrial Diversion, Inc.   Court Accountable Homeless Services
+  (CAHS)
+:phone: "(415) 626-4995"
+:services:
+- Clients with severe mental health issues are provided with close monitoring of mental
+  health treatment and medication compliance
+- Anger Management
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Post-Incarceration Support
+- Referrals to other resources available as needed
+:url: www.sfpretrial.com
+:what_to_bring: 

--- a/organizations/san-francisco-public-library-project-read.yml
+++ b/organizations/san-francisco-public-library-project-read.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.projectreadsf.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-public-library-project-read.yml
+++ b/organizations/san-francisco-public-library-project-read.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: Project Read -- Main Library 5th Floor, 100 Larkin St.  SF, CA 94102
+:contact_name: 
+:description: Our mission is to provide free instruction for English-speaking adults
+  (18 or older) who want to improve their basic reading and writing skills, thereby
+  enabling access to great opportunities in their lives.   www.sfpl.org
+:eligible_population: stable housing, working phone, 90 days clean and sober, over
+  18 years of age.
+:email: projectread@sfpl.org
+:faith_based: No.
+:fax: "(415) 557-4375"
+:fees: No fees.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday: 10am-6pm; Tuesday - Thursday 9am-8pm; Friday: 12pm to 6pm; Saturday 10am-6pm
+  Notes: No referral needed. Drop-ins for interview allowed. Further appointments will be scheduled.
+:name: San Francisco Public Library   Project Read
+:phone: "(415) 557-4388"
+:services:
+- Access to Internet
+- Mentorship
+- Outreach
+- Basic/Remedial Education
+- GED & High School Education
+- Reading/Literacy
+- Money Management/Personal Financial Education
+- Voting Outreach & Education
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.projectreadsf.org
+:what_to_bring: 

--- a/organizations/san-francisco-sheriff-s-department-community-programs.yml
+++ b/organizations/san-francisco-sheriff-s-department-community-programs.yml
@@ -38,3 +38,5 @@
   intervention program
 :url: www.sfsheriff.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-sheriff-s-department-community-programs.yml
+++ b/organizations/san-francisco-sheriff-s-department-community-programs.yml
@@ -1,0 +1,40 @@
+---
+:accessibility: Wheelchair accessible, first floor only. Limited service to vision-impaired.
+:address: 70 Oak Grove Street, San Francisco, CA 94107
+:contact_name: 
+:description: The San Francisco Sheriff’s Department established the Community Programs
+  to provide educational, vocational, substance abuse treatment, and batterers’ intervention
+  classes, as well as a variety of specialized services designed to help ex-offenders
+  successfully reenter the community. The goal is to achieve successful community
+  reintegration on all levels. We nurture ongoing collaborations with a wide range
+  of community-based agencies to help address the needs of the clients. Further, clients
+  are provided the opportunity to participate in the Five Keys Charter School.
+:eligible_population: All individuals, ages 18 and older.
+:email: 
+:faith_based: No.
+:fax: "(415) 575-6451"
+:fees: None.  Fees are only charged for SWAP or Electronic Monitoring
+:languages:
+- English
+- Spanish
+:miscellaneous: |
+  Intake Hours: Monday – Friday, 8:00am to 1:30pm
+  Program Hours: Monday-Friday, 8:00am to 4:00pm
+  Notes: No referrals required; Drop-ins only Monday-Friday 8:00am-4:00pm otherwise by appointment.
+:name: San Francisco Sheriff’s Department   Community Programs
+:phone: "(415) 575-6450"
+:services:
+- Anger Management
+- Counseling
+- Employment Placement
+- GED Preparation
+- AA/NA
+- Life Skills
+- Literacy/Basic Education
+- Mentoring
+- Transit Vouchers
+- Referrals to other resources available as needed
+- Community Works provides job development and Manalive, a 52-week, DV certified batterers
+  intervention program
+:url: www.sfsheriff.com
+:what_to_bring: 

--- a/organizations/san-francisco-sheriff-s-department-no-violence-alliance-nova.yml
+++ b/organizations/san-francisco-sheriff-s-department-no-violence-alliance-nova.yml
@@ -53,3 +53,5 @@
 - Referrals to other resources available as needed
 :url: www.sfsheriff.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-sheriff-s-department-no-violence-alliance-nova.yml
+++ b/organizations/san-francisco-sheriff-s-department-no-violence-alliance-nova.yml
@@ -1,0 +1,55 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+:address: No drop-ins
+:contact_name: Sgt. Dunn
+:description: The primary goal of the NoVA Project is to address the violence plaguing
+  San Francisco and in particular, the significantly high crime communities of Bayview
+  Hunters Point, Western Addition, and the Mission Districts, by providing intensive
+  services to formerly incarcerated individuals with a history of violence to aid
+  in their reentry into the community and reduce recidivism. The NoVA Project approach
+  engages men and women, and encourages them to take control of their violent behavior
+  through rehabilitation, and to the extent possible, successfully reenter the community
+  as a productive member of society. The comprehensive approach stresses offender
+  accountability and violence prevention education.
+:eligible_population: Men and Women who have been convicted of a violent crime(s).
+  Must be soon to be/recently released from County Jail.
+:email: Nova.SFSD@sfgov.org
+:faith_based: No.
+:fax: "(415) 558-2490"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:00am to 4:00pm
+  Notes: Referrals are required. No first-time drop-ins.
+  Direct Service: Case Management; Anger Management; Employment Training; Employment Placement; Transitional Housing; Mentoring.
+  San Francisco Sheriff’s Department   Women's Resource Center
+  A collaboration between the San Francisco Sheriff's Department, Community Works West, and Five Keys Charter School.  This is a multi-service drop-in center for women and LGBTQ.  WRC provides substance abuse counseling, anger management, Healthy Relationship claases, Seeking Sfatey, AA/NA, artisic craft therapy, as well as intensive case management. www.sfsheriff.com
+  WRC Main Phone: (415) 734-3150
+  Hours: Monday-Friday, 8:30am to 4:30pm (open later on some days for some programs)
+  Note: No referrals needed. Drop-ins are welcome.  If you have questions contact Aida McCray at 415-734-3150
+:name: San Francisco Sheriff’s Department   No Violence Alliance (NoVA)
+:phone: "(415) 575-6450"
+:services:
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Phone (no voicemail)
+- Substance Abuse Treatment
+- Health & Wellness Education
+- Anger Management
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Trauma Recovery Services
+- GED & High School Education
+- Vocational Education
+- Job Readiness/Life Skills
+- Parenting Support/Education
+- Rising Voices is a paid writing and performance internship for 18-25 year-old women
+- Referrals to other resources available as needed
+:url: www.sfsheriff.com
+:what_to_bring: 

--- a/organizations/san-francisco-sheriff-s-department-prisoner-legal-services.yml
+++ b/organizations/san-francisco-sheriff-s-department-prisoner-legal-services.yml
@@ -37,3 +37,5 @@
   request
 :url: www.sfsheriff.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-francisco-sheriff-s-department-prisoner-legal-services.yml
+++ b/organizations/san-francisco-sheriff-s-department-prisoner-legal-services.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+:address: 'All San Francisco County Jails, 555 7th Street, #201, San Francisco, CA  94103'
+:contact_name: Any Intern/Staff
+:description: We help the San Francisco Sheriff's Department in its mission to meet
+  or exceed local, state and federal mandates regarding the housing and treatment
+  of prisoners.  PLS provides San Francisco County Jail prisoners with meaningful
+  access to the courts as well as advocacy and limited direct services aimed at assisting
+  clients with problems occasioned by their incarceration and with barriers to reentry.
+:eligible_population: Incarcerated persons and persons recently released from the
+  custody of the San Francisco County Jail.
+:email: 
+:faith_based: No.
+:fax: "(415) 558-2490"
+:fees: None.
+:languages:
+- English
+- Translation services available
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  Notes: No referral needed. Incarcerated clients must submit a request for services; limited drop-in service for recently released prisoners.
+:name: San Francisco Sheriff's Department   Prisoner Legal Services
+:phone: "(415) 558-2472"
+:services:
+- Assistance Getting Driver’s License/Other ID
+- Transit Vouchers
+- Post-Incarceration Support
+- Inmate and Parolee Legal Issues
+- Family Law
+- Housing and Eviction Defense
+- Restraining/Staw Away Orders
+- Voting Outreach and Education
+- Jail Conditions
+- Visits of family Menbers in Jails and Prisons
+- Child Support/Custody
+- All legal or official mail may be posted or received on behalf of an inmate upon
+  request
+:url: www.sfsheriff.com
+:what_to_bring: 

--- a/organizations/san-francisco-state-university-asi-project-rebound.yml
+++ b/organizations/san-francisco-state-university-asi-project-rebound.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1650 Holloway Avenue,
+:contact_name: Jason Bell
+:description: Project Rebound sees education as an alternative to mass incarceration.
+  We seek to increase opportunities to become productive and responsible citizens,
+  decrease the risk of recidivism, motivate incarcerated individuals to strive to
+  change their lives, and interrupt the path of youth headed toward incarceration.
+:eligible_population: All individuals, 18 and older. A high school diploma or GED
+  is required.  Some services may not be available to registered sex offenders. May
+  not have prior convictions on SFSU grounds.
+:email: projectrebound@asi.sfsu.edu
+:faith_based: No.
+:fax: "(415) 338-0522"
+:fees: No fees.
+:languages:
+- English
+- Translators may be available for other languages
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:00am to 5:00pm
+  CCSC T-138, San Francisco State University,
+  San Francisco, CA 94132
+  Notes: No referral needed. Drop-ins allowed, but appointments are recommended.
+:name: San Francisco State University(ASI)   Project Rebound
+:phone: "(415) 405-0954"
+:services:
+- Books/Class Materials
+- Access to Internet
+- Food Vouchers
+- Transit Vouchers
+- Mental Health Treatment
+- Anger Management
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- College & Graduate Education
+- Referrals to other resources available as needed
+:url: http://asi.sfsu.edu/asi/programs/proj_rebound/about.html
+:what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency.

--- a/organizations/san-francisco-state-university-asi-project-rebound.yml
+++ b/organizations/san-francisco-state-university-asi-project-rebound.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: http://asi.sfsu.edu/asi/programs/proj_rebound/about.html
 :what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/san-mateo-county-service-connect.yml
+++ b/organizations/san-mateo-county-service-connect.yml
@@ -1,0 +1,46 @@
+---
+:accessibility: 'ADA Accommodations: Wheelchair accessible.'
+:address: 550 Quarry Road, 2nd Floor, San Carlos, CA 94070 
+:contact_name: Front Desk
+:description: Service Connect of San Mateo County provides a range of services aimed
+  at supporting former inmates as they re-enter the community. Service Connect is
+  available to individuals who have served sentences for specific low-level offenses,
+  who live or plan to live in San Mateo County, and who are enrolled in Post-Release
+  Community Supervision (PRCS) or who served their sentence in county jails under
+  the 1170h program. Please check with your Probation Officer to see if you qualify
+  for Service Connect or other re-entry assistance.  Service Connect is collaboration
+  between the San Mateo County Sheriff's Department, Correctional Health, Probation,
+  Human Services Agency, and the Health System. Our staff works across agency lines
+  to reduce recidivism and connect clients with needed services.
+:eligible_population: Must be on probation in San Mateo County.  Please check with
+  your Deputy Probation Officer to see if you are eligible.
+:email: 
+:faith_based: N/A.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: 8:00am-5:00pm
+  Notes: Please check with your Deputy Probation Officer to see if you are eligible for referral/services.
+:name: San Mateo County   Service Connect
+:phone: "(650) 508-6745"
+:services:
+- Temporary Emergency Shelter
+- Emergency Food
+- Clothing and Transportation Vouchers
+- Personal Hygiene Kits
+- Assistance Obtaining California Identification Documents
+- Case Management
+- " Assessments for Financial Benefits and Health Coverage"
+- Links to Job Training and Employment
+- Family Re-Engagement Support
+- Mental Health and Substance-Abuse Recovery Referrals
+- Employment Services
+- Support Groups and Community Mentorship
+- Peer-to-Peer Mentoring
+- Moral Reconation Therapy (MRT)
+- Health Services
+:url: ''
+:what_to_bring: 

--- a/organizations/san-mateo-county-service-connect.yml
+++ b/organizations/san-mateo-county-service-connect.yml
@@ -44,3 +44,5 @@
 - Health Services
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/santa-clara-county-reentry-center.yml
+++ b/organizations/santa-clara-county-reentry-center.yml
@@ -89,3 +89,5 @@
   Center
 :url: www.sccgov.org/sites/reentry/resourcecenter/Pages/Resource-Center.aspx
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/santa-clara-county-reentry-center.yml
+++ b/organizations/santa-clara-county-reentry-center.yml
@@ -1,0 +1,91 @@
+---
+:accessibility: ADA Compliant.
+:address: 151 W. Mission Street, San Jose, CA 95110
+:contact_name: General Information
+:description: The Re-Entry Resource Center is a centralized location for custodial
+  and non-custodial individuals to receive referral and wrap around services. Our
+  vision is to build safer communities and strengthen families through successful
+  reintegration and reentry of formerly incarcerated individuals back into Santa Clara
+  County.  Our mission is to reduce recidivism by using evidence-based practices in
+  implementing a seamless system of services, supports, and supervision. We offer
+  reentry services, Probation Intake and Assessment, and Custody Alternative Programs.
+:eligible_population: Men/Women ages 18 and older, must reside in Santa Clara County
+  and criminal justice involved.
+:email: 
+:faith_based: No, but can referred to faith-based reentry resource centers in Santa
+  Clara County.
+:fax: "(707) 425-4038"
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: "Intake Hours: Monday-Friday, 8am to 5pm\nNotes: Must be criminal
+  justice involved and reside in Santa Clara County.\nClient fees: None.\n\nDirect
+  Service: Probation Intake and Assessment, Parolee Reentry Program, Behavioral Health
+  Services, Public Benefits & Health Coverage, Reentry Mobile Clinic, Education, Employment,
+  Family Reunification, Legal Advice, linkage to faith-based reentry centers, Housing,
+  Peer Mentor/Support, Expungement, and Food Pantry/Clothing.\nHealthy Partnerships\tSubstance
+  Abuse Services\nHealthy Partnerships (HP) employs a consumer-oriented approach to
+  substance abuse treatment services. Clients participating in these services can
+  either enter voluntarily or through court-ordered to do so. HP works closely with
+  Probation and Parole in compliance with any court mandates. Clients requesting services
+  are assessed for individual treatment plans. We provide outpatient substance abuse
+  services.  www.healthypartnerships.com/\nHours: Monday-Friday, 8am to 5pm\nFairfield,
+  CA 94533\nNotes: If you do not have insurance please call (707) 784 2220 for assessment.\nClient
+  fees: None.\nNot done…Bobbye bmoore@healthypartnerships.com\n\nDirect Service: Outpatient
+  Substance Abuse Services; Case Management; DUI Services; Group Therapy; Individual
+  Counseling.\nMission SOLANO Rescue Mission\nMission SOLANO Rescue Mission focused
+  its vision to develop long-term residential treatment for homeless addicted men,
+  women, and Veterans. Since then, Mission SOLANO has successfully met the basic necessities
+  of the homeless and poverty stricken population. Our unique and nationally recognized
+  Nomadic Sheltering Program provides emergency shelter nights to those in need, while
+  maintaining and managing our Community Outreach Center (COC) and Social Industries
+  distributing food, clothing and ongoing community services. In 2009 we opened our
+  Bridge To Life Center, our long-term solution to homelessness. Through transitional
+  housing and a holistic program, we address spiritual, physical, emotional, psychosocial
+  and vocational needs. Our six buildings are able to provide for 208 individuals
+  through our Hope Home for Homeless Vets, the Matt Garcia Home for Women and Children,
+  and twelve two-bedroom family units.  Our doors are open 24 hours a day, 365 days
+  a year. Help is available without charge to any person regardless of race, color,
+  creed or social standing.   www.missionsolano.org\nHours: Monday-Friday, 8am to
+  5pm\nLocations:  Community Outreach Center, 740 Travis Blvd, Fairfield, CA  94553;
+  Bridge to Life Center, 310 Beck Avenue, Fairfield, CA  94553\nNotes: May show up
+  for a bed at 2:30pm daily to see if there is room.  No reservations, first come,
+  first serve.\nClient fees: None.\n\nDirect Service: Emergency Shelter; Long-Term
+  Residential; Food/Meals Prepared; Clothing.\nSolano County Substance Abuse Services\nSolano
+  County Substance Abuse Services is dedicated to providing a continuum of care that
+  benefits the clients and providers. Utilizing a combined administrative, clinical,
+  and preventive services approach, we deliver coordinated services to the diverse
+  populations of Solano County who are impacted by alcohol, tobacco, and other drugs
+  (ATOD), and related issues such as domestic violence. solanocounty.com/depts/hss/sas/default.asp\nHours:
+  Monday-Friday, 8am to 5pm\nLocations:  2101 Courage Drive, Suite 101, Fairfield,
+  CA  94553.\nNotes: Please call for an appointment.  If you need to stop using alcohol
+  or substances immediately, call the Southern Solano Alcohol Council Detox at (707)
+  643-2715 or visit the nearest emergency room.\nClient fees: Will be discussed during
+  intake. If you do not have insurance you will not be turned away.\n\nDirect Service:
+  Detox; Residential Substance Abuse Treatment; Outpatient Substance Abuse Treatment.\nCOTS
+  \  The Petaluma Kitchen\nCommittee on the Shelterless (COTS) Petaluma Kitchen offers
+  daily meals and weekly boxes of emergency food.  The Petaluma Kitchen serves critical
+  meals to many low income families, seniors and individuals in our community. In
+  this community kitchen, located at 900 Hopper Street in Petaluma, COTS provides
+  a nutritious meal each day to homeless and at-risk families and individuals. The
+  Food Box Program provides weekly boxes of supplemental groceries to residents of
+  Petaluma who meet the Emergency Food Assistance Program (EFAP) income requirements. 
+  Food Boxes are delivered on Saturdays or may be picked up Sunday – Thursday 9:30-11am. 
+  To apply for the Food Box Program must show a current photo id, proof of their address
+  in Petaluma, and proof of their income.     www.cots-homeless.org/index.php/how-we-help/homeless-services/\nPhone
+  :  (707) 765-6530 x131\nHours: Free meals are served daily: Breakfast from 7:30-9:00am,
+  Lunch from11:30am-1:00pm, Dinner for MIC residents only from 5:00-6:00pm\nNotes:
+  It is okay to drop-in."
+:name: Santa Clara County Reentry Center
+:phone: "(408) 535-4280"
+:services:
+- Food/Prepared Meals
+- Clothing
+- Shower Facilities
+- Access to Laundry Machines
+- The Petaluma Kitchen is the central contact point of COTS' outreach to persons living
+  on the streets, to encourage them to seek shelter and support at the Mary Isaak
+  Center
+:url: www.sccgov.org/sites/reentry/resourcecenter/Pages/Resource-Center.aspx
+:what_to_bring: 

--- a/organizations/saved-by-grace.yml
+++ b/organizations/saved-by-grace.yml
@@ -30,3 +30,5 @@
 - Restorative Justice Services
 :url: www.sbgm.vpweb.com
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/saved-by-grace.yml
+++ b/organizations/saved-by-grace.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible.
+:address: Call for information.
+:contact_name: Pastor Ronnie Muniz
+:description: Saved by Grace is a faith-based structured program dealing with all
+  of life’s issues. Our focus is to rebuild self-esteem and help individuals readjust
+  into society as productive citizens. We take a faith based approach toward recovery
+  and education. We mirror our beliefs in our actions. We teach faith but it is not
+  a requirement for entrance. We focus on teaching a positive outlook toward rebuilding
+  families torn by crime, drugs, and abuse to others as well as self. Our mission
+  is to educate, rehabilitate, graduate, and restore the youth and adults back into
+  the life they were meant to live.
+:eligible_population: Formerly incarcerated people.
+:email: pastor.muniz@aol.com
+:faith_based: Yes.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: 'Notes: No referrals required.'
+:name: Saved by Grace
+:phone: "(415) 955-7713"
+:services:
+- Clean and Sober Living
+- Life skills
+- Anger Management
+- Relapse Prevention
+- Parenting Skills
+- Assistance Getting Driver’s License or Other ID
+- Restorative Justice Services
+:url: www.sbgm.vpweb.com
+:what_to_bring: 

--- a/organizations/senior-ex-offender-program.yml
+++ b/organizations/senior-ex-offender-program.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.seopsf.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/senior-ex-offender-program.yml
+++ b/organizations/senior-ex-offender-program.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1706 Yosemite Avenue, San Francisco, CA 94124
+:contact_name: Frank Williams
+:description: Senior Ex-Offender Program (SEOP) gives direct and referral services
+  to older adult offenders and formerly incarcerated individuals ages 50 and over.  SEOP
+  is the first program in the nation to specifically work with older offenders who
+  are transition back to the community.   A program of the Bay View Hunter’s Point
+  Multipurpose Senior Services, the Senior Ex-Offender program provides counseling,
+  information, and referrals for ex-offenders who are seniors.
+:eligible_population: All formerly incarcerated people who are older adults. Men ages
+  50 and older and Women ages 45 and older. Housing is not provided for sex offenders.
+:email: info@seopsf.org
+:faith_based: No.
+:fax: "(415) 822-5327"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday and Friday, 9:00am to 4:30pm
+  Notes: No referrals required; Drop-ins welcome.
+:name: Senior Ex-Offender Program
+:phone: "(415) 822-1444 (Office)"
+:services:
+- Case Management
+- Transitional Housing
+- Counseling
+- Clothing
+- Personal Care/Hygiene Items
+- Substance Abuse Counseling
+- Food/Meals
+- Counseling
+- Food/Meals
+- Phone/Voicemail
+- Referrals to other resources available as needed
+:url: www.seopsf.org
+:what_to_bring: 

--- a/organizations/sf-bay-counseling-and-education.yml
+++ b/organizations/sf-bay-counseling-and-education.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1700 Irving Street, San Francisco, CA 94122
+:contact_name: Tim Karo, Program Director
+:description: Behavior is learned, re-enforced and sanctioned. Change is possible,
+  understanding is credible, so hope can be conceivable. Our mission is to help those
+  who come through our doors to help themselves, change recover and restore and return
+  to their homes families and community with the tools, resources to thrive and sustain
+  wellness in a positive non violent capacity.
+:eligible_population: Men, Women, Transgender people, ages 18-65.
+:email: 
+:faith_based: No.
+:fax: "(415) 871-2211"
+:fees: Based on documented income, GA, SSI, SSDI, employment. Fees range from $10
+  - $60 per session based on proof of income.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Specific Intake Days and Times: Tues, Thurs, Fri and Sat
+  Hours: Tuesday – Saturday, by appointment only. Intake Tuesday, Thurdsay, Friday and Saturday.
+  Notes: Referrals sometimes required. No drop-ins. Please call for more information and appointments.
+:name: SF Bay Counseling and Education
+:phone: "(415) 759-9500"
+:services:
+- Emergency Shelter - linkage to shelter system, access points
+- Rental Move-in Assistance - season of sharing and catholic charities rental assistance
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Anger Management
+- Group Counseling/Therapy
+- Outreach
+- Batterers Counseling (Domestic Violence) certified
+- certified Parenting Program DHS approved provider
+- Representative Payee Services
+- Housing & Eviction Defense - referrals to community partners
+- Restraining/Stay Away Orders - referrals to community partners
+- Parenting Support/Education – DHS-approved Parent Education Program
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: State-Issued ID. Program may be able to assist clients in getting
+  this.

--- a/organizations/sf-bay-counseling-and-education.yml
+++ b/organizations/sf-bay-counseling-and-education.yml
@@ -40,3 +40,5 @@
 :url: ''
 :what_to_bring: State-Issued ID. Program may be able to assist clients in getting
   this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/sf-clean-city-coalition-employment-partnership-program.yml
+++ b/organizations/sf-clean-city-coalition-employment-partnership-program.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Program Office
+:description: Clean City Partnership Program provides neighborhood-based transitional
+  employment, training and job placement assistance to homeless and low-income individuals
+  through community improvement projects and vocational training.  We provide participants
+  with paid employment, job readiness assistance, and assist clients in permanent
+  full-time employment.
+:eligible_population: All individuals 18 yrs and older.  Must be a San Francisco resident
+  and bale to pass a pre-employment drug test.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 7:30am to 4:30pm.
+  Office Location: 366 Eddy Street, San Francisco, CA 94102.
+  Notes: No referral needed. Must attend an orientation to be eligible for employment.  Orientations are offered weekly, please check website for location of orientations.
+:name: SF Clean City Coalition   Employment Partnership Program
+:phone: "(415) 552-9201 x14"
+:services:
+- Paid Employment
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Access to Internet
+- Referrals to other rrsources available as needed
+:url: www.sfcleancity.org
+:what_to_bring: 

--- a/organizations/sf-clean-city-coalition-employment-partnership-program.yml
+++ b/organizations/sf-clean-city-coalition-employment-partnership-program.yml
@@ -31,3 +31,5 @@
 - Referrals to other rrsources available as needed
 :url: www.sfcleancity.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/sf-strong.yml
+++ b/organizations/sf-strong.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: 
+:address: 4336 Irving St., SF, CA  94122
+:contact_name: Teri Delane
+:description: In partnership with the Delancey Street Foundation, SF Strong is a transitional
+  housing program for formerly incarcerated individuals.  The facility houses 15 men
+  who have been released from local or state custody and/or are on probation or parole.  Program
+  residents work with staff to develop an individualized reentry plan, including securing
+  employment and/or participating in job training and education programs.  Approximate
+  length of stay is 3 months, which varies based on individual needs.
+:eligible_population: Men who are exiting local or state incarceration.
+:email: sfstrong4336@gmail.com
+:faith_based: 'No'
+:fax: 
+:fees: No fees upon initial placement; as individuals secure income, they may be expected
+  to pay for some program costs.
+:languages:
+- English
+:miscellaneous: |
+  Hours: Monday – Friday from 9am – 5pm
+  Notes: Men who are exiting local or state incarceration.
+:name: SF Strong
+:phone: "(415) 340-3285"
+:services:
+- Transitional Housing
+- Counseling and Groups
+- Assistance with Job Readiness
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/sf-strong.yml
+++ b/organizations/sf-strong.yml
@@ -28,3 +28,5 @@
 - Referrals to other resources available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/shelter-inc.yml
+++ b/organizations/shelter-inc.yml
@@ -1,0 +1,38 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 'Main Office:  1815 Arnold Drive, Martinez, CA  94553'
+:contact_name: 
+:description: 'SHELTER, Inc. strives to realize a vision: Re-building lives, one family
+  at a time, by giving them a home, the skills and the resources to live the life
+  they deserve.  The mission of SHELTER, Inc. is to prevent and end homelessness for
+  low-income residents of Contra Costa County by providing resources that lead to
+  self-sufficiency.  Our work encompasses three main elements:'
+:eligible_population: Men and women 18 years and older, with or without children,
+  must be a Contra Costa County resident.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  preventing homelessness through rental assistance, case management, and housing counseling services; ending the cycle of homelessness by providing 3 to 24 months of housing in combination with supportive services such as job training, educational services and counseling; and by providing affordable housing to low-income households, including such special needs groups as transition-age youth, people with HIV/AIDS and those with mental health disabilities.  shelterinc.org
+  General Inquiries: (925) 335-0698
+  Prevention and Homeless Services: ONE DOOR, (925) 338-1038 (Monday-Friday, except holidays, 9:00am-4:00pm)
+  Main Office:  1815 Arnold Drive, Martinez, CA  94553
+  Notes: For the Rental Assistance Program and application process please call 925-338-1038 between 9:00 a.m. and 4:00 p.m. one time only Monday through Friday (except holidays).  Must call first for an appointment, No drop-ins.
+  What to bring:  For services we ask you have a picture ID, Social Security card and proof of income. Appointment is necessary.
+:name: Shelter Inc.
+:phone: 
+:services:
+- Interim Housing for families with children under 18 years old
+- Transitional Housing
+- Family Rapid Rehousing
+- Rental Assistance
+- Permanent Supportive Housing
+- Supportive Services for Veteran Families
+- Intensive Case Management
+- Referrals to other services as appropriate
+:url: ''
+:what_to_bring: 

--- a/organizations/shelter-inc.yml
+++ b/organizations/shelter-inc.yml
@@ -36,3 +36,5 @@
 - Referrals to other services as appropriate
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/sonoma-county-job-link.yml
+++ b/organizations/sonoma-county-job-link.yml
@@ -28,3 +28,5 @@
 - Resume Writing
 :url: www.joblinksonomacounty.com is
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/sonoma-county-job-link.yml
+++ b/organizations/sonoma-county-job-link.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: 'ADA Accommodations: Wheelchair accessibility'
+:address: 2227 Capricorn Way, Suite 100,Santa Rosa, CA  95407
+:contact_name: Front Desk
+:description: Job Link is Sonoma County's one-stop career center. Job Link serves
+  job seekers with meetings with Job Counselors, training scholarships, classes on
+  resume writing and online job search, access to a computer lab and disability tools.
+  Job Link hosts hiring events and job fairs at the Job Link office which has a computer
+  lab for on-line applications and interview space.  The Job Link Website,  a virtual
+  one-stop, offering many services online, 24 hours a day.  www.joblinksonomacounty.com 
+:eligible_population: Must be at least 18 years old to receive services.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday  8:00am - 5:00pm;
+  Resource Center 8:00am - 4:45pm; Computer Lab 8:30am - 4:00pm Monday - Thursday, 8:30am -3:30pm Friday.
+  Notes: Must attend a Job Link Orientation M-F at 1:30pm—no appointment needed.  Spanish speaking orientation on Thursdays at 10:00am.
+:name: Sonoma County Job Link
+:phone: "(707) 565-5550"
+:services:
+- Job Readiness
+- Job Search Assistance
+- Resume Writing
+:url: www.joblinksonomacounty.com is
+:what_to_bring: 

--- a/organizations/sonoma-county-probation-day-reporting-center.yml
+++ b/organizations/sonoma-county-probation-day-reporting-center.yml
@@ -1,0 +1,34 @@
+---
+:accessibility: 
+:address: 2400-A County Center Drive, Santa Rosa, CA 95403
+:contact_name: DRC Staff
+:description: The Sonoma County Probation Day Reporting Center is a comprehensive
+  program designed to accommodate the needs of individuals under probation supervision
+  who have recently been incarcerated and are transitioning back into the community.  The
+  focus of the center is to provide evidenced based programming to the participants
+  to promote behavior change.  Additionally, through the use of on-site community
+  partners, participants can quickly access much needed resources to address personal,
+  educational, and vocational goals, with the ultimate objective of reducing recidivism.
+:eligible_population: the AB 109 population and those individuals under probation
+  supervision with high risk for recidivism.
+:email: 
+:faith_based: 'No'
+:fax: 
+:fees: Participation in assigned programming is free of charge.
+:languages:
+- English/Spanish
+:miscellaneous: |-
+  Hours: Monday/Wednesday/Friday 9:00am-8:00pm; Tuesday/Thursday 7:00am-6:00pm
+  Notes: Referrals made directly from Sonoma County Adult Probation.
+:name: Sonoma County Probation   Day Reporting Center
+:phone: "(707) 565-8041"
+:services:
+- Cognitive behavioral Intervention Groups
+- Aggression Replacement training
+- Eligibility Worker
+- Vocational and Educational Services
+- Substance Abuse/Mental Health Assessment and Referral Resources
+- Chemical Testing
+- Referrals to other resources are available as needed
+:url: ''
+:what_to_bring: 

--- a/organizations/sonoma-county-probation-day-reporting-center.yml
+++ b/organizations/sonoma-county-probation-day-reporting-center.yml
@@ -32,3 +32,5 @@
 - Referrals to other resources are available as needed
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/south-of-market-health-center.yml
+++ b/organizations/south-of-market-health-center.yml
@@ -34,3 +34,5 @@
 - Pre-natal and well-baby care, patient education and outreach are also available
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/south-of-market-health-center.yml
+++ b/organizations/south-of-market-health-center.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 229 7th Street, San Francisco, CA  94104
+:contact_name: Any staff
+:description: South of Market Health Center is a non-profit community health center
+  that provides comprehensive medical, dental and podiatry services to individuals,
+  children and families who have difficulty getting healthcare. We are a full-service
+  clinic in the South of Market Area, providing high quality healthcare to over 5,000
+  patients every year.
+:eligible_population: Families and individuals with little or no health coverage.
+:email: info@smhcsf.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Spanish
+- Tagalog
+- Farsi
+- ''
+- Chinese
+:miscellaneous: |-
+  Main Clinic:
+  229 7th Street, San Francisco, CA  94104
+  Hours: Monday through Thursday, 8:00am-5:00pm; Friday through Saturday 8:00am-3:30pm.
+  Senior Clinic (For patients 55+):
+  317 Clementina, San Francisco, CA 94103
+  Hours: Monday through Thursday, 8:00am-5:00pm; Friday 8:00am-3:30pm.
+:name: South of Market Health Center
+:phone: "(415) 503-6000"
+:services:
+- SMHC provides a wide range of high quality primary medical, disease prevention,
+  dental and podiatry care
+- Pre-natal and well-baby care, patient education and outreach are also available
+:url: ''
+:what_to_bring: 

--- a/organizations/st-anthony-foundation-father-alfred-center.yml
+++ b/organizations/st-anthony-foundation-father-alfred-center.yml
@@ -45,3 +45,5 @@
 - Referrals to other resources available as needed
 :url: www.stanthonysf.org/RecoveryProgram
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/st-anthony-foundation-father-alfred-center.yml
+++ b/organizations/st-anthony-foundation-father-alfred-center.yml
@@ -1,0 +1,47 @@
+---
+:accessibility: 
+:address: 'Intake Location: 121 Golden Gate Avenue, San Francisco, CA  94102'
+:contact_name: Intake
+:description: The St. Anthony Foundation’s Father Alfred Center provides the Bay Area’s
+  only licensed no-fee residential recovery program to homeless men who are ready
+  to build sober, stable futures. The program serves men from San Francisco, Marin,
+  Alameda, Contra Costa and San Mateo counties.  The Father Alfred Center’s year-long
+  work-structured program empowers men with no income or resources with the tools
+  to overcome addiction, and the support to establish productive and healthy lives.
+  The multi-program access available through St. Anthony’s own services is rare in
+  the field of recovery, and allows the speedy assessment and resolution of clients’
+  medical, legal, vocational and educational needs, most or all of which have been
+  affected profoundly by their cycles of poverty and addiction.
+:eligible_population: Men ages 18 and older. May not have a criminal conviciton for
+  arson; may not be a registered sex offender; may not have a serious medical/mental
+  health condition requiring medication.  Client must be able to pass a physical examination
+  given by St. Anthony’s medical Clinic as part of the intake process.
+:email: 
+:faith_based: 12-Step based program.
+:fax: 
+:fees: No fee.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Intake Hours: Monday through Friday, 8:00am-10:00am
+  Intake Location: 121 Golden Gate Avenue, San Francisco, CA  94102
+  Notes: No referrals needed. Drop-ins welcome.
+:name: St. Anthony Foundation   Father Alfred Center
+:phone: "(415) 592-2831"
+:services:
+- Residential Recovery Program
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Medical Care
+- Anger Management
+- GED
+- Vocational Education
+- Employment Training
+- Employment Retention
+- Job Readiness/Life Skills
+- Referrals to other resources available as needed
+:url: www.stanthonysf.org/RecoveryProgram
+:what_to_bring: 

--- a/organizations/st-anthony-foundation-free-clothing-program.yml
+++ b/organizations/st-anthony-foundation-free-clothing-program.yml
@@ -26,3 +26,5 @@
 - The free clothing program offers clothing to men, women, and children
 :url: www.stanthonysf.org/FreeClothingProgram
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/st-anthony-foundation-free-clothing-program.yml
+++ b/organizations/st-anthony-foundation-free-clothing-program.yml
@@ -1,0 +1,28 @@
+---
+:accessibility: Wheelchair accessible
+:address: 121 Golden Gate Avenue
+:contact_name: 
+:description: We are happy to announce that the Free Clothing Program will be moving
+  to our new building located at 121 Golden Gate Ave. As of February 3rd, 2015, we
+  will be on the 2nd floor above the new Dining Room and next to the new Social Work
+  Center. It is our hope that centralizing our services will greatly improve our guests’
+  experience here at St. Anthony’s thus enabling us to fully serve each and every
+  man, woman and child who comes through our doors with immediate, accessible and
+  responsive wrap-around services.
+:eligible_population: All individuals needing clothes
+:email: 
+:faith_based: Yes.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  St. Anthony Foundation’s Free Clothing Program is San Francisco’s largest free clothing program, providing warm clothes, interview or employment apparel, and children’s clothing to homeless and low-income families and individuals.   www.stanthonysf.org/FreeClothingProgram
+  Hours:  Please call for updated hours.
+:name: St. Anthony Foundation   Free Clothing Program
+:phone: "(415) 241-2600"
+:services:
+- The free clothing program offers clothing to men, women, and children
+:url: www.stanthonysf.org/FreeClothingProgram
+:what_to_bring: 

--- a/organizations/st-anthony-foundation-social-work-center.yml
+++ b/organizations/st-anthony-foundation-social-work-center.yml
@@ -35,3 +35,5 @@
 - Referrals to other resources available as needed
 :url: www.stanthonysf.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/st-anthony-foundation-social-work-center.yml
+++ b/organizations/st-anthony-foundation-social-work-center.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 121 Golden Gate Avenue, 2nd Floor, San Francisco, CA 94102
+:contact_name: David Monterde, Intake Coordinator
+:description: The Social Work Center provides comprehensive services for families
+  and individuals under 60 who are dealing with issues related to homelessness and
+  poverty. The primary goal of the Center is to provide services that support, stabilize,
+  and improve the quality of life for homeless, low income, undocumented, and working
+  poor individuals and families.
+:eligible_population: All individuals 18 and older and families with the city and
+  county of San Francisco.
+:email: dmonterde@stanthonysf.org
+:faith_based: Yes.
+:fax: "(415) 766-6081"
+:fees: None.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday, Tuesday, Thursday, Friday, 8:30am to 12:00pm, 1:00pm to 4:00pm; Wednesday, 8:30am to 12:00pm; closed the 2nd Thursday of each month at 2:30pm
+  Notes: No referral needed. By appointment.  Call or walk-in to schedule.  Limited drop-in spaces available on Tuesdays and Thursdays at 8:30am and Fridays at 1:00pm.
+:name: St. Anthony Foundation   Social Work Center
+:phone: "(415) 592-2855"
+:services:
+- Substance Abuse Intake (Father Alfred Center, Monday-Thursday, 8:30am-10am)
+- Case Management
+- Counseling
+- Crisis Intervention
+- Advocacy
+- ID Assistance (limited monthly DMV vouchers, Birth Certificates, SF City ID Program)
+- Housing/Rental Assistance
+- Supplemental Food program
+- Clothing Vouchers
+- Information about eligibility for benefits (SSI, CalWorks, CalFresh,CAAP)
+- Referrals to other resources available as needed
+:url: www.stanthonysf.org
+:what_to_bring: 

--- a/organizations/st-anthony-foundation-tenderloin-tech-lab.yml
+++ b/organizations/st-anthony-foundation-tenderloin-tech-lab.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.  Call for info.
+:address: 150 Golden Gate Avenue, 3rd Floor, San Francisco, CA 94102
+:contact_name: Program Assistant
+:description: The Tenderloin Tech Lab (TTL) is the Tenderloin’s only free technology
+  center specializing in bridging the digital divide and looking for technology solutions
+  for issues of poverty.  The TTL we offer free intensive computer classes, one-on-one
+  tutoring, job search counseling and life skills courses, all designed specifically
+  for the learning style of adults struggling with poverty, addiction, mental health
+  challenges or homelessness.  In addition to the work in our physical space, we also
+  work with developers to create mobile technology solutions for challenges this population
+  is facing.
+:eligible_population: Open to the public.
+:email: gbickel@stanthonysf.org
+:faith_based: Yes.
+:fax: "(415) 440-7773"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday-Friday 8:30am-11:45am, 1:30pm-4:15pm; closed Wednesday afternoon; Saturday 10am-3pm
+  Notes: 30 minute orientation required for all first time guests and guest who have not visited in past 12 months.  Call for info.
+:name: St. Anthony Foundation   Tenderloin Tech Lab
+:phone: "(415) 592-2766"
+:services:
+- Access to Internet
+- Computer Classes
+- Computer Training
+:url: www.stanthonysf.org/TechLab
+:what_to_bring: 

--- a/organizations/st-anthony-foundation-tenderloin-tech-lab.yml
+++ b/organizations/st-anthony-foundation-tenderloin-tech-lab.yml
@@ -28,3 +28,5 @@
 - Computer Training
 :url: www.stanthonysf.org/TechLab
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/st-vincent-de-paul-wellness-center.yml
+++ b/organizations/st-vincent-de-paul-wellness-center.yml
@@ -31,3 +31,5 @@
 :services: []
 :url: svdp-sf.org/what-we-do/wellness-center/
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/st-vincent-de-paul-wellness-center.yml
+++ b/organizations/st-vincent-de-paul-wellness-center.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1175 Howard Street, San Francisco, CA  94103
+:contact_name: Tyler Butterfield, Program Manager
+:description: St. Vincent De Paul Society’s Wellness Center is dedicated to responding
+  to the call of our community, embracing a holistic healing approach to the needs
+  our participants carry daily.  Inspired by our core values of compassion, social
+  justice and spirituality, we are committed to bringing wellness, recovery and clinical
+  best practices to all who come through our doors. Using a harm reduction model,
+  the Wellness Center strives to meet people where they are by focusing on lending
+  continued support to those who are struggling with substance abuse issues and other
+  debilitating diagnoses. Our daily program consists of stress reduction techniques,
+  exercise, selections of personal and spiritual development as well as health topic
+  sessions. Good nutritional guidelines play a pivotal role at the Wellness Center.
+  We offer healthy free snacks and lunch based on a thoughtfully designed menu of
+  fresh local foods with high/dense nutritional value. All are welcome and encouraged
+  to participate on the level that best fits their needs.
+:eligible_population: All individuals 18 years of age and older.  Open to the public.
+:email: 
+:faith_based: Yes.
+:fax: 
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Business Hours:  8:30am-4:30pm; Class Hours:  9am-4pm.
+  Notes:  All sessions are free.  Drop-ins welcome.  Lunch is provided for those participating in morning sessions.  For class schedule visit:  svdp-sf.org/what-we-do/wellness-center/.
+  Direct Services:  Classes on Stress Reduction; Personal Development; Healthy Eating and Fitness; Substance Abuse Support Groups; Men’s and Women’s Support Groups; Holistic Healing appointments; Case Management.
+:name: St. Vincent de Paul   Wellness Center
+:phone: "(415) 552-5561\text.403"
+:services: []
+:url: svdp-sf.org/what-we-do/wellness-center/
+:what_to_bring: 

--- a/organizations/superior-court-of-california-county-of-san-francisco-access-center-legal-self-help.yml
+++ b/organizations/superior-court-of-california-county-of-san-francisco-access-center-legal-self-help.yml
@@ -42,3 +42,5 @@
   Changes, Evictions, Guardianship of the Person, Conservationship of the Person
 :url: www.sfsuperiorcourt.org/self-help
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/superior-court-of-california-county-of-san-francisco-access-center-legal-self-help.yml
+++ b/organizations/superior-court-of-california-county-of-san-francisco-access-center-legal-self-help.yml
@@ -1,0 +1,44 @@
+---
+:accessibility: Wheelchair accessible. ASL interpreters available. Other disabilities
+  are accommodated.
+:address: 400 McAllister Street, Room 509
+:contact_name: 
+:description: To provide linguistically and culturally appropriate self-help services
+  to individuals seeking to access and navigate the legal system in the county of
+  San Francisco. Areas of law are limited to Family Law and Civil Law
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None.
+:languages:
+- Cantonese
+- Mandarin
+- Toisanese
+- Spanish
+- Italian
+- Volunteers also speak Russian
+- French
+- Portuguese
+- Tagalog
+- French
+- ''
+- other languages
+- Materials are multilingual
+:miscellaneous: |-
+  Info Line:  (415) 551-5880
+  Hours: Monday, Tuesday, Thursday 8:30am – 12:00pm and 1:30pm - 4:00pm;
+  San Francisco, CA 94102
+  Notes: No referrals needed. Drop-ins available.
+  Eligible Populations: All individuals and family members.
+:name: Superior Court of California, County of San Francisco   ACCESS Center (Legal
+  Self-Help)
+:phone: 
+:services:
+- 'Family Law Services: Dissolution of Marriage/Domestic Partnership,  Legal Separation,
+  Annulment/Nullity of Marriage, Established Paternity/Parental Relationship, Child
+  Support, Domestic Violence Restrating Orders,Step-Parent Adoptions'
+- Civil Law, Small Claims, Civil Harassment Restraining Orders, Name Changes, Gender
+  Changes, Evictions, Guardianship of the Person, Conservationship of the Person
+:url: www.sfsuperiorcourt.org/self-help
+:what_to_bring: 

--- a/organizations/swords-to-plowshares-health-and-social-services.yml
+++ b/organizations/swords-to-plowshares-health-and-social-services.yml
@@ -1,0 +1,79 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1060 Howard Street, San Francisco, CA 94103
+:contact_name: James Robinson, Intake/ Eligibility Specialist
+:description: The vision of Swords to Plowshares is that all veterans will have access
+  to the care and services they need and deserve to rebuild their lives. War causes
+  wounds and suffering that last beyond the battlefield. Swords to Plowshares’ mission
+  is to heal the wounds, to restore dignity, hope and self-sufficiency to all veterans
+  in need, and to significantly reduce homelessness and poverty among veterans. Founded
+  in 1974, Swords to Plowshares is a community-based not-for-profit organization that
+  provides counseling and case management, employment and training, housing, and legal
+  assistance to veterans in the San Francisco Bay Area. We promote and protect the
+  rights of veterans through advocacy, public education and partnerships with local,
+  state and national entities.
+:eligible_population: All individuals, 18 and older, who are veterans of the U.S.
+  Military. Discharge status irrelevant.
+:email: jrobinson@stp-sf.org
+:faith_based: No.
+:fax: "(415) 252-4790"
+:fees: No client fees.
+:languages:
+- English
+- Spanish
+- Tagalog
+- Mandarin
+:miscellaneous: |-
+  Hours: Monday-Friday, 9:00am to 12:00pm and 1:00pm to 5:00pm
+  Transitional and Permanent Housing programs at other sites and not available for drop-in.
+  Employment services at 401 Van Ness, Suite 302
+  Notes: No referral required. Drop-ins are welcome. (Transitional and permanent housing are off-site, and not available for drop-ins.)
+:name: Swords to Plowshares   Health and Social Services
+:phone: "(415) 252-4788"
+:services:
+- Emergency Shelter
+- Hotel Vouchers
+- Permanent Housing
+- Rental Move-in Assistance
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Mail Service
+- Phone/Voicemail
+- Transit Vouchers
+- Move in/out assistance
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Medical Care
+- Anger Management
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Trauma Recovery Services
+- Vocational Education
+- Assessment & Application for Food Stamps, General Assistance, SSI
+- Credit Repair
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Housing & Eviction Defense
+- VA benefits assistance
+- Family Reunification
+- Parenting Support/Education
+- Visits of Family Members in Jails & Prisons
+- Referrals to other resources available as needed
+:url: www.swords-to-plowshares.org
+:what_to_bring: State-Issued ID, military discharge form DD-214. Program will assist
+  entering clients in getting these, and will see clients before the documentation
+  is complete.

--- a/organizations/swords-to-plowshares-health-and-social-services.yml
+++ b/organizations/swords-to-plowshares-health-and-social-services.yml
@@ -77,3 +77,5 @@
 :what_to_bring: State-Issued ID, military discharge form DD-214. Program will assist
   entering clients in getting these, and will see clients before the documentation
   is complete.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/swords-to-plowshares-legal-department.yml
+++ b/organizations/swords-to-plowshares-legal-department.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 1060 Howard Street, San Francisco, CA 94103
+:contact_name: 
+:description: War causes wounds and suffering that last beyond the battlefield. Our
+  mission is to heal the wounds, to restore dignity, hope and self-sufficiency to
+  all veterans in need, and to significantly reduce homelessness and poverty among
+  veterans. Many veterans never receive the benefits for which they are eligible.
+  The Legal Department of Swords to Plowshares helps veterans to cut through the extremely
+  arduous VA benefits application process by providing free attorney representation,
+  case management, and advocacy to indigent veterans by seeking benefits.
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: "(415) 252-4790"
+:fees: None.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Tuesday to Thursday, 9:00am-11:45am
+  Notes: No referrals needed. Drop-ins available.
+  Eligible Populations: All veterans of the U.S. military. Must be homeless or veteran of the wars in Iraq or Afghanistan.
+:name: Swords to Plowshares   Legal Department
+:phone: "(415) 252-4788"
+:services:
+- Legal Assistance/Advocacy—access to benefits for veterans of the U.S. Military
+- Referral to other services provided, as appropriate
+:url: www.swords-to-plowshares.org
+:what_to_bring: TB Clearance; Proof of homelessnes and veteran status (Defense Department
+  Form 214). Program will assist clients in obtaining these documents.

--- a/organizations/swords-to-plowshares-legal-department.yml
+++ b/organizations/swords-to-plowshares-legal-department.yml
@@ -28,3 +28,5 @@
 :url: www.swords-to-plowshares.org
 :what_to_bring: TB Clearance; Proof of homelessnes and veteran status (Defense Department
   Form 214). Program will assist clients in obtaining these documents.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tenderloin-housing-clinic-housing-and-supportive-services.yml
+++ b/organizations/tenderloin-housing-clinic-housing-and-supportive-services.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 472 Turk Street, San Francisco
+:contact_name: Clinic Staff
+:description: THC provides affordable supportive housing in San Francisco to over
+  1,500 formerly homeless tenants in 16 master leased properties residing in the Tenderloin,
+  Mission, Union Square, and South of Market (SOMA) neighborhoods. Additionally, THC
+  owns and operates the Galvin Apartments, a building in SOMA, designed for tenants
+  transitioning out of Single Room Occupancy Hotels (SROs). The Housing Services Staff
+  are enthusiastic about helping clients retain and maintain their housing through
+  rental payment and money management services. THC provides supportive case management
+  to all THC tenants, using a harm reduction framework. Through the harm reduction
+  lens, each tenant is seen as an individual with unique needs. We attempt to serve
+  tenants in a fair, consistent and supportive manner, which builds upon their strengths
+  and promotes self-sufficiency.
+:eligible_population: 
+:email: 
+:faith_based: No.
+:fax: "(415) 921-8691"
+:fees: 
+:languages: []
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:30am to 4:00pm
+  Notes: To qualify for placement in a master lease hotel, prospective tenants must: 1) Be homeless. 2) Have a qualifying income.
+  3) Must be referred from an approved source.
+  Languages: English, Spanish, Cantonese, Mandarin, Assamese.
+  How to Sign Up for the Master Lease Program:
+  If you are a CAAP Recipient: Any client who is active and listed as homeless with their County Adult Assistance Program (CAAP) worker is eligible for master lease hotel housing. Check with your CAAP worker during your monthly Homeless Residency verification appointment regarding housing opportunities.  Your CAAP worker is the only person who can provide you with this information.
+  If you are a SSI/SSDI/SSA/VA/CAPI Recipient: To qualify for the Master Lease program, you must stay at a qualified emergency shelter or work with a qualified agency. These include: MSC South, Next Door, Hospitality House, Episcopal Sanctuary, A Woman's Place, Larkin St., Dolores St. or the Homeless Outreach Team. Each shelter has a designated number of referrals slots and has its own internal process for making referrals to THC. Please see your shelter case manager to learn about their referral process. If your income is CAAP you cannot be referred through a shelter.
+  If you are a Qualified Low-Income Working Individual: To qualify for the Master Lease program, you must stay at a qualified emergency shelter or work with a qualified agency. These include: MSC South, Next Door, Hospitality House, Episcopal Sanctuary, A Woman's Place, Larkin St., Dolores St. or the Homeless Outreach Team. Each shelter has a designated number of referrals slots, and has its own internal process for making referrals to THC. Please see your shelter case manager to learn about their referral process. If your income is CAAP you cannot be referred through a shelter.
+:name: Tenderloin Housing Clinic   Housing and Supportive Services
+:phone: "(415) 771-2427"
+:services:
+- Intake & Assessment, Case Management, Benefits Advocacy, Community Organizing, Mediation
+  with Property Management, Conflict Resolution, Support Groups, Social Events, Organized
+  Tenant Activities, Wellness Checks, and Referrals to other resources available as
+  needed
+:url: www.thclinic.org
+:what_to_bring: Referral source provides this information.

--- a/organizations/tenderloin-housing-clinic-housing-and-supportive-services.yml
+++ b/organizations/tenderloin-housing-clinic-housing-and-supportive-services.yml
@@ -37,3 +37,5 @@
   needed
 :url: www.thclinic.org
 :what_to_bring: Referral source provides this information.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tenderloin-housing-clinic-legal-services.yml
+++ b/organizations/tenderloin-housing-clinic-legal-services.yml
@@ -34,3 +34,5 @@
 :url: www.thclinic.org
 :what_to_bring: State-Issued ID, Social Security card, Rental Agreement and/or lease,
   any late rent notices and/or Unlawful Detainer.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tenderloin-housing-clinic-legal-services.yml
+++ b/organizations/tenderloin-housing-clinic-legal-services.yml
@@ -1,0 +1,36 @@
+---
+:accessibility: No wheelchair access. Reasonable attempts to provide accommodations
+  will be provided as needed.
+:address: 126 Hyde Street, San Francisco, CA 94102
+:contact_name: Steven Shubert, Legal Manager
+:description: The Tenderloin Housing Clinic law office represents low-income tenants
+  in San Francisco in all aspects of landlord-tenant and housing law. We primarily
+  represent seniors, the disabled, and minority and immigrant families, often as defendants
+  in unlawful detainer actions and in affirmative lawsuits for wrongful eviction,
+  and to address substandard housing conditions. THC's attorneys are some of the most
+  experienced and well-respected attorneys in San Francisco, with decades of experience
+  representing low-income tenants. The law office also provides limited free legal
+  counseling to tenants.
+:eligible_population: 
+:email: steven@thclinic.org
+:faith_based: No.
+:fax: "(415) 771-1287"
+:fees: None.
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- Tagalog
+- Assamese
+:miscellaneous: |-
+  Hours: Monday-Friday, 9:00am to 5:00pm
+  Notes: No referrals needed. Drop-ins welcome.
+  Eligible Populations: San Francisco tenants facing landlord-tenant and housing issues.
+:name: Tenderloin Housing Clinic   Legal Services
+:phone: "(415) 771-9850"
+:services:
+- Free legal services for qualified participants
+:url: www.thclinic.org
+:what_to_bring: State-Issued ID, Social Security card, Rental Agreement and/or lease,
+  any late rent notices and/or Unlawful Detainer.

--- a/organizations/tenderloin-housing-clinic-new-roads-program.yml
+++ b/organizations/tenderloin-housing-clinic-new-roads-program.yml
@@ -35,3 +35,5 @@
 - Financial and Clothing Assistance
 :url: www.thclinic.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tenderloin-housing-clinic-new-roads-program.yml
+++ b/organizations/tenderloin-housing-clinic-new-roads-program.yml
@@ -1,0 +1,37 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 427 Turk Street, San Francisco, CA 94102
+:contact_name: Naomi Prochovnick
+:description: 'In partnership with San Francisco Adult Probation, the New Roads Program
+  provides services to clients who are on Adult Probation in San Franisco.  The New
+  Roads Program is a rental subsidy program designed for clients who are homeless
+  or unstably housed, and are seeking housing and financial stability.  Services for
+  clients accepted into the program include:  housing search assistance; rental subsidies;
+  financial assistance; and supportive setvices.  The goal for all New Roads clients
+  is to obtain permanent housing and increase monthly income during program participation,
+  in order to become self-sufficient.'
+:eligible_population: Clients must be referred  to the program by the San Francisco
+  Adult Probation Department, must be currently homeless or unstably housed, and have
+  at least 12 months remaining on supervision.
+:email: 
+:faith_based: No.
+:fax: "(415) 921-8691"
+:fees: 
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- Assamese
+:miscellaneous: |-
+  Hours: Monday – Friday, 9:30am to 4:00pm
+  Notes: Clients may phone or drop-in to inquire about services, but will need an appointment for an intake.  Clients must be on supervised Adult Probation in San Francisco and must be referred by their Deputy Probation Officer.
+:name: Tenderloin Housing Clinic   New Roads Program
+:phone: "(415) 771-2427 x125"
+:services:
+- Housing Placement Assistance
+- Rental Subsidies
+- Supportive Services
+- Financial and Clothing Assistance
+:url: www.thclinic.org
+:what_to_bring: 

--- a/organizations/tenderloin-housing-clinic-representative-payee-program.yml
+++ b/organizations/tenderloin-housing-clinic-representative-payee-program.yml
@@ -39,3 +39,5 @@
 :services: []
 :url: www.thclinic.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tenderloin-housing-clinic-representative-payee-program.yml
+++ b/organizations/tenderloin-housing-clinic-representative-payee-program.yml
@@ -1,0 +1,41 @@
+---
+:accessibility: The Representative Payee office has a small step at the front door.  There
+  is an office across the street from the payee office that is wheelchair accessible
+  and services can be rendered there for mobility impaired clients.
+:address: 447 Turk Street, San Francisco, CA  94102
+:contact_name: Epifanio Ruiz
+:description: Tenderloin Housing Clinic’s Representative Payee program provides representative
+  payee and money management services to low-income individuals residing in San Francisco
+  and receiving benefits from the Social Security Administration (this includes SSA,
+  SSDI, and SSI).  Clients must be permanently housed or must be willing to seek permanent
+  housing at the time of program entry.  The program assists clients with their housing
+  search.  The program helps clients receiving Social Security benefits budget their
+  income amount in a way that allows them to pay their essential bills and meet essential
+  needs, first and foremost.  This includes rent, food, and utility bills.
+:eligible_population: Clients must reside in San Francisco and must receive Social
+  Security benefits in order to be eligible for the program.  Housing is not a requirement
+  at program entry but clients must be willing to and obtain housijng after enrollment
+  in the program.
+:email: epifanio@thclinic.org
+:faith_based: No.
+:fax: "(415) 928-1058"
+:fees: No fees.
+:languages:
+- English
+- Spanish
+- Cantonese
+- Mandarin
+- Assamese
+:miscellaneous: "Hours: Monday – Friday, 9:30am to 4:00pm\nNotes: Clients may drop-in
+  to inquire about services, but will need an appointment for an intake.  Clients
+  can be placed on the waitlist through a referral from a community agency or a client
+  self-referal.  Individuals who are mandated by Social Security to have a payee and
+  those in Housing First buildings, are priortized on the waitlist.\nDirect Services:\t
+  SRO Housing Placement Assistance; Assistance Getting Driver’s License and Other
+  ID; Representative Payee Services; Money Management/Personal Financial Education;
+  Assistance and Advocacy Maintaining Social Security Benefits."
+:name: Tenderloin Housing Clinic   Representative Payee Program
+:phone: "(415) 336-6171  x114"
+:services: []
+:url: www.thclinic.org
+:what_to_bring: 

--- a/organizations/tenderloin-neighborhood-development-corporation-social-work-unit.yml
+++ b/organizations/tenderloin-neighborhood-development-corporation-social-work-unit.yml
@@ -1,0 +1,53 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 
+:contact_name: 
+:description: Tenderloin Neighborhood Development Corporation’s (TNDC) mission is
+  to provide safe, affordable housing with support services for low-income people
+  in the Tenderloin community and to be a leader in making the neighborhood a better
+  place to live. The Social Work Unit provides services with a Harm Reduction approach
+  and operates under the philosophy of "meeting clients where they are at." Tenants
+  are not required to participate in support services and all tenant participation
+  is 100% voluntary.
+:eligible_population: All currently homeless individuals with multiple diagnoses,
+  referred by Human Services Agency. May not have a criminal conviciton for a violent
+  offense within five years. May not have a criminal conviction for a sex offense
+  (lifetime), and may not be a registered sex offender. No drug-related convictions
+  within three years.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: No fees. Rent is based on regulatory requirements of each site.
+:languages:
+- English
+- Some Spanish
+- Tagalog
+- Cantonese
+- Mandarin
+- German
+- Vietnamese
+:miscellaneous: |-
+  Hours: Monday - Friday; 8:30am-5pm
+  Office Location: 215 Taylor Street, San Francisco, CA 94102.
+  Notes: No referral needed. Drop-ins welcome. Individuals must be housed at TNDC to receive services from the Social Work Unit.
+:name: Tenderloin Neighborhood Development Corporation   Social Work Unit
+:phone: "(415) 358-3938"
+:services:
+- Permanent Housing
+- Assistance Getting Drivers License or Other
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Tenants have access to Social Worker office phones during business hours
+- Shower Facilities
+- Transit Vouchers
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Intensive Case Management
+- Outreach
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- After-school Program
+- Referrals to other resources available as needed
+:url: www.tndc.org
+:what_to_bring: State-Issued ID, Social Security Card.

--- a/organizations/tenderloin-neighborhood-development-corporation-social-work-unit.yml
+++ b/organizations/tenderloin-neighborhood-development-corporation-social-work-unit.yml
@@ -51,3 +51,5 @@
 - Referrals to other resources available as needed
 :url: www.tndc.org
 :what_to_bring: State-Issued ID, Social Security Card.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/the-bread-project-employment-training-programs.yml
+++ b/organizations/the-bread-project-employment-training-programs.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: '1555 Park Ave #B, Emeryville, CA  94608'
+:contact_name: Rafi Amini, Intake & Outreach Specialist
+:description: Our mission is to empower individuals with limited resources on their
+  path to self-sufficiency through skills instruction, on-the-job training, and assistance
+  with establishing a career in the food service industry.  We currently offer a 3
+  week Bakery Bootcamp and a more in-depth 10 week Baking Training Program.
+:eligible_population: Individuals, 18 years and older who are legally eligible to
+  work in the U.S., no violent or sex offenses in the past 7 years (on a case by case
+  basis), no outstanding warrants, stable housing, and at least 5 months of sobriety.
+:email: rafi@breadproject.org  or info@breadproject.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- Dari
+- Pashtu
+- Nepali
+- Chinese
+:miscellaneous: |-
+  Intake Hours: Thursdays from 10:00am to 2:00pm
+  Notes: Referrals are preferred.  Drop-ins are allowed for intakes.  Appointments are accepted.  Participants must be able to stand for 8 hours and lift up to 25 pounds.
+:name: The Bread Project   Employment Training Programs
+:phone: "(888) 282-3522 x902 or (510) 594-1702"
+:services:
+- 'Vocational Training: 3 week Bakery Bootcamp and 10 week Baking Training Program'
+- Employment Placement Assistance
+- Employment Retention
+- Job Readiness/Life Skills
+:url: www.breadproject.org
+:what_to_bring: State-Issued ID; Social Security Card; Proof of Income; Proof of Address

--- a/organizations/the-bread-project-employment-training-programs.yml
+++ b/organizations/the-bread-project-employment-training-programs.yml
@@ -31,3 +31,5 @@
 - Job Readiness/Life Skills
 :url: www.breadproject.org
 :what_to_bring: State-Issued ID; Social Security Card; Proof of Income; Proof of Address
+:__meta__:
+  :version: 0.0.1

--- a/organizations/the-latino-commission.yml
+++ b/organizations/the-latino-commission.yml
@@ -41,3 +41,5 @@
 - Referrals to other resources available as needed
 :url: www.thelatinocommission.org
 :what_to_bring: State-Issued ID; TB Clearance. Will assist client in getting these.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/the-latino-commission.yml
+++ b/organizations/the-latino-commission.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Some sites in San Francisco are not wheelchair accessible.
+:address: 'Intake Address:  301 Grand Ave., Suite 301, S. San Francisco, CA  94080'
+:contact_name: Camilo Gonzalez, Intake Coordinator
+:description: The Latino Commission program design and methodology are derived from
+  models of culturally-sensitive treatment for Latinos which have been developed and
+  implemented in the last decade by the Latino Commission. The model incorporates
+  current best practices in services delivery to Latinos utilizing a solid family-centered
+  approach, one that integrates the concepts of conocimiento (self-awareness), respeto
+  (respect for others), and confianza (mutual trust) to create a traditional peer
+  support system.
+:eligible_population: All individuals, including adults with children, and pregnant
+  women. Must not be convicted of sex offense.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- Spanish
+- English
+:miscellaneous: |-
+  Intake Hours: Monday-Friday, 9am to 3pm
+  Intake Address:  301 Grand Ave., Suite 301, S. San Francisco, CA  94080
+  Locations: Casa Quetzal: 635 Brunswick, San Francisco, CA 94112; Casa Ollin: 161 Margaret Avenue, San Francisco, CA 94112; Aviva House: 1724 Bryant Street, SF, CA 94110
+  Notes: No referral needed. Appointments are recommended.
+  Client fees: Sliding scale.
+:name: The Latino Commission
+:phone: "(650) 244-0305"
+:services:
+- Transitional Housing
+- Access to Internet
+- Assistance Getting Driver’s License/Other ID
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Shower Facilities
+- Substance Abuse Treatment
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Access to Benefits
+- Parenting Support/Education
+- Referrals to other resources available as needed
+:url: www.thelatinocommission.org
+:what_to_bring: State-Issued ID; TB Clearance. Will assist client in getting these.

--- a/organizations/the-metropolitan-fresh-start-house-inc.yml
+++ b/organizations/the-metropolitan-fresh-start-house-inc.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: 
+:address: 1300 30th Ave., SF, CA  94122
+:contact_name: Richard Suydam, Intake Coordinator Administrator
+:description: 'The Metropolitan Fresh Start Program is a six-month (or longer) faith-based
+  transitional and outpatient program designed for men struggling with life’s problems.
+  The program is designed to provide progressive rehabilitation based on time-tested
+  social model programs: the process of learning through doing and experiencing plus
+  exposure of clients to positive role models through staff and volunteers.'
+:eligible_population: Men, ages 18-80. Must be clean and sober, must not have any
+  medical or mental health condition that would prohibit program participation.  May
+  not have conviction for sex offense or be a registered sex offender.
+:email: admin@freshstarthouse.org
+:faith_based: Yes - optional.
+:fax: 
+:fees: Minimum $850/month for residential treatment.  Funding available for veterans.
+:languages:
+- English
+:miscellaneous: |-
+  Hours: All Programs Residential; Office Hours: Daily, 8:00am to 5:00pm
+  Office Location/Treatment Center:
+  1300 30th Ave., SF, CA  94122
+  Mailing Address:
+  P.O. Box 12190, SF, CA  94117
+  Notes: No referral needed. Appointments only: Call Intake Coordinator. No drop-ins.
+:name: The Metropolitan Fresh Start House, Inc.
+:phone: "(415) 242-2412 Fax: (415) 242-2414"
+:services:
+- Alcohol/Drug Treatment
+- Anger Management
+- Clothing
+- Counseling
+- Food/Meals
+- Life Skills
+- Mentoring
+- Phone/Voicemail
+- Residential/Housing (6 months to 1 year)
+- Showers
+- Transit Vouchers
+- Referrals to other resources available as needed
+:url: www.metropolitanfreshstart.org
+:what_to_bring: 

--- a/organizations/the-metropolitan-fresh-start-house-inc.yml
+++ b/organizations/the-metropolitan-fresh-start-house-inc.yml
@@ -40,3 +40,5 @@
 - Referrals to other resources available as needed
 :url: www.metropolitanfreshstart.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/the-mission-at-kern-county.yml
+++ b/organizations/the-mission-at-kern-county.yml
@@ -38,3 +38,5 @@
 - Referrals to other resources available as needed
 :url: www.thebrm.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/the-mission-at-kern-county.yml
+++ b/organizations/the-mission-at-kern-county.yml
@@ -1,0 +1,40 @@
+---
+:accessibility: Wheelchair accessible
+:address: 816 East 21st Street, Bakersfield, CA  93305
+:contact_name: Staff
+:description: The Mission at Kern County is the largest provider of homeless and addiction
+  recovery services in all of Kern County.  The Mission at Kern County is the place
+  where the homeless and addicted can come not just for a day of food and night of
+  shelter, but Christ-centered long-term care that transforms lives. The Mission at
+  Kern County’s purpose is to offer an environment conducive to physical, emotional
+  and spiritual well-being of the people we serve by providing hope and future through
+  Jesus Christ.
+:eligible_population: male Only Shelter.  Must not have a conviction for any sex offense
+  or arson and no AB109 placement
+:email: info@themissionkc.org
+:faith_based: Yes.
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday-Thursday: 8:30-5:00pm Friday: 8:30-12:00pm
+  Notes: Please call for information regarding services.  No referral needed.
+:name: The Mission at Kern County
+:phone: "(661) 325-0863"
+:services:
+- Emergency Shelter
+- Hygiene/Personal Care Items
+- Food/Prepared Meals
+- Education Services
+- Primary Healthcare Services
+- Homeless Recovery Services
+- Counseling
+- Life Skills/Life Management
+- Spiritual Encouragement
+- Addiction Revovery/Substance Abuse
+- Discipleship Program
+- Referrals to other resources available as needed
+:url: www.thebrm.org
+:what_to_bring: 

--- a/organizations/this-sacred-space.yml
+++ b/organizations/this-sacred-space.yml
@@ -24,3 +24,5 @@
 :services: []
 :url: www.thissacredspace.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/this-sacred-space.yml
+++ b/organizations/this-sacred-space.yml
@@ -1,0 +1,26 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 'Mailing Address Only: Box 3, Fairfax, CA 94930'
+:contact_name: Kenneth Dale Johnson
+:description: This Sacred Space is an organization whose objective is to share with
+  those who are currently or formerly incarcerated the message that spiritual freedom
+  is available now. Using dialogue, contemplation and meditation, our program points
+  to this sacred space where the mind and heart experiences the peace that is eternally
+  present.
+:eligible_population: All individuals currently in prison or jail or recently released.
+  Must be clean and sober.
+:email: kenny@thissacredspace.org
+:faith_based: Yes.
+:fax: "(707) 933-8846"
+:fees: No fees.
+:languages:
+- English
+:miscellaneous: "Hours: Monday – Friday, 9:00am to 5:00pm\nMailing Address Only: Box
+  3, Fairfax, CA 94930\nNotes: No referral needed. Contact to set up an appointment.\nDirect
+  Services:\t Counseling and Mentoring. Referrals to other resources available as
+  needed."
+:name: This Sacred Space
+:phone: "(415) 706-3782"
+:services: []
+:url: www.thissacredspace.org
+:what_to_bring: 

--- a/organizations/tom-waddell-clinic-obot.yml
+++ b/organizations/tom-waddell-clinic-obot.yml
@@ -30,3 +30,5 @@
 :url: ''
 :what_to_bring: Proof of SF Residency. Program will assist entering clients in getting
   this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/tom-waddell-clinic-obot.yml
+++ b/organizations/tom-waddell-clinic-obot.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible.
+:address: OBOT Program, Tom Waddell urban Health Clinic, 230 Golden Gate Avenue, San
+  Francisco, CA  94102
+:contact_name: Margaret Farny RN, OBOT Program Coordinator
+:description: Substance abuse treatment under the harm reduction model.
+:eligible_population: All individuals with an opiate dependence.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Tom Waddell accepts medicare, medical, HSF (sliding scale)
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 4:30pm
+  Notes: Clients are referred from Ward 93, PCP, OBIC, UC, other CHC Sites. Drop-ins allowed, but appointments are preferred. Please call or write for appointment.
+:name: Tom Waddell Clinic   OBOT
+:phone: "(415) 647-6327"
+:services:
+- Hygiene/Personal Care Items
+- Mental Health Treatment
+- Substance Abuse Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Medical Care
+- Health & Wellness Education
+- Group Counseling/Therapy
+- Individual Counseling/Therapy
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: Proof of SF Residency. Program will assist entering clients in getting
+  this.

--- a/organizations/toolworks-janitorial-training-placement.yml
+++ b/organizations/toolworks-janitorial-training-placement.yml
@@ -41,3 +41,5 @@
 :what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency; Proof
   of homelessness; proof of disability.  These documents are not necessary to attend
   an info session.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/toolworks-janitorial-training-placement.yml
+++ b/organizations/toolworks-janitorial-training-placement.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 'Office at 25 Kearny Street, #400, San Francisco, CA  94104. Training site
+  on Treasure Island.'
+:contact_name: 
+:description: Toolworks, in partnership with people in disadvantaging conditions,
+  is a human service agency dedicated to providing the tools/resources to promote
+  independence, equality, and personal satisfaction.
+:eligible_population: 'Individuals, 18 years and older, who meet both eligibility
+  requirements of HEC Grant: 1) homelessness 2) disabled.'
+:email: rarbo@toolworks.org
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+- ASL
+:miscellaneous: |-
+  Specific Intake Days and Times:
+  Info session every Friday at 1:00pm
+  25 Kearny Street, #400
+  Training Hours: 6:45am to 11:45am
+  Notes: Referrals are not required to attend an info session. No drop-ins. Information session every Friday at 1:00pm at Kearny Street location.
+:name: Toolworks   Janitorial Training/Placement
+:phone: 
+:services:
+- Access to Internet
+- Assistance Getting Drivers License or Other ID
+- Hygiene/Personal Care Items
+- Phone/Voicemail
+- Intensive Case Management
+- Mentorship
+- Vocational Education
+- Assessment & Application for SSI
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Referrals to other resources available as needed
+:url: www.toolworks.org
+:what_to_bring: State-Issued ID; Social Security Card; Proof of SF Residency; Proof
+  of homelessness; proof of disability.  These documents are not necessary to attend
+  an info session.

--- a/organizations/transitions-clinic.yml
+++ b/organizations/transitions-clinic.yml
@@ -40,3 +40,5 @@
 :what_to_bring: State-issued ID, Social Security Card, and Proof of SF Residency.
   No additional documentation needed prior to entry, but will need these documents
   in 30 days for San Francisco insurance program. Program will assist entering clients.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/transitions-clinic.yml
+++ b/organizations/transitions-clinic.yml
@@ -1,0 +1,42 @@
+---
+:accessibility: Wheelchair accessible.
+:address: Southeast Health Center
+:contact_name: 'Ron Sanders, Juanita Alvarado, Joseph Calderon: Community Health Workers'
+:description: Transitions Clinic is a unique primary care clinic dedicated to recently
+  released chronically-ill men and women and their families. Transitional and primary
+  care services are available within the first two weeks upon release from prison.
+  Patients are supported by community health workers who have a history of incarceration.
+:eligible_population: Men, Women, Transgender people, Pregnant women, and families.
+:email: ronald.sanders@sfdph.org, juanita.alvarado@sfdph.org,  joseph.calderon@sfdph.org
+:faith_based: 'No'
+:fax: 
+:fees: None
+:languages:
+- English
+- Spanish
+- others
+:miscellaneous: |-
+  Clinic Hours: Wednesday 8am-12pm, Thursday 8am-12pm, Friday 8am-12pm
+  2401 Keith Street, San Francisco Ca 94124
+  Public Transportation: T Train, 54, 29
+  Notes: Community Health Workers are available by phone Monday through Friday 8am-5pm.  No drop-ins, must have appointment scheduled. Can be screened by community health workers by phone. For future doctor’s appointments, please contact community health workers.
+  Community Health Workers Services: All patients are supported by trained community health workers with a history of incarceration. Our clinic partners with many community organizations and are we not funded by the criminal justice system.
+:name: Transitions Clinic
+:phone: "(415) 671-7087 – office; Ron: (415) 933-4403 (cell); Juanita: (415) 730-5357
+  (cell); Joseph: (415) 676-0816 (cell)"
+:services:
+- Medical Care
+- Health & Wellness Education
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration support
+- Referrals to other resources available as needed
+- including referral for employment, housing, mental health and substance use treatment
+- 'Medical care on site: buprenorphine (suboxone), optometry, podiatry, acupuncture,
+  smoking cessation classes, lab services and nutrition'
+- Clothing & food access upon request
+:url: www.transitionsclinic.org
+:what_to_bring: State-issued ID, Social Security Card, and Proof of SF Residency.
+  No additional documentation needed prior to entry, but will need these documents
+  in 30 days for San Francisco insurance program. Program will assist entering clients.

--- a/organizations/turning-point-residential-treatment-program.yml
+++ b/organizations/turning-point-residential-treatment-program.yml
@@ -41,3 +41,5 @@
 - Outside AA/NA Meetings
 :url: www.daacinfo.org/PS_residential.shtml
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/turning-point-residential-treatment-program.yml
+++ b/organizations/turning-point-residential-treatment-program.yml
@@ -1,0 +1,43 @@
+---
+:accessibility: 'ADA Accommodations: Wheelchair accessibility.'
+:address: 2401 professional drive, Santa Rosa, CA  95401
+:contact_name: Central Intake Department
+:description: 'A program of center Point DAAC, Turning Point is a residential treatment
+  program from 30 to 270 days.  Turning Point Residential Program offers co-ed and
+  gender-specific services, with a specialized treatment track intended for those
+  with co-occurring mental health and substance abuse problems. Additional treatment
+  tracks include: Working Adults Program (for individuals seeking intensive treatment
+  while maintaining their employment) and an Opiate Addictions Program (in coordination
+  with Narcotic Replacement Therapy, such as Methadone or Suboxone).  Core components
+  of residential treatment at Turning Point includes initial participant assessment/placement,
+  individual, collateral/family and group counseling, case management and individualized
+  treatment planning, mental health evaluation and short-term on-site counseling support
+  as warranted, as well as services focusing on life skills such as maintaining health,
+  building and maintaining socially supportive relationships, recognizing and preventing
+  substance abuse relapse, avoiding violence and criminal behavior, recognizing and
+  shifting self-defeating thinking and behavior pattern, parenting skills and stress
+  management and improved coping skills.'
+:eligible_population: All individuals 18 and older who are residents of Sonoma County.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Sliding scale.  Funding available.  Will be discussed during intake.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Hours: Monday–Friday, 9:00am-5:00pm
+  Notes: Call first for appointment.  If you are interested in residential or outpatient care please call.
+:name: Turning Point   Residential Treatment Program
+:phone: "(707) 544-3295"
+:services:
+- Residential Substance Abuse Treatment
+- Outpatient
+- Individualized Treatment Plans
+- Case Management
+- Cognitive Behavioral Therapy
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Health & Wellness Education
+- Outside AA/NA Meetings
+:url: www.daacinfo.org/PS_residential.shtml
+:what_to_bring: 

--- a/organizations/u-s-department-of-veteran-affairs-san-francisco-va-downtown-clinic.yml
+++ b/organizations/u-s-department-of-veteran-affairs-san-francisco-va-downtown-clinic.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 4150 Clement Street, San Francisco, CA 94121
+:contact_name: 
+:description: The SFVAMC Downtown Clinic offers primary care and a wide array of mental
+  health services, including group and individual counseling, substance abuse, PTSD,
+  and compensated work therapy. The clinic is one of VHA’s first Comprehensive Homeless
+  Veterans Centers providing a full range of services to homeless veterans, and it
+  provides special care to homeless veterans through the Health Care for Homeless
+  Veterans program. The Downtown Clinic is a part of the San Francisco VA Medical
+  Center System.
+:eligible_population: All Veterans of the U.S. Military.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: None collected here, means test determines fees.
+:languages:
+- English
+- Tagalog
+- Translation services available for other languages
+:miscellaneous: |-
+  San Francisco VA Downtown Clinic Location: 401 3rd Street, San Francisco, CA 94107
+  Hours: Monday-Friday, 8:00am to 4:30pm
+  Notes: No referral needed. Drop-ins welcome.
+  San Francisco VA Medical Center
+:name: U.S. Department of Veteran Affairs   San Francisco VA Downtown Clinic
+:phone: "(415) 281-5100"
+:services:
+- Emergency Shelter
+- Transitional Housing CWT/TR Program
+- Access to Internet
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Phone/Voicemail
+- Shower Facilities
+- Storage Facilities
+- Mental Health Treatment
+- Substance
+- Abuse Treatment
+- Medical Care
+- Anger Management
+- Group Counseling/Therapy
+- Outreach
+- Referrals to other resources available as needed
+:url: www.sanfrancisco.va.gov
+:what_to_bring: Discharge form DD214. Program will assist entering clients in getting
+  this.

--- a/organizations/u-s-department-of-veteran-affairs-san-francisco-va-downtown-clinic.yml
+++ b/organizations/u-s-department-of-veteran-affairs-san-francisco-va-downtown-clinic.yml
@@ -46,3 +46,5 @@
 :url: www.sanfrancisco.va.gov
 :what_to_bring: Discharge form DD214. Program will assist entering clients in getting
   this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/ucsf-citywide-case-management-forensic-nova-therapy-program.yml
+++ b/organizations/ucsf-citywide-case-management-forensic-nova-therapy-program.yml
@@ -37,3 +37,5 @@
 - Referrals to other resources available as needed
 :url: www.cw-cf.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/ucsf-citywide-case-management-forensic-nova-therapy-program.yml
+++ b/organizations/ucsf-citywide-case-management-forensic-nova-therapy-program.yml
@@ -1,0 +1,39 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities are accommodated.
+:address: 982 Mission Street, San Francisco, CA 94103
+:contact_name: Yasi Shirazi, MFT, Clinical Supervisor
+:description: The purpose of this program is to provide culturally competent mental
+  health services in support of the Sheriff’s Department NoVA Program’s goals of aiding
+  offenders’ successful reentry into the community and reducing recidivism, treating
+  all individuals with dignity, compassion and respect.
+:eligible_population: Individuals who are enrolled in the SF Sheriff Department’s
+  NoVA program.
+:email: yasaman.shirazi@ucsf.edu
+:faith_based: No.
+:fax: "(415) 597-8004"
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Monday – Friday, 8:30am to 4:45pm; Saturday, 10:00am to 1:00pm
+  Notes: Clients must all be enrolled in the San Francisco Sheriff's Department NoVA program and be referred by his or her community-based case manager. No drop-ins.
+  Client fees: There are no client fees for NoVA therapy services.
+:name: UCSF   Citywide Case Management Forensic NoVA Therapy Program
+:phone: "(415) 597-8027"
+:services:
+- Mental Health Treatment
+- Co-occurring Disorder/Dual Diagnosis Treatment
+- Group and Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Trauma Recovery Services
+- Assistance with Assessment & Application for SSI
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Couples/Family Counseling
+- Referrals to other resources available as needed
+:url: www.cw-cf.org
+:what_to_bring: 

--- a/organizations/ucsf-citywide-case-management-forensic-program.yml
+++ b/organizations/ucsf-citywide-case-management-forensic-program.yml
@@ -50,3 +50,5 @@
 - Referrals to other resources available as needed
 :url: www.cw-cf.org/Home/citywide-forensics-project
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/ucsf-citywide-case-management-forensic-program.yml
+++ b/organizations/ucsf-citywide-case-management-forensic-program.yml
@@ -1,0 +1,52 @@
+---
+:accessibility: Wheelchair accessible. Other disabilities accommodated.
+:address: 982 Mission Street, San Francisco, CA 94103
+:contact_name: Marta Gilbert, Clinical Supervisor
+:description: 'The program is one of three intensive case management programs co-located
+  at 982 Mission Street, under the umbrella of the UCSF Department of Psychiatry''s
+  Community Services Division.  Mission Statement: "The Citywide Focus Center is a
+  UCSF site in which the Citywide Focus programs provide compassionate, respectful,
+  culturally and clinically competent, and comprehensive psychiatric services to individuals
+  with severe and persistent mental illnesses and to their families and support networks."'
+:eligible_population: Must meet Community Behavioral Health Services’s medical necessity
+  for a serious mental illness. For employment services only, must meet Department
+  of Rehabilitation’s criteria for mental illness.
+:email: marta.gilbert@ucsf.edu
+:faith_based: No.
+:fax: "(415) 597-8004"
+:fees: 
+:languages:
+- English
+- Spanish
+- Russian
+- Onsite translation in Chinese dialects
+- Vietnamese
+- ''
+- Tagalog
+:miscellaneous: |-
+  www.cw-cf.org/Home/citywide-forensics-project   psych.ucsf.edu
+  Hours: Monday – Friday, 8:30am to 4:45pm; Saturday, 10:00am to 1:00pm
+  Notes: Clients must have a referral from the San Francisco Behavioral Health Court, Jail Reentry Services, or Community Behavioral Health Services. Clients who wish to self-refer should first contact SF Mental Health Access at (415) 255-3737.
+  Client fees: Client fees are determined by Community Behavioral Health Services. Services are billed through Medi-Cal if available. No one is refused services due to lack of income or benefits.
+:name: UCSF   Citywide Case Management Forensic Program
+:phone: "(415) 597-8071"
+:services:
+- Mental Health Treatment
+- Co-Occurring Disorder/Dual Diagnosis Treatment
+- Anger Management
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Outreach
+- Post-Incarceration Support
+- Trauma Recovery Services
+- Assistance with Assessment & Application for General Assistance and SSI
+- Employment Training
+- Employment Placement
+- Employment Retention
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Representative Payee Services
+- Referrals to other resources available as needed
+:url: www.cw-cf.org/Home/citywide-forensics-project
+:what_to_bring: 

--- a/organizations/veterans-justice-outreach.yml
+++ b/organizations/veterans-justice-outreach.yml
@@ -28,3 +28,5 @@
 :services: []
 :url: ''
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/veterans-justice-outreach.yml
+++ b/organizations/veterans-justice-outreach.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: Kyong Yi, LCSW or
+:description: Veterans Justice Outreach (VJO) is a VA outreach program designed to
+  collaborate with local justice system partners to help veterans who enter the criminal
+  justice system and are in need of treatment services and/or alternatives to incarceration.
+:eligible_population: Vets who served before 1980; Vets who served after 1980 for
+  at least 2 years and received an honorable discharge. Other Vets may still get help
+  with housing and service referrals.
+:email: kyong.yi@va.gov or
+:faith_based: No.
+:fax: 
+:fees: 
+:languages:
+- English
+:miscellaneous: "Hours: Monday – Friday, 8:00am to 4:30pm\nAddress: San Francisco
+  VA Med Center\nDowntown Clinic 401 3rd Street, San Francisco, CA 94107\nNotes: No
+  referral needed. Contact to set up an appointment.\nClient fees: No fees.\nDirect
+  Services:\t Social Work Services:  Assistance Accessing VA Benefits; Housing; Referrals;
+  Employment Services; Residential Treatment Referrals.  Health Care Services: Medical;
+  Dental; Pharmacy; Inpatient Hospital Services.  Mental Health Services: Sexual Trauma
+  Counseling; Veteran Center Counseling Referrals; Substance Abuse Treatment; PTSD
+  & TBI Treatment.  Other Services: Showers & Laundry; Free Telephone Access (local);
+  Mail Box Service."
+:name: Veterans Justice Outreach
+:phone: "(415) 281-5159 or"
+:services: []
+:url: ''
+:what_to_bring: 

--- a/organizations/victory-outreach-san-francisco-victory-outreach-recovery-home.yml
+++ b/organizations/victory-outreach-san-francisco-victory-outreach-recovery-home.yml
@@ -1,0 +1,55 @@
+---
+:accessibility: 
+:address: 1266 Fitzgerald Avenue
+:contact_name: Edgardo Gonzalez, Pastor
+:description: No description
+:eligible_population: Men and women, 18 and older. May not have a criminal conviction
+  for sex offense; may not be a registered sex offender; may not be on psychiatric
+  medication.
+:email: info@vosf.org
+:faith_based: Yes - Christian.
+:fax: "(415) 710-4938"
+:fees: Free of charge unless they have a source of income.
+:languages:
+- English
+:miscellaneous: |-
+  url: www.vosf.org
+  Hours: Monday – Friday, 10:00am to 5:00pm
+  San Francisco, CA  94124
+  Notes: No referral needed. Appointments only—no drop-ins.
+:name: Victory Outreach San Francisco   Victory Outreach Recovery Home
+:phone: "(415) 644-0555"
+:services:
+- Housing
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- P.O. Box/Mail Service
+- Shower Facilities
+- Substance Abuse Treatment
+- Free Clinic for Physical Health
+- Anger Management
+- Community Education & Mediation
+- Group Counseling/Therapy
+- Intensive Case Management
+- Individual Counseling/Therapy
+- Mentorship
+- Outreach
+- Post-Incarceration Support
+- Restorative Justice/Survivor Impact
+- Trauma Recovery Services
+- Victim/Survivor Services
+- Basic/Remedial Education
+- Vocational Education
+- Assessment & Application for Food Stamps, General Assistance
+- Employment Training
+- Job Readiness/Life Skills
+- Money Management/Personal Financial Education
+- Clean Slate/Conviction Expungement Services
+- Couples/Family Counseling
+- Family Reunification
+- Parenting Support/Education Services for Children - Visits of Family Members in
+  Jails & Prisons
+- Referrals to other resources available as needed
+:url: www.vosf.org
+:what_to_bring: TB Clearance. Program will assist clients in getting this.

--- a/organizations/victory-outreach-san-francisco-victory-outreach-recovery-home.yml
+++ b/organizations/victory-outreach-san-francisco-victory-outreach-recovery-home.yml
@@ -53,3 +53,5 @@
 - Referrals to other resources available as needed
 :url: www.vosf.org
 :what_to_bring: TB Clearance. Program will assist clients in getting this.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/village-connect-culture-based-transformative-coaching-cbtc.yml
+++ b/organizations/village-connect-culture-based-transformative-coaching-cbtc.yml
@@ -30,3 +30,5 @@
 - Personal Development
 :url: www.village-connect.org/
 :what_to_bring: Desire to grow
+:__meta__:
+  :version: 0.0.1

--- a/organizations/village-connect-culture-based-transformative-coaching-cbtc.yml
+++ b/organizations/village-connect-culture-based-transformative-coaching-cbtc.yml
@@ -1,0 +1,32 @@
+---
+:accessibility: Wheelchair accessible
+:address: San Francisco/Oakland/Berkeley
+:contact_name: Gaylon Logan
+:description: Village Connect’s CBTC’s mission is to build capacity of people to become
+  more self-aware and self-directed resulting in sustainable positive transformation.  Our
+  philosphy of change is steeped in a culturally competent approach that is client-centered
+  and sensitive to the gender-specific and inter-generational dynamics critical to
+  the individual and group.    CBTC is a strength-based coaching model that maximizes
+  personal, professional, and academic potential.  Coaches/Facilitators trained in
+  the CBTC model support clients to meet life’s opportunities and challenges by providing
+  insights and guidance from an inside/out perspective rather than outside/in.  Utilizing
+  a culturally proficient curriculum and community-based interdisciplinary approach,
+  Village Connect effectively transforms the individual, family, and community.
+:eligible_population: Men, women, youth ages 12 and older
+:email: gl@village-connect.org
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Varies
+  Notes: CBTC is offered to individuals, groups and families.  Please call for information.
+:name: Village Connect   Culture Based Transformative Coaching (CBTC)
+:phone: "(510) 564-4240"
+:services:
+- Life Skills
+- Self-Empowerment
+- Personal Development
+:url: www.village-connect.org/
+:what_to_bring: Desire to grow

--- a/organizations/village-connect-human-sustainability-groups-hsg.yml
+++ b/organizations/village-connect-human-sustainability-groups-hsg.yml
@@ -26,3 +26,5 @@
 - Personal Development
 :url: www.village-connect.org/
 :what_to_bring: Desire to grow.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/village-connect-human-sustainability-groups-hsg.yml
+++ b/organizations/village-connect-human-sustainability-groups-hsg.yml
@@ -1,0 +1,28 @@
+---
+:accessibility: Wheelchair accessible.
+:address: San Francisco/Oakland/Berkeley
+:contact_name: Gaylon Logan
+:description: Aligned with our mission to build the capacity of people to become more
+  self-aware and self-directed resulting in sustainable positive transformation, HSG
+  is a peer support network and mentoring model of men, women, and youth coming together
+  for the purposes of healing and self-development through interactive processes,
+  networking, and education.  Subsequently providing leadership and excellence that
+  ignites and transforms community.
+:eligible_population: Men, women, youth 12 yrs. and older
+:email: gl@village-connect.org
+:faith_based: No.
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: |-
+  Hours: Varies
+  Notes: There are 3 variations of HSG: (1) Ongoing drop-in groups, (2) closed cohort based groups, which operates on 6-month cycles, and (3) closed cohort based groups, which requires a 12-month commitment.  Please call for information.
+:name: Village Connect   Human Sustainability Groups (HSG)
+:phone: "(510) 564-4240"
+:services:
+- Life Skills
+- Self-Empowerment
+- Personal Development
+:url: www.village-connect.org/
+:what_to_bring: Desire to grow.

--- a/organizations/weingart-center-homeless-services.yml
+++ b/organizations/weingart-center-homeless-services.yml
@@ -46,3 +46,5 @@
 :url: ''
 :what_to_bring: CA ID, Social Security Card, program will assist clients to obtain
   these documents, and no more than two weeks ‘of clothing.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/weingart-center-homeless-services.yml
+++ b/organizations/weingart-center-homeless-services.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair and other disabilities accommodated.
+:address: 'Locations:  566 South San Pedro Street, Los Angeles, CA 90013'
+:contact_name: Van Bellows
+:description: The Weingart Center is a non-profit comprehensive human services organization
+  that was established in 1983 after recognizing that widespread homelessness was
+  a new phenomenon facing the city of Los Angeles. The Weingart Center provides homeless
+  individuals with the basic skills necessary to stabilize their lives, secure income
+  and find permanent housing.  Our organization’s mission is to empower and transform
+  lives by delivering innovative solutions to combat poverty and break the cycle of
+  homelessness. The Weingart Center transitions homeless men and women from street
+  life to self-sufficiency through a variety of programs and services, such as: Workforce
+  Development, Mental Health & Substance Abuse Treatment, Case Management, Veterans
+  Transition Housing, Women’s Renaissance, Re-entry Programs, and various other solutions.
+:eligible_population: All individuals at least 18 years of age.
+:email: center@weingart.org
+:faith_based: No.
+:fax: "(213) 489-3108"
+:fees: 
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  url: weingart.org/
+  Hours: Monday-Friday 8:00am-4:30pm
+  Locations:  566 South San Pedro Street, Los Angeles, CA 90013
+  Notes: For assistance on how to get help, please call our Resource Center at 213-689-2160
+  Client fees: None.
+:name: Weingart Center   Homeless Services
+:phone: "(213) 627-2151"
+:services:
+- Emergency Shelter
+- transitional Housing
+- Assistance with Permanent Housing
+- Workforce Development
+- Vocational Training
+- Job Placement Assistance
+- Mental Health & Substance Abuse Treatment
+- Case Management
+- Veterans Transition Housing
+- Women’s Renaissance
+- Reenrty Programs
+- Trauma-Informed/Gender Responsive Programs
+- Clinical Services
+- Referrals to other resources available as needed
+:url: ''
+:what_to_bring: CA ID, Social Security Card, program will assist clients to obtain
+  these documents, and no more than two weeks ‘of clothing.

--- a/organizations/westside-community-services-services-for-adults.yml
+++ b/organizations/westside-community-services-services-for-adults.yml
@@ -1,0 +1,44 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 245 11th Street, San Francisco, CA 94103
+:contact_name: 
+:description: Westside Community Services has been providing an array of community-based
+  prevention, mental health, substance abuse, and social services to clients in the
+  City and County of San Francisco for 40 years. Incorporated in 1967, Westside is
+  one of the oldest community-based mental health agencies in the nation. The range
+  of programs and services has varied over the years, while a commitment to providing
+  excellent, high-quality, culturally and community appropriate programs has remained
+  central to the core of the organization.
+:eligible_population: San Francisco residents; other eligibility requirements may
+  apply. Contact program for specifics.
+:email: crisisclinic@westside-health.org
+:faith_based: No.
+:fax: "(415) 355-0349"
+:fees: 
+:languages:
+- English
+:miscellaneous: |-
+  Behavioral Health Services
+  outpatient@westside-health.org
+  ACT@westside-health.org
+  Methadone Maintenance & Detoxification
+  HIV Testing, Counseling & Linkages
+  AIDS Case Management & Home Care
+  CTL@westside-health.org
+  Things to Know
+  Client Fees: Sliding scale. Medi-Cal share of cost, if appropriate.
+:name: Westside Community Services   Services for Adults
+:phone: "(415) 355-0311"
+:services:
+- Advocacy
+- Chemical Dependency Services
+- Outreach
+- In-Home Support
+- Therapeutic Interventions
+- Care Coordination
+- Medication Monitoring and Health Screening
+- Crisis Assessment
+- Crisis Intervention
+:url: www.westside-health.org
+:what_to_bring: Program may require photo ID or other documentation. Contact Westside
+  for specifics.

--- a/organizations/westside-community-services-services-for-adults.yml
+++ b/organizations/westside-community-services-services-for-adults.yml
@@ -42,3 +42,5 @@
 :url: www.westside-health.org
 :what_to_bring: Program may require photo ID or other documentation. Contact Westside
   for specifics.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/westside-community-services-services-for-children-and-youth.yml
+++ b/organizations/westside-community-services-services-for-children-and-youth.yml
@@ -46,3 +46,5 @@
 - School Readiness Assistance
 :url: www.westside-health.org
 :what_to_bring: Please call for information.
+:__meta__:
+  :version: 0.0.1

--- a/organizations/westside-community-services-services-for-children-and-youth.yml
+++ b/organizations/westside-community-services-services-for-children-and-youth.yml
@@ -1,0 +1,48 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 
+:contact_name: 
+:description: Westside Community Services has been providing an array of community-based
+  prevention, mental health, substance abuse, and social services to clients in the
+  City and County of San Francisco for 40 years. Incorporated in 1967, Westside is
+  one of the oldest community-based mental health agencies in the nation. The range
+  of programs and services has varied over the years, while a commitment to providing
+  excellent, high-quality, culturally and community appropriate programs has remained
+  central to the core of the organization.
+:eligible_population: Youth up to 24 years of age who are exhibiting emotional problems
+  and are at risk of developing more serious problems such as mental illness and substance
+  abuse.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: Sliding scale. Accept MediCal, private insurance, Healthy Families, Healthy
+  Kids.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  www.westside-health.org
+  Child Youth & Family Outpatient Services and AJANI program (Afrocentric Family Focused Treatment)
+  1140 Oak Street
+  San Francisco, CA 94117
+  (415) 431-8252 Phone
+  (415) 431-3195 Fax
+  AJANI@westside-health.org
+  Notes:  For general info please call (415) 431-9000.
+  Things to Know:
+:name: Westside Community Services   Services for Children and Youth
+:phone: 
+:services:
+- Individual/Group/Family Therapy
+- Clinical Case Management (school and community-based)
+- Medication Support Services
+- Substance Abuse Prevention, Education, and Intervention
+- Social Skills Training
+- Anger Management
+- Vocational Resource Referrals
+- Educational and Literacy Support
+- Independent Living Skills Support
+- Housing Assistance
+- School Readiness Assistance
+:url: www.westside-health.org
+:what_to_bring: Please call for information.

--- a/organizations/wia-workforce-investment-act-breaking-thru-barriers.yml
+++ b/organizations/wia-workforce-investment-act-breaking-thru-barriers.yml
@@ -28,3 +28,5 @@
 - Supportive Services (transportation, union dues, book/school fees, etc)
 :url: oaklandpic.org/reentry
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/wia-workforce-investment-act-breaking-thru-barriers.yml
+++ b/organizations/wia-workforce-investment-act-breaking-thru-barriers.yml
@@ -1,0 +1,30 @@
+---
+:accessibility: Wheelchair accessible-NO.
+:address: 1212 Broadway, Suie 200, Oakland, CA  94612
+:contact_name: Zina Y. Taylor
+:description: 'Our mission is to improve employment, vocational training, and educational
+  outcomes via direct intervention/prevention post release of clients currently on
+  parole or probation. Program is to achieve a reduction of recidivism rates and associated
+  recidivist behaviors associated with Returning Citizens. Link to resource guide:'
+:eligible_population: All individuals between the age of 18 and 60 years old who are
+  Alameda County residents.
+:email: ztaylor@oaklandpic.org
+:faith_based: 'No'
+:fax: 
+:fees: None
+:languages:
+- English
+:miscellaneous: |2
+
+  Hours: Monday –Friday, 8:30am-4:45pm
+  Notes:  This program is dedicated to the formerly incarcerated returning residents
+  (Parole/Probation) needing help finding employment.
+:name: WIA Workforce Investment Act   Breaking Thru Barriers
+:phone: "(510) 768-4462"
+:services:
+- Job Readiness/Life Skills
+- Employment Training
+- Employment Placement
+- Supportive Services (transportation, union dues, book/school fees, etc)
+:url: oaklandpic.org/reentry
+:what_to_bring: 

--- a/organizations/women-s-community-clinic-women-s-community-clinic-outreach-services.yml
+++ b/organizations/women-s-community-clinic-women-s-community-clinic-outreach-services.yml
@@ -31,3 +31,5 @@
 - Referrals to other resources available as needed
 :url: www.womenscommunityclinic.org
 :what_to_bring: 
+:__meta__:
+  :version: 0.0.1

--- a/organizations/women-s-community-clinic-women-s-community-clinic-outreach-services.yml
+++ b/organizations/women-s-community-clinic-women-s-community-clinic-outreach-services.yml
@@ -1,0 +1,33 @@
+---
+:accessibility: Wheelchair accessible.
+:address: 1833 Fillmore Street, San Francisco, CA  94115
+:contact_name: 
+:description: The mission of the Women’s Community Clinic is to improve the health
+  and well-being of women and girls. We believe preventive, educational care is essential
+  to lifelong health and that all women deserve excellent health care, regardless
+  of their ability to pay. We work hard to ensure that each client feels comfortable
+  and safe using her voice to direct the care she receives.
+:eligible_population: Women, Transgender people, 12 years and older, Women with children.
+:email: 
+:faith_based: No.
+:fax: 
+:fees: All services are free.
+:languages:
+- English
+- Spanish
+:miscellaneous: |-
+  Phones staffed: Monday – Friday, 1:00pm to 9:00pm; Tuesday, Friday and Saturday, 9:30am to 1:00pm
+  Appointment Hours: Monday and Wednesday, 5:00pm to 9:00pm; Tuesday and Thursday, 1:00pm to 9:00pm; Friday, 9:00am to 5:00pm; Saturday, 9:00am to 1:00pm.
+  Drop-in Hours: Tuesdays, beginning at 8:30am. Open until full.
+  Notes: No referral needed. Drop-ins allowed. See above.
+:name: Women's Community Clinic   Women's Community Clinic Outreach Services
+:phone: "(415) 379-7800"
+:services:
+- Clothing
+- Food/Prepared Meals
+- Hygiene/Personal Care Items
+- Medical Care
+- Health & Wellness Education
+- Referrals to other resources available as needed
+:url: www.womenscommunityclinic.org
+:what_to_bring: 

--- a/sources/apd/guide_2013.txt
+++ b/sources/apd/guide_2013.txt
@@ -1,0 +1,5718 @@
+﻿Community Housing Partnership (CHP)
+CHP is a San Francisco-based nonprofit organization.  CHP’s mission is to help homeless people secure housing and become self-sufficient.  Community Housing Partnership is an outcome focused nonprofit that fulfills its mission by developing and managing high quality supportive housing and providing services to homeless individuals, seniors and families to help them rebuild their lives and break the cycle of homelessness. www.chp-sf.org 
+
+To Get Connected
+Administration Mailing Address: 
+Occupancy & Compliance
+519 Ellis St., San Francisco, CA  94109
+Phone: (415) 563-3205 x123
+Email:  housingopportunities@chp-sf.org
+
+For information regarding properties with and without wait lists please call 415-563-3205 x123, or visit www.chp-sf.org
+
+Properties Without Waitlists:
+684 Ellis Street
+850 Broderick Street
+650 Eddy Street
+365 Fulton
+25 Essex
+3155 Scott
+374 5th St.
+810 Avenue D
+
+Notes: The above properties do not maintain waitlists.  All vacancies are filled through referrals provided to CHP by programs through the HSA and DPH depending on the property.  Please visit the website for more info.
+Things To Know
+Languages Spoken: English 
+What to Bring: State-Issued ID. Program will assist client in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None
+Eligible Population: All currently homeless individuals and family members.  There are additional eligibility requirements per property that may include, but not limited to, annual income limits and verified disability.  Please visit the website for more onformation.
+Faith Based: No.
+
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Hygiene/Personal Care Items; Phone/Voicemail; Substance Abuse Treatment; Health & Wellness Education; Intensive Case Management; Outreach; Assessment & Application for Food Stamps, General Assistance, and SSI; Employment Training; Job Readiness/Life Skills; Parenting Support/Education; Services for Children. Referral to other services as needed.
+Catholic Charities/CYO   Leland House
+Cathonic Charities/CYO’s mission is to house homeless people with disabling HIV and AIDS. At Leland House, which provides permanent housing, we respond to residents on a Harm Reduction basis working with behaviors as they become difficult for others and when they  impede the safety of the resident themselves.  www.cccyo.org
+
+To Get Connected
+Contact Persons:  Timothy Quinn, Intake Coordinator
+Phone: (415) 405-2063 
+Fax: (415) 337-1137
+Email: TQuinn@cccyo.org 
+Intake Days: Wednesdays and Thursdays
+Facility Hours: 24 hours/7 days
+Location: 141 Leland Avenue, San Francisco, CA  94134 
+Notes: Referral required. Intake appointment needed – no drop-ins.
+Things To Know
+Languages Spoken: English, Spanish and German.
+What to Bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance; Medi-Cal card or other proof of insurance so that medications can be ordered.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Rent is calculated at 30% of monthly income. There is an annual income limit.
+Eligible Population: All currently homeless individuals, 18 years or older, with disabling HIV or AIDS, psychiatric disorders or substance abuse issues.
+Faith Based: No.
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Voicemail; Shower Facilities; Utilities (hot water, heat); Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education through in house dietician; Anger Management; Group Counseling/Therapy - Anger Management, HIV Support, Harm Reduction; Money Management/Personal Financial Education; Many additional supportive services available upon referral behavioral health, employment, case management, and other specialists, as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Compass Family Services   SF Home  
+Compass SF HOME helps families in danger of homelessness to stabilize and maintain their housing and rapidly re-houses homeless families so that they can work towards long-term economic self-sufficiency.  The program is designed to help homeless families find a unit, and then provide a rental subsidy paired with case management until the family increases their income to the point that they can pay the rent on their own.    www.compass-sf.org
+
+To Get Connected
+Contact Person: Beth Mitchell, Program Director
+Phone: (415) 644-0504 ext. 2201
+Email: bmitchell@compass-sf.org 
+Location: 995 Market St, 5th Floor, SF 94103
+Notes: Please call for more information and to receive an application packet.  No referral required but families we prioritize families who are either in a shelter or on the Connecting Point family shelter waitlist. 
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: We will let you know what documents are needed at the time you apply.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None, although families must pay 40-50% of their net income towards the rent in their unit.
+Eligible Population: Homeless families staying in San Francisco. Must have more than 50% custody of a child under 18, minimum income of $500, maximum income 50% AMI. Must have a concrete plan to increase your income to the point where you can afford rent.
+Faith Based: No.
+
+Direct Services: Assistance Obtaining Permanent Housing; Rental Subsidies; Intensive Case Management; Education and Professional Goals; Money management; Access to a Food Pantry; Clothing; Personal Hygiene Products; Diapers and Baby Supplies; Transportation Assistance; Access to Educational/Recreational Activities for Children. 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hamilton Family Center   The Dudley Apartments
+Our mission is to break the cycle of homelessness and poverty.  Through a housing-first approach, we provide a continuum of housing solutions and hands-on services that promote self-sufficiency for families and individuals, and foster the potential of children and youth.  The Dudley Apartments is a 75-unit Permanent Supportive Housing development where Hamilton family Center offers intensive case management services for single adults, seniors, families, and children managing disabilities who have experienced homelessness.  www.hamiltonfamilycenter.org
+To Get Connected
+Contact Person: Mary Brown, Case Manager
+Phone: (415) 861-8645 x105
+Fax:  (415) 861-86447
+Email: mbrown@hamiltonfamilycenter.org 
+Location: 172 6th Street, San Francisco, CA  94103
+Notes: Please call for an appointment.  Referal from a service provider who can supply a certificate of homelessness is required.  A waitlist is managed through Mercy Housing.  
+See listing under Hamilton First Avenue program for other housing options and instructions.
+
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: State issued ID, Social Security Card.  Program will assist clients getting these documents.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: Client pays 30% of their income toward rent.
+Eligible Population: Men, women, transgender, pregnant women, women with children, families.  There are extensive restrictions for this program as it works with Mercy Housing providing section 8 units.  Please contact the Dudley Apartments staff for more information.
+Faith Based: No.
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Driver’s License/Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Shower Facilities; Mental Health Treatment; Health & Wellness Eductaion; Intensive Case Management; Individual Counseling/Therapy; Housing Placement Assistance; Assistance Applying for CalFresh/Food Stamps; Assistance Applying for PAES/GA/CalWorks; Assessment & Application for SSI; Credit Repair; Job Readiness/Life Skills; Money Management/Personal Financial Eduction; Assistance Applying for Health Insurance; Couples/Family Counseling; Family Reunification; Parenting Support/Education; Services for Children.
+
+
+San Francisco Human Services Agency   San Francisco Rental Assistance Program
+Provide back rent or security deposit to low income San Francisco residents meeting criteria. www.sfhsa.org
+
+To Get Connected
+Contact Person: Darlene Fernandez-Ash, Rental Assistance Coordinator
+Phone: (415) 557-6484  
+Fax: (415) 557-6033 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Mailing Address: P.O. Box 7988, San Francisco, CA 94120, worker #ZB34
+Notes: After verifying need and eligibility based on phone or mail inquiry, clients are referred to a community agency that can help them complete a rental assistance application. No drop-ins.
+Things To Know
+What to Bring: State-Issued ID; Social Security Card; Birth Certificates (for children); Proof of Income; Lease Agreement; and other supporting documentation, as needed.
+Client fees, if any: None.
+Primary Community Served: Low-income (80% AMI or below) families with minor children in their custody; adults (verifiably disabled, senior 55+), emancipated foster youth, veterans, victim of recent violence. Must be San Francisco resident.
+Faith Based: No.
+
+Direct Services: Assistance with back rent; security deposit; critical family needs. Referrals to other services as needed.
+Tenderloin Housing Clinic   New Roads Program
+In partnership with San Francisco Adult Probation, the New Roads Program provides services to clients who are on Adult Probation in San Franisco.  The New Roads Program is a rental subsidy program designed for clients who are homeless or unstably housed, and are seeking housing and financial stability.  Services for clients accepted into the program include:  housing search assistance; rental subsidies; financial assistance; and supportive setvices.  The goal for all New Roads clients is to obtain permanent housing and increase monthly income during program participation, in order to become self-sufficient. www.thclinic.org
+
+To Get Connected
+Contact Person: Naomi Prochovnick
+Phone: (415) 771-2427 x125  
+Fax: (415) 921-8691 
+Hours: Monday – Friday, 9:30am to 4:00pm
+Location: 427 Turk Street, San Francisco, CA 94102
+Notes: Clients may phone or drop-in to inquire about services, but will need an appointment for an intake.  Clients must be on supervised Adult Probation in San Francisco and must be referred by their Deputy Probation Officer.
+Things To Know
+Languages Spoken:  English, Spanish, Cantonese, Mandarin, Assamese. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: Clients must be referred  to the program by the San Francisco Adult Probation Department, must be currently homeless or unstably housed, and have at least 12 months remaining on supervision.
+Faith Based: No.
+
+
+
+Direct Services: Housing Placement Assistance; Rental Subsidies; Supportive Services; Financial and Clothing Assistance.
+Tenderloin Housing Clinic   Housing and Supportive Services
+THC provides affordable supportive housing in San Francisco to over 1,500 formerly homeless tenants in 16 master leased properties residing in the Tenderloin, Mission, Union Square, and South of Market (SOMA) neighborhoods. Additionally, THC owns and operates the Galvin Apartments, a building in SOMA, designed for tenants transitioning out of Single Room Occupancy Hotels (SROs). The Housing Services Staff are enthusiastic about helping clients retain and maintain their housing through rental payment and money management services. THC provides supportive case management to all THC tenants, using a harm reduction framework. Through the harm reduction lens, each tenant is seen as an individual with unique needs. We attempt to serve tenants in a fair, consistent and supportive manner, which builds upon their strengths and promotes self-sufficiency. www.thclinic.org
+
+To Get Connected
+Contact Person: Clinic Staff
+Phone: (415) 771-2427 
+Fax: (415) 921-8691
+Hours: Monday – Friday, 9:30am to 4:00pm
+Location: 472 Turk Street, San Francisco
+Notes: To qualify for placement in a master lease hotel, prospective tenants must: 1) Be homeless. 2) Have a qualifying income. 
+3) Must be referred from an approved source. 
+Things To Know
+Languages: English, Spanish, Cantonese, Mandarin, Assamese.
+What to Bring: Referral source provides this information.
+Accessibility: Wheelchair accessible.
+Faith Based: No.
+
+How to Sign Up for the Master Lease Program:
+If you are a CAAP Recipient: Any client who is active and listed as homeless with their County Adult Assistance Program (CAAP) worker is eligible for master lease hotel housing. Check with your CAAP worker during your monthly Homeless Residency verification appointment regarding housing opportunities.  Your CAAP worker is the only person who can provide you with this information.
+
+If you are a SSI/SSDI/SSA/VA/CAPI Recipient: To qualify for the Master Lease program, you must stay at a qualified emergency shelter or work with a qualified agency. These include: MSC South, Next Door, Hospitality House, Episcopal Sanctuary, A Woman's Place, Larkin St., Dolores St. or the Homeless Outreach Team. Each shelter has a designated number of referrals slots and has its own internal process for making referrals to THC. Please see your shelter case manager to learn about their referral process. If your income is CAAP you cannot be referred through a shelter.
+
+If you are a Qualified Low-Income Working Individual: To qualify for the Master Lease program, you must stay at a qualified emergency shelter or work with a qualified agency. These include: MSC South, Next Door, Hospitality House, Episcopal Sanctuary, A Woman's Place, Larkin St., Dolores St. or the Homeless Outreach Team. Each shelter has a designated number of referrals slots, and has its own internal process for making referrals to THC. Please see your shelter case manager to learn about their referral process. If your income is CAAP you cannot be referred through a shelter.
+
+Direct Services: Intake & Assessment, Case Management, Benefits Advocacy, Community Organizing, Mediation with Property Management, Conflict Resolution, Support Groups, Social Events, Organized Tenant Activities, Wellness Checks, and Referrals to other resources available as needed. 
+
+
+ARA First Step Home   Sober Living House 
+The Alcoholics Rehabilitation Association of San Francisco, Inc., operates the ARA First Step Home, a residence for men and women who are suffering from alcoholism. Our main objective is to return the alcoholic to his or her rightful place in society. The recovery program is oriented towards Alcoholics Anonymous. Help is also provided to make use of community resources to aid in the recovery process. All residents are required to attend the Monday and Thursday A.A. meetings held at 7:30 PM in the First Step Home and one outside meeting of their choice. They will also be required to attend the weekly home forum meeting on Tuesdays at 6:30 PM.       www.arafirststephome.com
+
+To Get Connected
+Contact Person:  ARA Staff
+Phone: (415) 863-3661 
+Fax: (415) 863-3670
+Email:  arahouse@pacbell.net 
+Specific Intake Days and Times: Monday, Wedensday, Friday 6:30am-9:30am	
+Hours: Monday – Friday, 6:00am to 2:00pm, Saturday and Sunday, 7:00am to 10:00am
+Location: 1035 Haight Street, San Francisco, CA  94117 
+Notes: Applicants are referred to the house by institutions, clinics, AA clubs, members, doctors, and other responsible individuals.  If you are on probation or parole, you must be on supervision in San Francisco.  We do not accept probationers or parolees from other counties.
+Checklist
+1. Call to be sure you meet the minimum requirements.
+2. Telephone Interview.
+3. Once accepted to waiting list, check-in Mon, Wed., & Fridays 9-5.
+4. Know the House Meeting requirements.
+5. Valid identification
+6. TB test required upon entering or within 1st seven days. 
+ 
+Things To Know
+Languages Spoken: English 
+What to Bring: Valid Identification  
+Client fee, if any:  Call for information.
+Eligible Population: The primary qualifications for residence in the ARA First Step Home are:
+1. Completion of a primary program (minimum 28 days) within the last year.
+2. An honest and sincere desire to gain and maintain sobriety.
+3. The need for food, shelter, and an atmosphere of friendly understanding.
+4. Ability and willingness to accept gainful employment.
+Faith Based: No
+Direct Services: Sober Living; Transitional Housing; Meals; AA Meetings.  There are three meetings of Alcoholics Anonymous held at the Home each week. Attendance at meetings is considered a requirement of residence in the Home.
+CATS   A Woman’s Place-CARE Program
+The CARE Program offers Transitional Housing for up to 18 months available for HIV+ women (including transgender women) residents of San Francisco; services also include case management and – if needed – mental health counseling.   www.catsinc.org
+
+To Get Connected
+Contact Persons: Pau Lagarde, HIV Case Manager/Mental Health Worker
+Phone: (415) 293-7364 
+Email: pau@awpcats.org
+Days and Times: Sunday-Thursday, 8am-4pm. 
+Location: 1049 Howard St. San Francisco, CA 94103 
+Notes: Prefer that clients be referred by service provider, but clients can self-refer by calling contact person (above) and scheduling intake appointment.  Clients must provide documentation of HIV+ status and income verification at intake.  Program is Harm-Reduction-based: there are no sobriety requirements for clients, but no substance use is allowed on the premises. 
+ 
+
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Letter of Diagnosis for HIV+ and tb clearance documentation – both within 6 months; current income verification.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: 30% of monthly net income, plus requirement to set aside additional money in savings account – amount to be determined.
+Eligible Population: Homeless HIV+ women (including transgender women) residents of San Francisco. 
+Faith Based: No.
+Direct Services: Transitional Housing;  Case Management; Mental Health Counseling.
+
+Center on Juvenile and Criminal Justice (CJCJ)   Cameo House Alternative Sentcing Program
+In partnership with the San Francisco Adult Probation Department, the Center on Juvenile and Criminal Justice’s Cameo House serves criminally involved pregnant and parenting women, who are certified as homeless (as defined by the City and County of San Francisco).  The goal of Cameo House is to identify eligible women who are awaiting adjudication and recommend to the courts that they be sentenced to Cameo House in lieu of State Prison or County Jail, when appropriate.  All women residing at Cameo House must have at least one child in their custody, have active reunification services with at least one of their children or be pregnant at the time of enrollment. Cameo House is a 12-month program but clients can remain for up to two years.  All residents must be willing to participate in case management and other clinical services as a condition of the residency. During their stay at Cameo House women are expected to obtain employment, reunify with at least one of their children, remain clean and sober (verified through random UAs conducted at Cameo House at least once per month), satisfy their Probation requirements, and obtain steady employment; with the goal being for them to obtain and sustain permanent housing.  Cameo House Residents work intensively with our on-site Case Manager and Therapist to insure that all these objectives are met. www.cjcj.org
+
+To Get Connected
+Contact Person: Intake/Staff
+Phone: (415) 703-0600 
+Fax: (415) 703-0550
+Facility Hours: 24 hours/7 days
+Location: Located in San Francisco. Write to Cameo House, 40 Boardman Place, San Francisco, CA 94103.
+Notes: Clients may call for more information about the referral process.  Appointments required.
+Things To Know
+Languages Spoken: English and Spanish. 
+Client fees, if any: None.
+Eligible Population: Formerly incarcerated women with young children. May not have a criminal conviction for a sex offense or be a registered sex offender.
+Faith Based: No.
+
+Direct Services: Assistance with Permanent Housing; Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Storage Facilities; Transit Vouchers; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Community Education & Mediation; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach; Post-Incarceration Support; Restorative Justice/Survivor Impact; Basic/Remedial Education; College & Graduate Education; GED & High School Education; Reading/Literacy; Assessment & Application for Food Stamps, General Assistance, SSI; Credit Repair; Employment Training; Employment Retention; Money Management/Personal Financial Education; Representative Payee Services; Clean Slate/ Conviction Expungement Services; Inmate & Parolee Legal Issues; Employment Law; Childcare; Family Reunification; Parenting Support/Education; Services for Children. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+Compass Family Services   Compass Clara House
+Compass Clara House (CCH) is a two-year transitional housing program of Compass Family Services and is aimed at supporting families with minor children to permanently break the cycle of homelessness.  Through intensive case management, on-site therapy, life skills classes, parenting support, on-site licensed childcare for children through age 5, after school programs, education/vocational support, money management, and recovery support, our two-year program helps families build a lasting foundation for success.
+www.compass-sf.org
+To Get Connected
+Contact Person: Felicia Less, Intake Coordinator
+Phone: (415) 644-0504 ext. 5104
+Email: fless@compass-sf.org 
+Hours: Monday – Friday, 10:00am to 6:00pm
+Location: 111 Page Street, San Francisco, CA 94102
+Notes: Clients must be referred by a social service agency (such as a family shelter or substance abuse treatment program. Appointment required. 
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: First, case manager or referring agency speaks with intake coordinator. After that, necessary documents include TB Clearance, proof of custody of minor(s), proof of income (if any), and identification information (state-issued or other) are required.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: 30% of monthly income for program fees, and a mandatory 20% of monthly income towards savings, returned upon exit.
+Eligible Population: Only homeless families with minor children.  Parents or guardians must have 50% legal and physical custody of the children or a solid reunification plan.  Clients must have 6 months clean prior to being referred.  Clients who have experienced domestic violence must be able to demonstrate at least 2 months separation from batterer.  Must not have a conviction for a violent offence, sex offenses, or arson.
+Faith Based: No.
+
+Direct Services: Case Management; Life Skills; Permanent Housing Placement; Licensed Child Care and Afterschool Activities; Transitional Housing (up to 2 years); Individual Therapy; Educational/Vocational Support. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+GEO Reentry Services   Taylor Street Facility  
+GEO Reentry Services’ mission is to help prepare individuals to reintegrate back to society and be responsible individuals who are accountable for their actions. Placements usually last from six months to one year. www.geogroup.com 
+
+To Get Connected
+Contact Persons: Daionne Washington
+Phone: (415) 346-9769 
+Fax: (415) 346-0358
+Facility Hours: 24 hours/7 days
+Location: 111 Taylor Street, San Francisco, CA  94102 
+Notes: Must be referred by CDCR Agent of Record or Federal BOP, Probation Officer/ Federal Pretrial services. Self-pay county beds call for info. No drop-ins.
+Things To Know
+Languages Spoken: English, some Spanish. 
+What to Bring: TB Clearance. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Self-pay residents pay $80/day. No sliding scale. All other residents are covered by an agency. BOP requires 25% of income for subsistence. No cost for CDCR residents but residents must save 75% of net income in saving account for their release.
+Eligible Population: All individuals without criminal conviction for sex offense, arson, or who are not registered sex offenders.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Shower Facilities; Transit Vouchers; Mental Health Treatment; Substance Abuse Treatment; Anger Management; Community Education & Mediation; Individual Counseling/Therapy; Post-Incarceration Support; Victim/Survivor Services; Basic/Remedial Education; GED & High School Education referral; Reading/Literacy; Vocational Education; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Family Reunification; Parenting Support/Education. Referrals to other resources available as needed.
+
+Good Shepherd   Gracenter
+As a Women's Secondary Recovery Program, Good Shepherd Gracenter offers housing, case management and supportive services.  The program is based on 12-step spirituality and a holistic approach. The program’s mission is based on a belief in the dignity and worth of each person as a child of God. Participants are expected to stay at least six months. www.gsgracenter.org 
+To Get Connected
+Contact Person: Sandra Munoz, Case Manager
+Phone: (415) 337-1938 
+Fax: (415) 337-4668
+Email: smunoz@gsgracenter.org  
+Location: 1310 Bacon St., San Francisco, CA 94134 
+Notes: No referral needed. Appointment needed – No drop-ins.
+Things To Know
+Languages Spoken: Spanish, Greek, English 
+What to Bring: State-Issued ID, Social Security Card, TB Clearance; Medical Clearance
+Accessibility: ADA Accessibility Plan in place by June, 2010
+Client fees: $300/month minimum.
+Eligible Population: Women and Transgender Women. May not have criminal convictions for sex or arson offenses. May not be a registered sex offender.
+Faith Based: Yes, the program is faith based. 
+
+Direct Services: Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Shower Facilities; Transit Vouchers; Community Education and Mediation; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Restorative Justice/Survivor Impact; Support with Assessment and Application for Food Stamps, General Assistance, SSI, Credit Repair; Job Readiness and Life Skills; Money Management/Personal Financial Education; Representative Payee Services. Referrals to other resources available as needed.
+
+Hamilton Family Center   First Avenues Program
+The mission of Hamilton Family Center is to break the cycle of homelessness and poverty. Through a Housing First approach, HFC provides a continuum of housing solutions and comprehensive services that promote self-sufficiency for families and individuals, and foster the potential of children and youth. In July 2006, HFC launched a city wide Housing First Initiative called First Avenues: Housing Solutions for Families. First Avenues’ primary focus is to return families to independent living and to assist families and individuals to maintain their housing. First Avenues assists families with addressing housing barriers, such as; eviction and credit problems, locating and securing rental units, and accessing available resources for rental and move-in assistance, and short-term rental subsidies. Families applying for First Avenues financial assistance grants and/or residing in a San Francisco shelters may access the housing services from a First Avenues Homeless Prevention Case Manager including; Bay Area housing search, linkage to fair market housing, linkage to affordable, subsidized, permanent supportive housing, Housing Authority waitlists, etc, housing application assistance, housing advice and counseling, landlord/tenant assistance, address obstacles such as bad credit and history of eviction, access credit reports, deposit and move-in assistance, application to short term rental subsidies, for those whom are eligible.  www.myhousing.org  www.hamiltonfamilycenter.org
+To Get Connected
+Contact Person: Intake Specialist 
+Phone: (415) 614-9060 ext. 108
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 255 Hyde Street, San Francisco
+Notes: Applications for the Rental Subsidy Program can be picked up at the office.  To qualify prospective applicants must: 1) Be homeless or at risk of homelessness in San Francisco. 2) Have a qualifying income. 
+3) Must have legal custody of at least one minor child. 
+Things To Know
+Languages Spoken: English, Spanish, Cantonese.
+What to Bring: All required documents are listed on the front of the Rental Subsidy Application. 
+Accessibility: Wheelchair accessible. 
+Client fees, if any: No client fees.
+Eligible Population: Individuals who are currently homeless or at risk of losing their housing.
+Faith Based: No.
+
+Move-In Assistance 
+Once housing is secured, First Avenues will provide a qualifying family with a grant towards deposit and/or first month’s rent. First Avenues Move-In Assistance grants are one-time only. Deposits can be accessed for housing located both in and outside of San Francisco. 
+Eligibility Criteria:
+•	Family unit with legal custody of minor children 
+•	Homeless, must provide appropriate documentation i.e. Certification of Homelessness 
+•	Moving within or from San Francisco. 
+•	Family has sufficient resources to pay monthly rent
+
+Rental Subsidy Program:
+The First Avenues Rental Subsidy Program is targeted towards working families in San Francisco. Families may be in shelter or in housing on the verge of homelessness. The Rental Subsidy Program provides eligible families with monthly rental assistance for3-24 months. Families must demonstrate an ability to increase their income by at least the amount of the subsidy and recertify quarterly for eligibility, need and progress. This subsidy is used to enhance each family’s employment goals and maintain their housing goals as they move towards self-sufficiency. Families pay 50% of their monthly income towards rent and the rental assistance maximum per family is $800 per month. The rental subsidy is only applicable to market rate and affordable housing options; it cannot be applied to subsidized options like housing authority where the family’s rental amount is determined by a percentage of their income. Families enrolled in this program receive home-based support services* for the duration of their financial assistance. 
+
+Eligibility Criteria: 
+•  Family is living in a shelter or transitional housing program in San Francisco or is housed in San Francisco and at risk of losing their housing; 
+•  Have a household member who is working part or full-time, and/or families on Cal Works who are transitioning into work; 
+•  If the family did not receive the subsidy they would be paying over 50% of their income toward rent; 
+•  Income must be less than 50% AMI in San Francisco; 
+•  Family has the ability to increase their monthly income and take over the full rent by the end of the program term.
+
+Eviction Prevention Program:
+First Avenues Eviction Prevention assistance is a one time, maximum $1,500 grant to families and individuals facing imminent eviction and subsequent homelessness. The grant must prevent an eviction and avert the family or individual from entering shelter. First Avenues Eviction Prevention targets households who are at risk of eviction and who would be able to retain their housing with one-time rental assistance. Households receive follow up phone calls to ensure that they have remained stably housed.
+
+Eligibility Criteria:
+•  Must have a legal lease
+•  W-9 from the landlord (or can obtain one from the landlord) 
+•  Eviction Notice (within 30 days)
+•  Ability to pay rent forward.
+Households need to call the Eviction Prevention Specialist at 415-614-9060 ext. 114
+
+Direct Services: Eviction Prevention Assistance, Rental Move-in Assistance; Access to Internet; Clothing; Food/Prepared Meals; Transit Vouchers (youth passes for MUNI); Mental Health Treatment; Substance Abuse Treatment; Health & Wellness Education; Group Counseling/Therapy; Outreach; Employment Placement; Job Readiness/Life Skills; Money Management/Personal Financial Education; Housing & Eviction Defense; Couples/Family Counseling; Parenting Support/Education; Services for Children. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+Hamilton Family Center   Transitional Housing Program
+The Hamilton Family Center Transitionl Housing program seeks to break the cycle of homelessness and poverty. Through a housing-first approach, we provide a continuum of housing solutions and hands-on services that promote self-sufficiency for families and individuals, and foster the potential of children and youth. The Transitional Housing Program offers 20 high-needs families interim housing with comprehensive support services for up to 18 months.  www.hamiltonfamilycenter.org
+To Get Connected
+Contact Persons: Front Desk
+Phone: (415) 409-2100 ext 100
+Fax: (415) 345-0471
+Email: thp.intake@hamiltonfamilycenter.org 
+Location: 1631 Hayes St, San Francisco, CA 94117
+Notes: Clients are required to have a referral from a social service provider and needs to have a certificate of homelessness.  Appointment required.
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: State-Issued ID, Social Security Card; birth certificates for children in physical/ legal custody and back rent notice or certification of homelessness. Program will try to assist client in getting these.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Clients pay 30% of their income towards rent and an additional 20% into savings that is returned to them when they exit the program.
+Eligible Population: Families (any adult/s with children) with at least one child under 18 in physical or legal custody or be in the 3rd trimester or 5th month of high risk pregnancy
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance getting Driver’s License/ID; Clothing; Mental Health treatment; Health & Wellness Education; Intensive Case Management; Individual Counseling, Housing Placement Assistance; Assistance Applying For CalFresh/Food Stamps; Assessment & Application for SSI; Credit Repair; Job Readiness/Life Skills; Money Management/Personal Financial Education; Assistance Applying For Health Insurance; Couples/Family Counseling; Family RAeunification; Parenting Support/Education; Services For Children.
+
+
+Harbor House The Salvation Army    
+Our mission is to create and deliver integrated solutions to profound social problems. Since 1991, The Salvation Army Harbor House has operated housing programs, provided chemical dependency treatment, workforce solutions, and other supportive services to single parent families with children or in reunification, who are homeless.   www.harborhousesf.org 
+To Get Connected
+Contact Persons: Aviva Zuckrow, Director
+Phone: (415) 503-3029 
+Email: aviva.zuckrow@usw.salvationarmy.org 
+Specific Intake Days and Times: Mon-Fri
+Hours: 8am-4pm
+Location: Call for location.
+Notes: Referral from a case manager or other person in a professional capacity, i. e. parole agent required. By appointment only -- No drop-ins.
+Things To Know
+Languages Spoken: English. 
+What to Bring: State-Issued ID, TB Clearance, if Veteran, Form DD214. Program may be able to assist clients in getting these.
+Client fees, if any: 30% of income-when income is in place. If just coming from prison, no charge until income in place.
+Eligible Population: Men, Women, Women with children, All families. May not have conviction for sex offense or be a registered sex offender. 
+Faith Based: No.
+Direct Services: Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Shower Facilities; Transit Vouchers; Substance Abuse Treatment; Dental Care; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration Support; Workforce Services; Assessment & Application for Food Stamps, Cal WORKS, General Assistance; Credit Repair; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Childcare; Family Reunification; Parenting Support/EducationServices for Children. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lutheran Social Services of Northern California   Forensic Housing Program
+The Forensic Housing Program is a HOPWA-funded transitional housing program for homeless HIV+ men and women (including transgender men and women) who’ve been incarcerated at the county, state or federal level within the past 12 months.  The program provides short term emergency shelter and transitional housing of up to 18 months while participants receive coordinated case management support to help stabilize their lives.  
+url: lssnorcal.org/what_we_do/san-francisco-programs/supportive-housing/forens.html
+
+To Get Connected
+Contact Persons: Frank Perez, Program Manager
+Phone: (415) 351-1337 
+Fax: (415) 351- 1228
+Email: fperez@lssnorcal.org
+Hours: Monday-Friday, 9am-5pm
+Location: Kinney Hotel, 410 Eddy St., San Francisco, CA  94109
+Notes: Clients must be referred by a primary case manager who will continue to provide services; referral process includes submitting program paperwork, letter of HIV+ diagnosis, income verification (if client already has income) and care plan. Client must be willing to follow rules and participate in program designed to provide stabilization and ensure transition into permanent housing
+ 
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: letter of HIV+ diagnosis, income verification and care plan must be provided at or by intake appointment.
+Accessibility: Not wheelchair accessible.
+Client fees, if any: 30% of monthly net income plus additional mandatory 20% monthly savings. 
+Eligible Population: HIV+ men and women (including transgender men and women) who’ve been incarcerated at the county, state or federal level within the past 12 months.  
+Faith Based: No.
+Direct Services: Transitional Housing; Case Management. Additional program services include housing advocacy, money management services, linkages to HIV prevention, access to benefits counseling/advocacy, workshops/groups focused on teaching basic life skills, access to medical, access to oral health care, and access to behavioral health services targeting post-incarcerated individuals living with HIV/AIDS in the city and county of San Francisco, CA.   
+
+
+The Metropolitan Fresh Start House, Inc.
+The Metropolitan Fresh Start Program is a six-month (or longer) faith-based transitional and outpatient program designed for men struggling with life’s problems. The program is designed to provide progressive rehabilitation based on time-tested social model programs: the process of learning through doing and experiencing plus exposure of clients to positive role models through staff and volunteers.  www.metropolitanfreshstart.org
+To Get Connected
+Contact Person: Richard Suydam, Intake Coordinator Administrator 
+Phone: (415) 242-2412 Fax: (415) 242-2414 
+Email: admin@freshstarthouse.org  
+Hours: All Programs Residential; Office Hours: Daily, 8:00am to 5:00pm
+Office Location/Treatment Center: 
+1300 30th Ave., SF, CA  94122
+Mailing Address:
+P.O. Box 12190, SF, CA  94117
+Notes: No referral needed. Appointments only: Call Intake Coordinator. No drop-ins.
+Things To Know
+Languages Spoken: English.
+Client fees, if any: Minimum $850/month for residential treatment.  Funding available for veterans.
+Eligible Population: Men, ages 18-80. Must be clean and sober, must not have any medical or mental health condition that would prohibit program participation.  May not have conviction for sex offense or be a registered sex offender. 
+Faith Based: Yes - optional.
+
+Direct Services: Alcohol/Drug Treatment; Anger Management; Clothing; Counseling; Food/Meals; Life Skills; Mentoring; Phone/Voicemail; Residential/Housing (6 months to 1 year); Showers; Transit Vouchers. Referrals to other resources available as needed.
+Nanny’s Sober Living
+To help men and women maintain recovery while taking on everyday life challenges to self independence.
+To Get Connected
+Contact Person: Suritha Jackson
+Phone: (415) 240-7526
+Phone: (916) 583-1917
+Fax: (415) 401-0500
+Email: nannys.sober.living@gmail.com
+Hours: Vary. Please call or write first.
+Location: 1686 Oakdale Avenue, San Francisco, CA 94124
+Notes: No referral needed. No drop-ins. Please call or write for appointment.
+Things To Know
+Languages Spoken: English.
+What to Bring: TB Clearance. Program will assist client in getting this.
+Client fees, if any: Varies, depending on income.
+Eligible Population: Men and women, 18 years and older. Cannot serve child sex offenders or minors; cannot serve individuals with a criminal conviction for gang-related offense, arson, or are registered sex offenders.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Assistance Getting Driver’s License or other ID; Food/Prepared Meals/ Hygiene/Personal Care Items; Phone/Voicemail; Shower Facilities; Group Counseling/ Therapy; Individual Counseling/Therapy; Family Reunification. Referrals to other resources.
+
+Our Father’s Sober Living Environment    
+Our Father’s SLE (OFSLE) provides service-structured, low-cost transitional housing to recovering men who have become displaced as a result of substance abuse and addiction.  Located in the Bayview Community, our home is designed to assist recovering men at the transitional and community re-entry phases of their recovery and our length of stay ranges from 6 months up to 1 year.  www.cleanlounge.info
+To Get Connected
+Contact Person:  Keesha Henry, Program Director
+Phone: (415) 926-0258
+Email:  keeshahenry@gmail.com
+Days and Hours: Monday-Friday, 9:00am to 5:00pm for intakes.
+Location: 1641 LaSalle Ave. San Francisco, CA 94124
+Notes: Appointments required.
+Things To Know
+Languages Spoken: English.
+What to Bring: California ID and any letters of recommendation or personal references to support your application to our program.
+Accessibility:  Not wheelchair accessible.
+Client fees: Shared rooms are $600/month.
+Eligible Population: Adult men, 18 years or older, with special outreach to veterans, seniors, parolees, and GBQT who have become homeless as a result of substance abuse/addiction.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/ Mail Service; Mental Health Treatment; Substance Abuse Treatment; Community Education & Mediation; Outreach; Post-Incarceration Support; Referrals to other resources available as needed.
+
+Phatt Chance Community Services
+Phatt Chance Community Services, Inc., (PCCS) is a nonprofit organization that provides transitional short and long-term housing and other basic support services to individuals reintegrating to society after incarceration, homelessness, and those with mental health concerns. PCCS provides a safe, clean & sober living environment, basic psychosocial services, as well as aftercare for clients in various stages of drug and/or alcohol abuse recovery. PCCS utilizes a reintegration model that provides minimum structure paired with maximum accountability, which allows program participants to pursue employment, continued education, counseling services and other off-site responsibilities when appropriate. The duration of clients’ stay at Phatt Chance Community Services depends entirely on the individual needs of each client.  http://phattchance.org 
+
+To Get Connected
+Contact Person: Intake/House Manager
+Phone: (415) 822-9922 
+Email: phattchancecommunity@gmail.com
+Intake Hours: Monday through Friday, 8 am to 4 pm and by appointment
+Location: San Francisco. Easily accessible by public transportation.
+Mailing Address: Phatt Chance Community Services, Inc., 2443 Fillmore Street #216, 
+San Francisco, CA 94115
+ 
+
+Things To Know
+Languages Spoken: English. 
+Client fees: Based on individual service needs. 
+Eligible Population: Male only, 18 years and older. 
+Faith Based: No.
+Notes: Long-term and short-term housing for men of any race, sexual orientation, ethnicity and faith.
+
+
+
+Direct Services: Transitional Housing; Clean & Sober Living; Mental Health Assessment; Substance Abuse Education; Relapse Prevention and Intervention; Treatment Referrals; In-house Peer Support Groups; Self-Esteem and Community Building; Life Skills Training.
+
+
+
+
+
+Recovery Survival Network (RSN)   Family of Friends Sober Living Network
+Our Mission: to help those who want to help themselves. Our goals: provide intensive case management coupled with clean and sober housing to help transition participants into self-sufficiency.   
+
+url: www.rsn2000.org
+To Get Connected
+Contact Persons: Lou Gordon, Executive Director; Kevin Henley, Program Manager
+Phone: (415) 552-1111 
+Fax: (415) 552-8444
+24 hour emergency hotline: 888-USE-NONE
+Email: rsn2000@gmail.com 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Locations: 
+3032-16th St., San Francisco, CA  94110
+3143-16th St., San Francisco, CA 94110
+68-6th St., San Francisco, CA 94103
+1312 Utah St., San Francisco, CA 94110
+1657 Market St., San Francisco, CA 94103
+30 Sycamore St., San Francisco, CA 94110
+2697 Mission St., San Francisco, CA 94110
+3308 Mission St., San Francisco, CA 94110
+Notes: RSN transitional housing requires a referral from SFAPD, Superior Court, or the SF Sheriff’s Department.  Appointments preferred.
+Things To Know
+Languages Spoken: English (translation for Spanish, Mandarin, Cantonese).
+What to Bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance. Program will assist entering clients in getting these.
+Accessibility: Some facilities accommodate people with mobility impairments.
+Client fees, if any: Clean and sober living housing rate is $1000.00 per month.
+Eligible Population: Men, Women, Transgender people. Individuals required to register as a sex offender are accepted on a case by case basis.  Clients need a referral.
+Faith Based: No.
+
+Direct Services: Stabilization Housing; Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Transit Vouchers; Mental Health Treatment; Substance Abuse Treatment; Co-occuring Disorder/Dual Diagnosis Treatment; Anger management; Community Education & Mediation; Intensive Case Management; Individual Counseling/Therapy (Peer-to-Peer only); Mentorship; Outreach; Post-Incarceration Support; Restorative Justice/Survivor Impact; Employment Training; Employment Placement; Job Readiness/Life Skills; Money Management/Personal Financial Education; Representative Payee Services; Family Reunification; Visits of Family Members in Jails & Prisons. Referrals to other resources available as needed.
+
+San Francisco Network Ministries Housing Corporation   San Francisco SafeHouse
+SafeHouse is an 18-month transitional housing program for women; we provide gender-specific responses to chronic homlessness for women in the commwercial sex industry.  Our clean and sober living community tempowers homeless women exiting prostitution gain the skills and resources they need to grow and become independent and self-sufficient members of society. Services include case management, substance abuse treatment, individual and group therapy, money management and financial education, vocational testing and guidance and assistance in finding permanent housing when leaving SafeHouse. www.sfsafehouse.org 
+To Get Connected
+Contact Person: Kristen Moore, Case Manager
+Phone: (415) 643-7861 
+Fax: (415) 643-1293
+Email: casemanager@sfsafehouse.org 
+Facility Hours: 24 hours/7 days; Intake Monday – Friday, 8:00am to 5:00pm
+Mailing Address:  P.O. Box 40369, San Francisco, CA  94140
+Location: Confidential location. 
+Notes: Clients can self-refer, or be referred by a provider; if the program beds are full, SafeHouse maintains a waitlist, and contacts prospective clients for intake..
+
+Things To Know
+Languages Spoken: English. 
+Client fees, if any: 30% of any government assistance and/or 20% of any earned income.
+Eligible Population: Women who are currently homeless, have a history of work in the sex industry, and have been clean and sober for at least 30 days. May not have a criminal conviction for arson or be a registered sex offender.
+Faith Based: No.
+Direct Services:  Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Shower Facilities; Storage Facilities; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Dental Care; Health & Wellness Education; menu planning and nutritionist weekly; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration Support; Trauma Recovery Services; Victim/Survivor Services; Basic/Remedial Education; College & Graduate Education; GED & High School Education; Assessment & Application for Food Stamps, General Assistance, SSI; Credit Repair; Job Readiness/Life Skills; Money Management/Personal Financial Education; Internship Program; Parenting Support/Education. Referrals to other resources available as needed.
+
+SF Strong
+In partnership with the Delancey Street Foundation, SF Strong is a transitional housing program for formerly incarcerated individuals.  The facility houses 15 men who have been released from local or state custody and/or are on probation or parole.  Program residents work with staff to develop an individualized reentry plan, including securing employment and/or participating in job training and education programs.  Approximate length of stay is 3 months, which varies based on individual needs. 
+To Get Connected
+Contact Persons:  Teri Delane
+Phone: (415) 340-3285 
+Email: sfstrong4336@gmail.com
+Hours: Monday – Friday from 9am – 5pm 
+Location: 4336 Irving St., SF, CA  94122
+Notes: Men who are exiting local or state incarceration.
+Things To Know
+Languages Spoken: English.
+Client fees, if any: No fees upon initial placement; as individuals secure income, they may be expected to pay for some program costs.
+Eligible Population: Men who are exiting local or state incarceration.
+Faith Based: No
+ 
+Direct Services:  Transitional Housing; Counseling and Groups; Assistance with Job Readiness; Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+Reentry Today
+Transitional housing and supportive services for people in recovery from substance abuse/addiction. 
+To Get Connected
+Contact Person: Chris Jones
+Phone: (415) 724-0311	
+Fax: (415) 658-7592
+Email:  cj122252@yahoo.com
+Hours: Monday – Friday, 9:00am-5:00pm
+Location: 1094 Gilman Street, San Francisco, CA 94124 
+Notes: No referral needed. Appointment required.
+
+
+Things To Know
+Languages Spoken: English. 
+What to Bring: No documents needed prior to entry. Program will assist with documentation after intake.
+Client fees, if any: $700/month
+Eligible Population: All individuals and family members. 
+Faith Based: No.
+
+Direct Services:	 Transitional Housing; Anger Management; Individual Counseling, Relapse Prevention; Substance Abuse Treatment; Job Readiness.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+Victory Outreach San Francisco   Victory Outreach Recovery Home
+No description
+url: www.vosf.org 
+To Get Connected
+Contact Persons: Edgardo Gonzalez, Pastor
+Phone: (415) 644-0555 
+Fax: (415) 710-4938
+Email: info@vosf.org 
+Hours: Monday – Friday, 10:00am to 5:00pm
+Location: 1266 Fitzgerald Avenue
+San Francisco, CA  94124 
+Notes: No referral needed. Appointments only—no drop-ins.
+
+Things To Know
+Languages Spoken: English. 
+What to Bring: TB Clearance. Program will assist clients in getting this. 
+Client fees, if any: Free of charge unless they have a source of income.
+Eligible Population: Men and women, 18 and older. May not have a criminal conviction for sex offense; may not be a registered sex offender; may not be on psychiatric medication. 
+Faith Based: Yes - Christian.
+
+Direct Services: Housing; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Shower Facilities; Substance Abuse Treatment; Free Clinic for Physical Health; Anger Management; Community Education & Mediation; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration Support; Restorative Justice/Survivor Impact; Trauma Recovery Services; Victim/Survivor Services; Basic/Remedial Education; Vocational Education; Assessment & Application for Food Stamps, General Assistance; Employment Training; Job Readiness/Life Skills; Money Management/Personal Financial Education; Clean Slate/Conviction Expungement Services; Couples/Family Counseling; Family Reunification; Parenting Support/Education Services for Children - Visits of Family Members in Jails & Prisons. Referrals to other resources available as needed.
+
+
+Emergency Shelter for Individuals
+If you are an adult without children with you, you can seek emergency shelter through any one of the following locations. These places can help you reserve a shelter bed during the days and times listed, at one of the emergency shelters for individuals in San Francisco.  Further, these locations can help you get connected to more permanent housing opportunities.
+Glide Walk-In Center
+Language(s) Spoken: English, Cantonese and Spanish
+Location: 330 Ellis Street, #101, San Francisco, CA 
+Hours: Monday - Friday: 7:00am to 11:00am; 4:00pm to 9:00pm
+Phone: (415) 674-6012	
+Fax: (415)775-1989
+Accessibility: Wheelchair accessible; all other reasonable accommodations as needed.
+Mission Neighborhood Resource Center
+Language(s) Spoken: English and Spanish
+Location: 165 Capp Street, between 16th and 17th Streets, San Francisco, CA 
+Hours:	Monday – Friday: 7:00am to 12:00pm and 2:00pm to 7:00pm (Thurs until 5pm) 
+Saturday: 7:00am to 12:00pm
+Phone: (415) 869-7977	
+Fax: (415) 241-9758
+Accessibility: Wheelchair accessible; all other reasonable accommodations as needed.
+Multi-Service Center (MSC) South
+Language(s) Spoken: English
+Location: 525 5th Street, San Francisco, CA 
+Hours:	24 Hours; Shelter Reservations from 5:00pm-1:00am
+Phone: (415) 597-7960	
+Fax: (415) 597-7946
+Accessibility: Wheelchair accessible; all other reasonable accommodations as needed.
+United Council of Human Services
+Language(s) Spoken: English and Spanish
+Location: 2111 Jennings Street, between Van Dyke and Wallace Avenues, San Francisco, CA 
+Hours:	Everyday: 7:00am to 9:00am (Breakfast), 9:00am to 5:00pm (Office Hours), 5:00pm to 7:00pm (Dinner), 7pm-9pm (Showers)
+Phone: (415) 671-1100	
+Fax: (415) 822-3436
+Accessibility: Wheelchair accessible; all other reasonable accommodations as needed.
+
+Direct Services:
+
+CATS   A Woman's Place
+CATS helps those most in need get off the street, achieve stability and establish permanent housing by providing compassionate, culturally sensitive services and stays of 4-18 months. www.catsinc.org
+To Get Connected
+Contact Persons: Case Manager on duty
+Phone: (415) 487-2140 Email: 
+Transitional Housing: sherita@awpcats.org 
+HIV Caseworker:  pau@awpcats.org
+Substance use treatmen: Blake@awpcats.org
+Program Coordinator: rachel@awpcats.org 
+Intake: Everyday 8am-4pm. 
+Facility Hours: 24 hours/7 days. Business hours: 8am-4:00pm; Drop-in 12pm-4:30pm.
+Location: 1049 Howard St. San Francisco, CA 94103 
+Notes: No referral needed. 
+
+Things To Know
+Languages Spoken: Spanish, English. 
+What to Bring: TB Clearance.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Emergency shelter clients do not pay program fees. Clients in Substance Abuse or Transitional Housing pay 30% of income based on HUD guidelines.
+Eligible Population: All Women, MTF Transgender people, Pregnant women. Program does not serve FTM Transgender individuals.
+Faith Based: No.
+Direct Services: Emergency Shelter; Transitional Housing;  Access to Internet (no computers available, wireless only); Food/Prepared Meals; Hygiene/Personal Care Items; Phones (no voicemai); Shower Facilities; Substance Abuse Treatment; Medical Care. Referrals to other resources available as needed.
+
+
+
+
+Emergency Shelter for Families
+If you are an adult with your children, you can seek emergency shelter for families through Compass Connecting Point for family shelters. You should get on this waiting list as soon as possible. If you need a family shelter bed tonight, contact Hamilton Family Residences and Emergency Center (on the following page). 
+Compass Family Services   Compass Connecting Point
+Compass Connecting Point (CCP) is a unique program that gives any San Francisco family experiencing a housing crisis quick access to the services that they need most, including eviction prevention, emergency shelter, health care, child care and eductional programs.  CCP manages the shelter waiting list for the City funded long-term family shelters.  Our goals are to place families into shelter and provide supportive services during that wait, including emergency food, diapers, transportation assistance, and intensive supoort with housing search.  Additionally CCP provides a one time interest free loan for move in funds and eviction prevention.  
+www.compass-sf.org/programs/connecting-point
+
+To Get Connected
+Contact Person: Any hotline worker or Crisis Intervention Counselor
+Phone: (855) 234-2667
+Fax:  (415) 442-5138
+Specific Intake Days/Times:  Monday 9am-12pm and 1pm-5pm; Tuesday 9am-12pm and 3pm-5pm; Wednesday 9am-12pm and 1pm-5pm; Thursday 9am-12pm and 2pm-5pm; and Friday 9am-12pm and 1pm-5pm
+Note:  No referral required.  All clients are required to do a 15 minute phone intake over the hotline at (855) 234-2667.  Drop-in services are available Monday 9am-12pm, Wednesday 10:30am-12pm, Friday 9am-12pm..  Families are typically on the waitlist for 6 to 8 months during which we provide supportive services.
+
+
+Things To Know
+Languages Spoken: English, Spanish, Cantonese, Mandarin, German.  We are able to arrange ASL interpreters.
+Accessibility:  Wheelchair accessible.
+Client fees: None
+Eligible Population: All families, pregnant women, women with children.  Eligible families have at least one legal adult plus either a minor child in their custody or a preganancy.  There is no maximum family size.  For shelter wait list, families must be homeless and receiving public benefits in SF or willing to transfer to SF.  For rental assisitance, families must be SF residents.  For move in funds, they must be homeless in SF and have a unit they have been accepted into.
+Faith Based: No.
+Direct Services: Emergency Shelter; Rental Move-In Assistance; Access to Internet; Assistance Getting Driver’s License or Other ID; Clothing; Food/Prepared Meals; Hygeine/Personal Care Items; P.O. Box/Mail Service; Transit Vouchers; Mental Health Treatment; Health & Wellness Education; Assistance Applying for Calfresh/Food Stamps.
+
+
+
+Hamilton Family Center   Hamilton Family Residence & Emergency Center
+Our mission is to break the cycle of homelessness and poverty. Through a housing-first approach, we provide a continuum of housing solutions and hands-on services that promote self-sufficiency for families and individuals, and foster the potential of children and youth. www.hamiltonfamilycenter.org
+To Get Connected
+Contact Persons: Any staff member.
+Emergency Center Phone: (415) 292-9930
+Emergency Bed Call-in #: (415) 292-5228 
+Fax: (415) 292-9951
+Call-ins for Emergency Beds twice daily:
+Monday to Friday, 11:00am and 5:00pm
+415-292-5228
+Facility Hours: 24 hours, 7 days
+Location: 260 Golden Gate Ave., San Francisco, CA 94102 
+Notes: Emergency beds are available daily for 1-night stays, and are given away on a first come, first served basis. Emergency Center program also has 60-day stays. Call Emergency Center for more information.
+Things To Know
+Languages Spoken: English & Spanish. 
+What to Bring: State-Issued ID, Social Security Card, Birth Certificate, and TB Clearance. Note: There is a grace period of a few days for individuals who are gathering these documents. Program will assist client in getting these documents.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: Must have child under 18 in physical or legal custody or be pregnant in third trimester or in fifth month of high risk pregnancy.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Access to Internet; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Local Phone; Shower Facilities; Transit Vouchers; Mental Health Treatment; Medical Care; Health & Wellness Education; Group Counseling/Therapy; Individual Counseling/Therapy; Job Readiness/Life Skills; Money Management/Personal Financial Education; After school programming and activities for children ages 0-18; Parenting Support/Education. Referrals to other resources available as needed.
+Domestic Violence Shelters   
+If you are in danger of violence, seek help. The following shelters offer temporary housing at confidential locations.
+Asian Women's Shelter   
+The mission of the Asian Women’s Shelter (AWS) is to eliminate domestic violence by promoting the social, economic, and political self-determination of women. AWS is committed to every person’s right to live in a violence-free home. It specifically addresses the cultural and language needs of immigrant, refugee, and U.S.-born Asian women and their children. AWS’s perspective is reflected in the agency’s broad strategy, which integrates culturally knowledgeable and language-accessible shelter services, educational programs, and community-based initiatives and advocacy. www.sfaws.org 
+To Get Connected
+Contact Person: Crisis Line 
+Phone: (415) 751-0880 
+Crisis Line: Monday – Friday, 9:00am to 5:00pm. After hours, crisis line rolls over to WOMAN, Inc.
+Mailing Address: 3543 - 18th Street #19, SF, CA 94110 
+Notes: No referral needed. Call crisis line at any time. Location is confidential, so no drop-ins, but call to get connected with services.
+Things To Know
+Languages Spoken: Arabic, Bengali, Cantonese, Dutch, Farsi, Georgian, Gujarati, Hindi, Indonesian, Japanese, Javanese, Kachi, Kannada, Korean, Lao, Mandarin, Punjabi, Russian, Spanish, Tagalog, Taiwanese, Tamil, Telugu, Thai, Toisa. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: no
+Eligible Population: Women, Transgender people, Pregnant women, Women with children, All families.  No male adults over the age of 18.
+Faith Based: No.
+Direct Services: Emergency Shelter; Rental Move-in Assistance; Access to Internet; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Phone/Voicemail; Shower Facilities; Storage Facilities; Transit Vouchers; Health & Wellness Education; Intensive Case Management; Outreach; Childcare (Emergency); Children Program Activities; Parenting Support/Education; Services for Children. Referrals to other resources available as needed.
+
+La Casa de las Madres
+La Casa offers a comprehensive continuum of support services for survivors of domestic violence. La Casa offers safety-first, empowerment and client-centered services. It offers crisis response, emergency shelter, and ongoing counseling and resource advocacy. Ending or escaping domestic violence is a process. Services are confidential. Individuals do not have to leave the abusive partner before accessing support.  www.lacasadelasmadres.org
+To Get Connected
+Phone: (415) 503-0500	
+24-Hour Hotline: (877) 503-1850 
+Fax: (415) 503-0301 Email: info@lacasa.org
+Hours: Monday – Friday, 8:30am to 5:00pm 
+Address: 1663 Mission Street, Suite 225, San Francisco, CA 94103 or 850 Bryant Street, 5th Floor SVU, San Francisco, CA 94103 
+Notes: No referral needed. Drop-ins available. Shelter location is confidential.
+Things To Know
+Languages Spoken: English, Spanish, Mandarin, Farsi, and Others. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: Free and confidential.
+Eligible Population: Women; Transgender Women; Women w/ Children; Pregnant Women; Teens, Age 11-24; if facing domestic violence.
+Faith Based: No. 
+Direct Services: Emergency Shelter; Legal Assistance/Advocacy; Accompany to Court Dates; Help/Vouchers to Get State ID; Parenting Support; Services for Children; Counseling; Life Skills; Mentoring; Trauma Recovery; Victim Services. Referrals to other resources available as needed.
+
+
+
+
+
+GED Testing Service
+Preparing to pay for college: Free Application for Federal Student Aid (FAFSA). One of the tools you can use to estimate your eligibility for federal student financial assistance is the Financial Aid Estimator Tool – FAFSA4caster – which is available online at www.fafsa4caster.ed.gov.  You may have heard that if you have been convicted of a felony, you are not eligible to receive financial aid. This is not necessarily true. A student convicted for the possession or sale of illegal drugs may have eligibility suspended if the offense occurred while the student was receiving federal student aid (grants, loans, or work-study). When you complete the Free Application for Federal Student Aid (FAFSA), you will be asked whether you had a drug conviction for an offense that occurred while you were receiving federal student aid. If the answer is yes, you will be provided a special worksheet to help you determine whether your conviction affects your eligibility for federal student aid. You may preview the worksheet in the FAFSA Information section at www.studentaid.ed.gov/pubs. If you have been convicted of a forcible or nonforcible sexual offense, and you are subject to an involuntary civil commitment upon completion of a period of incarceration for that offense, you are ineligible to receive a Federal Pell Grant.
+Contact:  gedtestingservice.com
+
+
+Direct Services:
+
+City College of San Francisco   Disabled Students Programs & Services (DSPS)
+The overall mission of DSPS is to provide exemplary instruction, support services and access to students with disabilities. DSPS will support students with disabilities in educationally related activities consistent with the mission and vision of CCSF and in compliance with federal and state laws. To "level the playing field" for students with disabilities through ensuring equal access to programs and facilities and to provide reasonable accommodations for documented disabilities. www.ccsf.edu/dsps 
+To Get Connected
+Phone: (415) 452-5481
+TDD: (415) 452-5451
+Locations: 
+John Adams Campus
+1860 Hayes Street
+San Francisco, CA 94117 
+Ocean Campus
+50 Phelan Ave San Francisco, CA 94112
+Notes: Students can make an appointment to see a DSPS counselor at the Mission, Downtown, Chinatown, and Southeast campuses by calling (415) 452-5481.
+Things To Know
+Eligible Population: Individuals with a disability that causes a limitation in an educational setting. 
+Faith Based: No
+
+Direct Services:  Access to Internet; Mental Health Treatment; Medical Care; Disability Management Counseling; Group Counseling/Therapy, Test-Taking Anxiety Workshops; Basic/Remedial Education; College & Graduate Education; Creative or Performing Arts Programs; English as a Second Language; GED & High School Education; Vocational Education; Employment Training; Employment Placement. Referrals to other resources available as needed.
+ 
+
+City College of San Francisco   Guardian Scholars Program
+Our mission is to make the dream of attending college a reality for former foster youth or out of home placement youth in juvenile justice system.  
+url: https://www.ccsf.edu/en/student-services/student-counseling/guardians-scholars-program.html
+
+To Get Connected
+Contact Person: Reception
+Phone: (415) 239-3279 
+Hours: Monday –Thursday, 8:00am to 5:00pm; Closed Friday.
+Location: 
+Guardian Scholars Program
+50 Phelan Avenue
+Multi-Use Building
+Room MU298
+San Francisco CA, 94112
+
+Notes: Confirmation of foster youth or out-of-home placement status is required. Foster Youth Status (Referral from County Human Services agency); Out of Home Placement Status (Referral from County Juvenile Justice agency or State Social Services Agency). Drop-in services provided; appointments made on request.
+
+Things To Know
+Languages Spoken: English, Spanish. Additional language translation possible.
+What to Bring: Verification of foster youth or out of home placement status for at least one year when minor. Program will assist client in getting documentation.
+Eligible Population: All individuals 18-25 who have experienced foster care.
+Faith Based: No.
+
+Direct Services: Rental Move-in Assistance; Transitional Housing Referrals; Access to Internet; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Storage Facilities; Transit Vouchers; Mental Health Treatment referrals; Medical Care through referral either; Intensive Case Management; Mentorship; Basic/Remedial Education; Employment Training; Job Readiness/Life Skills; Money Management/Personal Financial Education; Legal Rights Workshops on Housing, Education, Employment; Summer College Readiness Program. Referrals to other resources available as needed.
+  
+
+City College of San Francisco   Second Chance Program
+The Extended Opportunity Programs and Services (EOPS) Second Chance program at City College of San Francisco (CCSF) serves students who are formerly incarcerated, offering them education as an alternative to incarceration. Through understanding and addressing the unique needs of this student population, the Second Chance program provides comprehensive academic support services with the goal of increasing their probability for academic success, while simultaneously reducing the likelihood of recidivism. www.ccsf.edu
+
+To Get Connected
+Contact Person: Charles E. Moore, Outreach Recruiter/Community Liaison 
+Email: cemoore@ccsf.edu 
+Phone: (415) 239-3075 
+Fax: (415) 239-3514
+Location: City College of San Francisco – EOPS, 50 Phelan Avenue, San Francisco, CA 94112  
+Hours: Monday – Friday, 8:00am to 2:00pm.
+Notes: No referral needed. Drop-ins allowed, but appointments are highly recommended. Applicants on probation or parole need to provide verification of their status from their probation/parole officer.
+Things To Know
+Languages Spoken: English. 
+What to Bring: State-Issued ID; Social Security Card; Proof of SF Residency. Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None
+Eligible Population: Individuals, ages 18 and older. Must be highly motivated and have a strong desire to be in college and to participate in higher education.  Good to be clean and sober or actively participating in 12-step or other recovery program, if applicable.
+Faith Based: No
+
+Direct Services: Assist w/Matriculation & Application; Peer Counseling; Tutors; Book Vouchers; Academic Advising; Educational Planning; Voc. Education; Associate Degree; Transfer Programs. 
+ 
+
+
+City College of San Francisco   Way Pass Women’s Aftercare Program
+The Women’s Aftercare Program and Services is a collaborative project with City College of San Francisco, under the auspices of the Health Science Department and the Women’s Studies Department. We are designed to address the unique needs of self-identified women who are formerly incarcerated. We serve women coming home from prisons, jails, and drug programs. It is our belief that education is the best alternative to incarceration and it is our desire to assist our sisters in their academic endeavors. 
+
+To Get Connected
+Contact Person: Tandy Iles, Faculty Advisor
+Phone: (415) 452-4889 
+Email: tiles@ccsf.edu 
+Hours: Tuesday – Thursday, 12:00pm to 5:00pm when school is in session or by appointment.
+Location: City College of San Francisco – Way Pass, 50 Phelan Avenue, Multi-Use Building MUB 301-C, San Francisco, CA 94112 
+Notes: No referral needed. 
+
+
+Things To Know
+Languages Spoken: English.
+What to Bring: Positive attitude
+Accessibility: Wheelchair accessible; other disabilities will be accommodated.
+Client fees, if any: Free to any current City College student. 
+Eligible Population: Formerly incarcerated women.
+Faith Based: No.
+Direct Services: Case Management; Help with Registration Forms; Informal Counseling and Support; Class Planning and Management; Support Groups and Workshops.  Referrals to other resources available as needed.
+
+Five Keys Charter School
+Five Keys Charter School provides basic adult educational options for obtaining a High School Diploma or High School Equivalency.  Our goal is to increase educational levels for successful Re-entry, finding employment and reintegrating into the community. Class times and schedules are flexible, offering students classroom based instruction, independent study and online learning. Five Keys partners with respected CBO’s that provide wrap around support services that our students need to meet their educational and career goals.  We have over 20 community locations throughout San Francisco where a teacher is integrated into the program model so education, treatment or work readiness is integrated to education.  www.fivekeyscharter.org 
+
+To Get Connected
+Contact Person: Administrative Office
+Phone: (415) 734-3310 
+Fax: (415) 734-3314
+Address:  70 Oak Grove, San Francisco, CA  94107
+Notes: Free education.  GED test is paid for by 5 Keys.  No referral needed. Drop-ins welcome at 70 Oak Grove and 1800 Oakdale.
+Things To Know
+Languages Spoken: English, Spanish, Chinese.
+Accessibility: 70 Oak Grove is not wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: All individuals 18 and older, 16 and above at 1601 Lane St location. 
+Faith Based: No.
+
+Locations:
+Goodwill Industries:  Comprehensive Access Point (CAP), 1500 Mission Street, San Francisco, CA, 94103, (415) 730-3218
+Arriba Juntos: 1850 Mission Street, San Francisco, CA, 94103, (415) 730-3218
+Asian Neighborhood Design:  1245 Howard Street, San Francisco, CA, 94103, (415) 730-3218
+Bayview YMCA: 1601 Lane Street, San Francisco, CA , 94124 (415) 730-3218
+CASC: 564 6th Street, San Francisco, CA  94103, (415) 489-7320
+CCSF Southeast Campus: 1800 Oakdale Street, San Francisco, CA 94124, (415) 821-2400
+Ella Hill Hutch Community Center:  1050 McAllister Street, San Francisco, CA, 94115 (415) 730-3218
+FACES SF:  Visitation Valley Neighborhood Access Point, 1099 Sunnydale Ave, 2nd Floor, San Francisco, CA, 94134, (415)308-1689
+HSA/MEDA: 3120 Mission Street, San Francisco, CA, 94114,(415) 730-3218
+Mission Economic Development Agency: 2301 Mission Street, San Francisco, CA  (415) 730-3218
+SFAPD Learning Center: 850 Bryant Street, San Francisco, CA  94103, (415) 553-1924
+Thomas Paine Square Community Center:   1086 Golden Gate Avenue, #G, San Francisco, CA, 94115,  (415) 929-1104
+TURF/Sunnydale Housing: 1652 Sunnydale Ave, San Francisco, CA, 94134 (415) 730-3218
+Visitation Valley Strong Family: (ESL only) 50 Raymond Street, San Francisco, CA  94134, (415) 730-3218
+WANAP Success Center:  1449 Webster Street, San Francisco, CA, 94115, (415) 730-3218
+Women’s Resource Center:  930 Bryant St., San Francisco, CA, 94103, (415) 734-3150
+
+Direct Services: Basic/Remedial Education; English as a Second Language; GED & High School Education; Reading/Literacy; Vocations Education, Independent Study, Intensive Case Management and Re-entry support groups.
+
+San Francisco Conservation Corps
+The San Francisco Conservation Corps (SFCC) is a non-profit job and academic training organization serving young people ages 18-26.   www.sfcc.org
+To Get Connected
+Contact Person: Jeff Bostic, Recruitment Manager 
+Phone: (415) 928-7417 x310 
+Fax: (415) 771-4299
+Email: jbostic@sfcc.org 
+Hours: Monday – Friday, 7:30am to 4:30pm
+Location: 102 Fort Mason, San Francisco, CA  94123
+Notes: Weekly info/interview session every Tuesday at 2:30pm.
+Things To Know
+Languages Spoken: English. 
+What to Bring: Will assist individuals get the required documents for orientation.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: No fees.
+Eligible Population: All individuals and family members, ages 18-26. 
+Faith Based: No.
+
+Direct Services: Employment Placement; Assistance/Guidance Regarding Benefits (SSI, GA, TANF, etc.); Counseling; Employment Retention; Employment Training; High School Diploma; Help/Vouchers to Get State ID; Life Skills; Literacy/Basic Education; Mentoring; Transit Vouchers. Referrals to other resources available as needed.
+
+
+
+San Francisco Public Library   Project Read
+Our mission is to provide free instruction for English-speaking adults (18 or older) who want to improve their basic reading and writing skills, thereby enabling access to great opportunities in their lives. www.projectreadsf.org  www.sfpl.org
+To Get Connected
+Phone: (415) 557-4388 
+Fax: (415) 557-4375
+Email: projectread@sfpl.org 
+Hours: Monday: 10am-6pm; Tuesday - Thursday 9am-8pm; Friday: 12pm to 6pm; Saturday 10am-6pm
+Location: Project Read -- Main Library 5th Floor, 100 Larkin St.  SF, CA 94102 
+Notes: No referral needed. Drop-ins for interview allowed. Further appointments will be scheduled.
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fees.
+Eligible Population: stable housing, working phone, 90 days clean and sober, over 18 years of age. 
+Faith Based: No.
+
+
+Direct Services:  Access to Internet; Mentorship; Outreach; Basic/Remedial Education; GED & High School Education; Reading/Literacy; Money Management/Personal Financial Education; Voting Outreach & Education; Parenting Support/Education. Referrals to other resources available as needed.
+
+San Francisco State University(ASI)   Project Rebound 
+Project Rebound sees education as an alternative to mass incarceration. We seek to increase opportunities to become productive and responsible citizens, decrease the risk of recidivism, motivate incarcerated individuals to strive to change their lives, and interrupt the path of youth headed toward incarceration.   http://asi.sfsu.edu/asi/programs/proj_rebound/about.html 
+To Get Connected
+Contact Persons: Jason Bell
+Phone: (415) 405-0954 
+Fax: (415) 338-0522 
+Email: projectrebound@asi.sfsu.edu 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 1650 Holloway Avenue, 
+CCSC T-138, San Francisco State University,
+San Francisco, CA 94132 
+Notes: No referral needed. Drop-ins allowed, but appointments are recommended. 
+Things To Know
+Languages Spoken: English. Translators may be available for other languages.
+What to Bring: State-Issued ID; Social Security Card; Proof of SF Residency.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fees.
+Eligible Population: All individuals, 18 and older. A high school diploma or GED is required.  Some services may not be available to registered sex offenders. May not have prior convictions on SFSU grounds. 
+Faith Based: No.
+
+Direct Services: Books/Class Materials; Access to Internet; Food Vouchers; Transit Vouchers; Mental Health Treatment; Anger Management; Mentorship; Outreach; Post-Incarceration Support; College & Graduate Education. Referrals to other resources available as needed.
+
+Anders and Anders Foundation    
+To break the cycle of recidivism through job opportunities. www.andersandandersfoundation.org
+ To Get Connected
+Contact Person: Terry Anders, Director
+Phone: (415) 309-6330 
+Email: andersandanders6@yahoo.com 
+Hours: Monday – Friday, 9:00am-7:00pm
+Location: 1460 McKinnon Ave. #206
+San Francisco, CA 94124
+Notes: No referral needed. Please call for appointment. No drop-ins.
+
+
+Things To Know
+Languages Spoken: English, some Spanish 
+What to Bring: State-Issued ID, Social Security Card. Program will assist client in getting these.
+Client fees, if any: No fees.
+Eligible Population: All individuals (men, women, veterans), ages 18 and older, who are formerly incarcerated or have struggled with addiction.
+Faith Based: No
+Direct Services: Assistance with Union Dues:  Assistance with Work Tools and Clothing; Assistance Getting Driver’s License or Other ID; Access to Computers; Addiction Counseling; Mentorship; Intensive Case Management; Outreach; Post-Incarceration Support; Basic Remedial Education; Employment Training (18 week pre-apprentice green construction training); Employment Placement (union trades—placement in 26 trades); Employment Retention; Job Readiness/Life Skills; Professional Clothing. Referrals to other resources available as needed.
+
+
+
+Arriba Juntos   Power Up Youth
+Arriba Juntos provides educational and employment programs on a citywide basis serving many neighborhoods and many different ethnic groups and cultures. Its mission is to promote economic self sufficiency through employment services and vocational education.  www.arribajuntos.org
+To Get Connected
+Contact Person: Mark Aquino, Youth Program Coordinator
+Phone: (415) 401-4931 
+Fax: (415) 401-4899
+Email: maquino@arribajuntos.org 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Things To Know
+Eligible Population: All individuals, ages 14-24, including pregnant women, women with children, families, and individuals on Juvenile Probation.
+Faith Based: No.
+
+Direct Services: Access to Internet; Youth Computer Lab; Assistance Getting Drivers License or Other ID; Clothing; Interview Attire; Prepared Meals on Thursdays and Snacks for Clients; Personal Hygiene Items; Postal Services; Transit Vouchers for WIA-Qualified Clients; Mental Health Specialist for Victims and Witnesses of Violence; GED Program; Application for Food Stamps; Employment and Job Readiness Services. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+America Works of California   Employment Placement Services
+America Works lifts people out of poverty using its unique brand of intensive, personalized, employment services.  Called “a company with a conscience,” it was founded in 1984 by social activist and entrepreneur Peter Cover.   America Works’ guiding principle is the belief that the best way to lift people out of poverty is to help them find a job—real private sector jobs.  In other words, it believes that work first works best.  www.americaworks.com
+To Get Connected
+Contact Person: Intake
+Phone: (415) 552-9676  
+Fax: (415) 552-9683
+Location:  1663 Mission Street, San Francisco, CA 94103
+Contact Person: America Works Staff 
+Phone: (415) 489-7318  
+Fax: (415) 489-7325
+Location:  CASC, 564 6th Street, San Francisco, CA  94103
+Hours: Monday – Friday, 9:00am to 5:00pm. 
+Notes: Clients must be referred by San Francisco Adult Probation.
+Things To Know
+Languages Spoken: English.
+What to Bring: CA ID, Social Security Card.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: All individuals supervised by the San Francisco Adult Probation Department.  Must be referred by San Francisco Adult Probation.
+Faith Based: No.
+
+Direct Services: Employment Placement; Employment Training; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Access to Internet; Assistance with Resumes; Interview Clothes.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Asian Neighborhood Design   Construction Training Program
+Our mission is to reduce poverty by building communities and providing opportunities for low-income residents to become economically self sufficient. www.andnet.org
+
+To Get Connected
+Contact Person: Chris Reyes, Program Manager
+Phone: (415) 575-0423 x218 
+Fax: (415) 575-0425
+Email: creyes@andnet.org 
+Hours: Monday – Friday, 7:00pm to 3:30pm. 
+Orientation are Thursdays, 10:00am
+Location: 1021 Mission St. San Francisco, CA  94103 
+Notes: No referral needed. Drop-ins are welcome, but orientations are held every Thursday at 10am.
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Proof of SF Residency.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated. 
+Client fees, if any: None.
+Eligible Population: Men, Women, Transgender people, ages 17 and older, Women with children, All families. Individuals with criminal convictions for a sex offense are considered on a case-by-case basis.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Light Meals; Access to Phones; Transit Vouchers; Anger Management; Community Education & Mediation; Group Counseling/Therapy; Intensive Case Management; Mentorship; Post-Incarceration Support; Basic/Remedial Education; GED and High School Education with 5 Keys Charter School on-site; Job Skills; Job Readiness; Job Placement; Construction Job Training; Employment Retention; Money Management/Personal Financial Education; Referrals provided for mental health treatment, medical care, dental care, vision care, trauma recovery services. Referrals to other resources available as needed.
+
+
+California Pacific Medical Center   PEP Jobs
+The mission of PEP Jobs is to serve people with epilepsy and/or brain injuries in navigating a career path, including finding and maintaining suitable employment, offering the highest quality assistance possible. www.cpmc/org/pepjobs
+
+To Get Connected
+Contact Person: Tom Post or Lia Kantor, Employment Coordinators
+Phone: Tom Post:  (415) 600-4875;  
+Lia Kantor:  (415) 600-4878
+Fax: (415) 600-4879
+Email: infopep@sutterhealth.org 
+Location: CPMC Davies Campus, 45 Castro Street, B-Level, South Tower, San Francsico, CA  94114
+Notes: Referral from CA Department of Rehabilitation - 301 Howard St, San Francisco, CA 94105. Call 415-904-4100. No Drop-ins.
+Things To Know
+Languages Spoken: English. Translation services available.
+What to Bring: Proof of right-to-work documents such as, State-Issued ID; Social Security Card.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fees.
+Eligible Population: All individuals, ages 18 and older, with a medical diagnosis of epilepsy or traumatic/acquired brain injury. Must be clean and sober for at least 90 days prior to intake.
+Faith Based: No.
+
+Direct Services: Employment Placement; Employment Retention; Job Readiness/Life Skills. Referrals to other resources available as needed.
+
+
+
+Center On Juvenile And Criminal Justice   Employment Services
+The Center on Juvenile and Criminal Justice (CJCJ)  San Francisco Training Partnership and Homeless Employment Collaborative offers program participants referrals to short-term trainings, job search workshops, job placements, life skills training that prepares them for employment, to return to school, or to enroll and participate in an occupational or vocational training programs. www.cjcj.org
+To Get Connected
+Contact Person: Employment Services
+Phone: (415) 621-5661
+Location: 40 Boardman Place, San Francisco, CA 94103
+Notes: No referral necessary.  Appointments are preferred but drop-ins will be seen.    
+Things To Know
+Languages Spoken: English.
+What to Bring: CA ID; Social Security Card.
+Client fees, if any: None
+Eligible Population: All individuals, ages 18 and older who are homeless.
+Faith Based: No.
+
+Direct Services:  Job Readiness/Life Skills; Employment Training; Vocational Training; Employment Retention; Access to internet; Assistance Getting Driver’s License/CA ID; Case Management.
+
+
+
+
+
+Charity Cultural Services Center   CityBuild Academy
+Charity Cultural Services Center (CCSC) offers a variety of vocational training programs.  The goal of the CityBuild program is to provide San Francisco residents the opportunity to receive vocational training and enter the union trades post graduation from the 18 week curriculum. sfccsc.org
+
+To Get Connected
+Contact Person:  Calvin Phan, Program Coordinator
+Phone: (415) 989-8224  x102
+Location: 731 Commercial Street, San Francisco, CA  94108
+Notes: Appointments are preferred but drop-ins will be seen.  Clients who are interested in a career in construction must be SF residents.  
+Things To Know
+Languages Spoken: English, Cantonese, Mandarin, Vietnamese.  Interpreter service available.
+What to Bring: Drivers License; Social Security Card.
+Client fees, if any: None
+Eligible Population: All individuals, ages 18 and older (171/2 ok with written permission from parents).  To enter CityBuild all clients must have a valid CDL and a high school diploma/GED.
+Faith Based: No.
+
+Direct Services:  Construction Training; Assistance Getting Driver’s License and Other ID; High School Diploma/GED; Vocational Education; Job Readiness; Employment Placement; Case Management; Access to Internet.  Referrals to other resources available as needed.  
+
+
+
+Department of Rehabilitation
+The California Department of Rehabilitation works in partnership with consumers and other stakeholders to provide services and advocacy resulting in employment, independent living and equality for individuals with disabilities. www.rehab.cahwnet.gov
+
+To Get Connected
+Phone: (415) 904-7100 (Voice)
+(415) 904-7138 (TTY)
+(415) 904-7100 (TTY)
+Location: 301 Howard Street, Suite 700
+San Francisco, CA 94105
+Notes: Orientations are held on Tuesdays and Thursdays at 2:00pm and on Wednesdays at 8:30am.
+
+
+
+Things To Know
+Languages Spoken: English.
+What to Bring: State-Issued photo ID. Medical records or documentation of disability.
+Accessibility: Wheelchair accessible. Other disabilites are accommodated.
+Client fees, if any: No fees.
+Eligible Population: Individuals with a documented disability. 
+Faith Based: No.
+Direct Services: Individualized Service Plan; Counseling; Transportation Assistance; Vocational Training; Assistance Getting and/or Maintaining Employment. Referrals to other resources available as needed. 
+Episcopal Community Services   CHEFS
+It is our mission to train homeless individuals in culinary arts and to assist them in finding and keeping employment, in order to support their move out of homelessness. www.ecs-sf.org
+
+To Get Connected
+Contact Persons: Sally Ray or Emile Sanders, Employment Specialist
+Phone: Sally Ray:  (415) 487-3300  x6115
+Emile Sanders: (415) 487-3300 x1107 
+Fax: (415) 487-3330
+Email: sray@ecs-sf.org or esanders@ecs-sf.org
+Hours: Monday – Friday, 9am to 5pm
+Location: 165Natoma Street
+San Francisco, CA  94103 
+Notes: Intake takes place at several points throughout the year, and requires three professional references. No formal referral form is needed, and drop-ins are welcome. Please call or write for more information. 
+Things To Know
+Languages Spoken: English. 
+What to Bring: Staff will assist cleints with necessary documents.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated. Note: Student must be able to work safely in a small kitchen.
+Client fees, if any: No fees.
+Eligible Population: Must be homeless and SF resident.
+Faith Based: No.
+
+
+Direct Services: Emergency Shelter; Permanent Housing; Access to Internet; Clothing; 
+Prepared Lunches; Hygiene/Personal Care Items; Intensive Case Management; Post-Incarceration Support; Basic/Remedial Education; GED & High School Education; Vocational Education; Employment Training and Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education. Referrals to other resources available as needed. 
+
+Goodwill Industries of San Franciso, San Mateo and Marin Counties  One Stop Career Link Center, Reentry Navigator and Other Services  
+Goodwill Industries supports people from all walks of life so that they can enhance their vocational development and return to the workforce. It helps to remove barriers to self sufficiency and to restore dignity to participants through training and job placements. The Reentry Navigator program helps formerly incarcerated individuals navigate citywide resources and to provide job readiness training, job development, and job placement assistance. www.sfgoodwill.org 
+To Get Connected
+One Stop Career Link Center
+Phone: (415) 575-4570 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Notes: Attend a One Stop Orientation. Orientations are offered Monday – Friday at 10:00am.
+
+Reentry Navigator: Isabel Navigator
+Phone: (415) 575-4538 
+Fax: (415) 575-2170
+Email: IPerez@sfgoodwill.org
+Hours: Please call to make an appointment.
+Location: 1500 Mission Street, San Francisco, CA 94103  
+Notes: No referral needed. 
+
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: State-Issued ID; Social Security Card; Proof of SF Residency. Program will assist client in getting these.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No cost to participants.
+Eligible Population: All individuals who obtain a One Stop Card may access services. All individuals with involvement in the criminal justice system may meet with the Reentry Navigator.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Drivers License or Other ID; Clothing Vouchers; Transit Vouchers; Intensive Case Management; Outreach; Post-Incarceration Support; English as a Second Language; GED & High School Education; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Clean Slate/Conviction Expungement Services; Inmate & Parolee Legal Issues; Phone/Voicemail; Vocational Education; Hotel Vouchers; Housing Resources; Retail/Warehouse Operation Training; Criminal Justice Navigator; Bus Tokens. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+Mission Hiring Hall   Employment Services
+Mission Hiring Hall’s (MHH) purpose is to meet the immediate and long-term employment needs of San Francisco’s employers and its low- and moderate-income, unemploeyed and underemployed residents. MHH offers a variety of employment services/programs including the CityBuild Academy, Construction Administration and Professional Services Academy, Hospitality Initiative, and Homeless Employment Services.  www.missionhiringhall.org 
+To Get Connected
+Contact Person:  Front Desk
+Phone: (415) 626-1919 x100  
+Location: 3080 16th Street, san Francisco, CA  94103
+Hours: Monday – Thursday, 9:00am to 5:00pm; Friday 9:00am to 4:30pm
+Notes:  Orientations/Registration is the first step to receiving services. Intakes are Monday at 9:30am
+
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Cantonese, Mandarin, Russian.
+What to Bring: CA ID; Social Security Card; Proof of SF Residency. Program will assist client in getting these.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: All individuals 18 years and older.  Must be a San Francisco resident.
+Faith Based: No.
+
+Direct Services: Employment Placement; Employment Training; Employment Retention; Job Readiness/Life Skills; Access to Internet; Assistance with Resumes; CityBuild Academy, CAPSA & STEP.  Referrals to other resources available as needed. 
+
+Jewish Vocational Services (JVS)
+At JVS, we can help you with the skills and resources you need to find the right job. Our job search assistance program is specially tailored to meet your particular employment needs. We work with job seekers that truly represent the broad diversity of San Francisco, and we work with some of the best Bay Area companies in healthcare, administration, reatil and technology.  Our Technology Center helps people improve their job related computer skills and provides online job search opportunities. You can search for a job; improve your typing speed and Microsoft Office skills with self-paced tutorials; use our software and print library to explore your career options; build your resume, cover letter, and basic skills; and study for the GED, NCLEX-PN, and NCLEX-RN.  www.jvs.org
+To Get Connected
+Contact Person: Alicia Velez-Rivers, Intake Coordinator
+Phone: (415) 782-6282 
+Fax: (415) 391-3617
+Email: avelez-rivers@jvs.org 
+
+Technology Center Contact Person: Jennifer Volk, TAC Coordinator
+Phone: (415) 782-6217 
+Fax: (415) 391-3617
+Email: jvolk@jvs.org@jvs.org 
+
+Hours: Monday-Friday, 9:00am to 5:00pm. 
+Location: 225 Bush Street, Suite 400 - West Lobby, San Francisco, CA 94104 
+Notes: No referral needed. Get started online at www.jvs.org/welcome or attend a drop-in Welcome Session (every Wednesday at 1:00pm.
+Things To Know
+Languages Spoken: Russian, English, Cantonese, Spanish. Note: Non-native speakers are welcome to access the Technology Center facilities although the job search resources are primarily in English.
+What to Bring: Authorization to work in the United States.
+Accessibility: Wheelchair accessible. Other disabilities accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals who are clean and sober and comply with a work-focused professional facility. 
+Faith Based: No.
+
+
+Direct Services: Employment Placement; Employment Retention; Employment Training; Job Readiness; Access to Internet. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Positive Resource Center   PRC Employment Services
+Positive Resource Center’s Employment Services Program provides vocational rehabilitation and job search services to people with HIV/AIDS or with Mental Health Disabilities. Our Employment Services Program assists clients who are considering temporary work, self-employment, permanent part-time or full-time work, or training and education opportunities. Positive Resource Center is the only employment service provider in the San Francisco Bay Area that has specifically developed its program for people who are facing multiple employment barriers. PRC Employment Services supports a whole person approach, using harm reduction, and supports a self-efficacy model to support people with disabilities to live independent lives. www.positiveresource.org
+To Get Connected
+Contact Person: Joe Ramirez-Forcier, Managing Director
+Phone: (415) 972-0831 
+Fax: (415) 777-1770
+Email: joer@positiveresource.org 
+Hours: Monday – Friday, 9:00am to 5:00pm. Orientation is every Weds at 2:00pm.
+Location: 785 Market Street, 10th Floor, San Francisco, CA 94103 
+Notes: No referral needed for HIV+ clients  Clients with disabilities can attend the orientation. 
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Program will assist client in getting necessary documents.
+Accessibility: Wheelchair accessible. Facilities approved by CARF and CA DoR.
+Client fees, if any: None.
+Eligible Population: All individuals with HIV/Mental Health/other disabilities.
+Faith Based: No.
+
+Direct Services: Access to Internet; Job Search Center; Anger Management; Conflict Management; Stress Management; Time Management; Community Education & Mediation; Group Counseling/Therapy; Vocational Counseling; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Vocational Education; Assessment & Application for Food Stamps, General Assistance; Legal advise and benefits representation; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education. Referrals to other resources available as needed.
+
+Renaissance Entrepreneurship Center
+Our goal is to assist re-entry clients explore entrepreneurship, because we understand that it is hard to get a job once you have a record.  rencenter.org
+To Get Connected
+Contact Person: April Gilbert, Program Director (SOMA)
+Phone: (415) 541-8580 
+Fax: (415) 541-8589
+Email: agilbert@rencenter.org 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 275 5th Street, San Francisco, CA 94103 
+Notes: No referral needed. Orientations offered twice monthly.  Call for details.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: Sliding Scale.  Varied depending on program.
+Eligible Population: All individuals.
+Faith Based: No.
+Direct Services: Business Planning; Start-up Training; Business Marketing Training; Mentorship; Credit Repair; Life Skills; Money Management/Personal Financial Education; Employment Law. Referrals to other resources available as needed.
+
+SF Clean City Coalition   Employment Partnership Program
+Clean City Partnership Program provides neighborhood-based transitional employment, training and job placement assistance to homeless and low-income individuals through community improvement projects and vocational training.  We provide participants with paid employment, job readiness assistance, and assist clients in permanent full-time employment.  www.sfcleancity.org
+To Get Connected
+Contact Person: Program Office
+Phone: (415) 552-9201 x14 
+Hours: Monday – Friday, 7:30am to 4:30pm.
+Office Location: 366 Eddy Street, San Francisco, CA 94102. 
+Notes: No referral needed. Must attend an orientation to be eligible for employment.  Orientations are offered weekly, please check website for location of orientations.
+Things To Know
+Languages Spoken: English and Spanish 
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: All individuals 18 yrs and older.  Must be a San Francisco resident and bale to pass a pre-employment drug test.
+Faith Based: No.
+
+Direct Services: Paid Employment; Employment Training; Employment Retention; Job Readiness/Life Skills; Access to Internet.  Referrals to other rrsources available as needed.
+
+
+
+
+
+
+The Bread Project   Employment Training Programs
+Our mission is to empower individuals with limited resources on their path to self-sufficiency through skills instruction, on-the-job training, and assistance with establishing a career in the food service industry.  We currently offer a 3 week Bakery Bootcamp and a more in-depth 10 week Baking Training Program.  www.breadproject.org
+To Get Connected
+Contact Person:  Rafi Amini, Intake & Outreach Specialist
+Phone:  (888) 282-3522 x902 or (510) 594-1702
+Email: rafi@breadproject.org  or info@breadproject.org 
+Intake Hours: Thursdays from 10:00am to 2:00pm
+Location: 1555 Park Ave #B, Emeryville, CA  94608
+Notes: Referrals are preferred.  Drop-ins are allowed for intakes.  Appointments are accepted.  Participants must be able to stand for 8 hours and lift up to 25 pounds.
+Things To Know
+Languages Spoken: English, Dari, Pashtu, Nepali, Chinese.
+What to Bring: State-Issued ID; Social Security Card; Proof of Income; Proof of Address
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: Individuals, 18 years and older who are legally eligible to work in the U.S., no violent or sex offenses in the past 7 years (on a case by case basis), no outstanding warrants, stable housing, and at least 5 months of sobriety.
+Faith Based: No.
+
+Direct Services: Vocational Training: 3 week Bakery Bootcamp and 10 week Baking Training Program; Employment Placement Assistance; Employment Retention; Job Readiness/Life Skills.
+Toolworks   Janitorial Training/Placement
+Toolworks, in partnership with people in disadvantaging conditions, is a human service agency dedicated to providing the tools/resources to promote independence, equality, and personal satisfaction. www.toolworks.org
+To Get Connected
+Email: rarbo@toolworks.org 
+Specific Intake Days and Times: 
+Info session every Friday at 1:00pm 
+25 Kearny Street, #400	
+Training Hours: 6:45am to 11:45am
+Location: Office at 25 Kearny Street, #400, San Francisco, CA  94104. Training site on Treasure Island.
+Notes: Referrals are not required to attend an info session. No drop-ins. Information session every Friday at 1:00pm at Kearny Street location.
+Things To Know
+Languages Spoken: English, ASL.
+What to Bring: State-Issued ID; Social Security Card; Proof of SF Residency; Proof of homelessness; proof of disability.  These documents are not necessary to attend an info session.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: Individuals, 18 years and older, who meet both eligibility requirements of HEC Grant: 1) homelessness 2) disabled.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Drivers License or Other ID;  Hygiene/Personal Care Items;  Phone/Voicemail; Intensive Case Management; Mentorship; Vocational Education; Assessment & Application for SSI; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+San Francisco Behavioral Health Access Center (BHAC), Community Behavioral Health Services, Department of Public Health
+The Behavioral health Access Center (BHAC) acts as an entry point into the substance abuse and mental health system-of-care in San Francisco.  BHAC can assess and authorize placement into different levels of care, depending on need.  Services include residential treatment, intensive outpatient services, outpatient services, and other services that assist in reducing barriers to care.  Residents of San Francisco are eligible for services at BHAC.
+For substance abuse or mental health treatment referrals, call (415) 503-4730 or toll free 1-800-750-2727.
+
+Languages: English, Spanish, Tagalog, Cantonese, Mandarin, Arabic, Japanese, Vietnamese.
+
+Location: 1380 Howard Street, 1st Floor, San Francisco, CA 94103
+Hours: Monday – Friday, 9:00am to 5:00pm 
+
+California HIV/AIDS Hotline
+If you have a question about HIV/AIDS or STDs, call the California HIV/AIDS hotline. A trained phone counselor is available to help you in English or in Spanish.
+Toll Free in California:
+(800) 367-AIDS (2437)
+(888) 225-AIDS (2437) (TTY)
+In San Francisco and outside California:
+(415) 863-AIDS (2437)
+Hours: Monday – Friday, 9:00am to 5:00pm
+(until 9:00pm on Tuesdays)
+Website: www.aidshotline.org
+Mailing Address:
+California AIDS Hotline
+995 Market Street, #200
+San Francisco, CA  94103
+Email Address:
+Contact-us@AIDSHotline.org
+
+Direct Services:
+
+Alcoholics Anonymous
+Alcoholics Anonymous is a fellowship of men and women who share their experience, strength and hope with each other that they may solve their common problem and help others to recover from alcoholism. The only requirement for membership is a desire to stop drinking. There are no fees, and there are more than 700 meetings in the area. A complete listing is available at www.aasf.org or through the Intercounty Fellowship of Alcoholics Anonymous:
+
+(415) 674-1821 (from SF)
+(415) 499-0400 (from Marin)
+Email: help@aasf.org
+Mobile Devices: www.aasf.org/m
+Location: 1821 Sacramento Street
+San Francisco, CA  94109
+Oficina Central Hispana:
+(415) 554-8811
+
+Direct Services:
+
+Narcotics Anonymous
+Narcotics Anonymous makes no distinction between drugs, including alcohol. Membership is free, and the group is not affiliated with any organizations outside of NA. Some meetings have specific focuses or may be particularly appropriate for certain people. Meeting schedules, information on wheelchair accessibility, and special foci, are available online, at www.sfna.org/meeting_schedule.html, and by calling the NA Helpline, (415) 621-8600.
+Mailing Address:
+San Francisco Area of Narcotics Anonymous
+Area Service Office
+The West Bay Conference Center
+1290 Fillmore Street #B
+San Francisco, CA 94115
+Help Line Phone Number: (415) 621-8600 
+Email: ASO@sfna.org
+Website: www.sfna.org
+
+Direct Services:
+
+Food Addicts in Recovery Anonymous (FA) 
+Food Addicts in Recovery Anonymous (FA) is a twelve step program offering a solution for anyone suffering from any form of food addiction including overheating, bulimia, under-eating or food obsession. There are over 30 meetings throughout the San Francisco Bay Area. For more information please visit our web-site at www.foodaddicts.org. 
+
+E-mail: fa@foodaddicts.org 
+Phone: (800) 600-6028
+
+Direct Services:
+
+Bayview Hunters Point Foundation for Community Improvement Substance Abuse Program
+The mission is to build a community that is empowered, clean, safe and healthy. The Methadone Maintenance Program embraces the San Francisco Department of Public Health’s principles of harm reduction and cultural competency to provide the highest quality of treatment services for our clients. www.bayviewci.org
+To Get Connected
+Contact Person: Maisha Bolden
+Phone: (415) 822-8200 
+Specific Intake Days and Times: Monday, Wedensday, Friday 6:30am-9:30am	
+Hours: Monday – Friday, 6:00am to 2:00pm, Saturday and Sunday, 7:00am to 10:00am
+Location: 1625 Carroll Avenue, San Francisco, CA  94124 
+Notes: No referral needed. 
+Things To Know
+Languages Spoken: English, Spanish. Translation services available upon request. 
+What to Bring: State-issued ID; Social Security Card; Proof of SF Residency.   
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: All adults. 
+Faith Based: No.
+
+Direct Services: Methadone; Substance Abuse Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment; Group and Individual Counseling/Therapy.
+
+
+Central American Resource Center (CARECEN) NOT UPDATED 
+Second Chance Tattoo Removal Program provides tattoo removal services for young adults wishing to remove gang-related tattoos. Dental services include emergency dental care, cleanings, examinations, x-rays, extractions, root canals, fillings, pit and fissure sealants, denture repairs, crowns, and referrals for other dental services. www.carecensf.org
+To Get Connected
+Phone: For tattoo removal services, call (415) 642-4425 or (415) 642-4400. 
+Email:  info@carecensf.org
+Specific Intake Days and Times: Call for details.	
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 3101 Mission Street, Suite 101, San Francisco, CA  94110 
+Notes: No referral needed. Make an appointment or drop in to inquire.
+Things To Know
+Languages Spoken: English, Spanish. 
+How does this program serve individuals whose primary language is not English? For other than Spanish we can access interpretation services. 
+What to Bring: Second Chance Tattoo Removal Program Application or Referral.  
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Free to those who qualify.
+Eligible Population: All individuals and family members. For tattoo removal services, ages 12-24 only. Men, Transgender people, Pregnant women. 
+Faith Based: No.
+
+ Direct Services: Tattoo Removal. Referrals to other resources available as needed.
+Community Acupuncture Project Ear Clinic at the American College of Traditional Chinese Medicine (ACTCM)
+The American College of Traditional Chinese Medicine’s Community Acupuncture Project brings ACTCM clinical faculty and interns to various locations in San Francisco. On average, ACTCM provides more than 20,000 treatments in its Community Clinic and off-site Community Acupuncture Project (CAP) sites annually. www.actcm.edu
+To Get Connected
+Contact Person: Tracy Tognetti 
+Phone: (415) 282-9603 
+Fax: (415) 282-9037 
+Drop-In Clinic Hours: Please call for clinic hours and days
+Location: 555 De Haro Street, Room G, San Francisco, CA 94107 
+Notes: No referral needed. Drop-in only. 
+Things To Know
+Languages Spoken: English, Spanish, Mandarin, Cantonese.
+Accessibility: Wheelchair accessible.
+Client fees, if any: The clinic is donation based. However, we will not turn anyone away for a lack of ability to make a donation.
+Eligible Population: All individuals and family members. 
+Faith Based: No.
+
+Direct Services: Acupuncture. Referrals to other resources available as needed.
+
+HealthRIGHT 360   Medical Clinics
+The mission of HealthRIGHT 360 is to give hope, build health, and change lives for people in need. We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community.    www.healthright360.org
+
+To Get Connected
+Contact Person: Jack Cheng or Maribel Baez
+Phone: (415) 226-17755 
+Fax: (415) 746-1941 Locations: 1735 Mission St, 558 Clayton St 
+Email: 
+scheduleappointment@healthright360.org 
+Hours: Monday – Friday, 9:00am to 5:00pm (Wednesday until 8pm at 558 Clayton St)
+Notes: Must schedule appointment and arrive 20 minutes early. Call for drop-in hours.
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility: Wheelchair accessible.
+Eligible Population: All adults. 
+Faith Based: No.
+
+Direct Services: Primary and Preventive Health Care; Women’s Health; Birth Control; STD Diagnosis and Treatment; Diabetes Treatment; Asthma Treatment; Chronic Disease Care; Opioid Management; Mental Health Treatment; Substance Abuse Treatment. Referrals to other resources available as needed.
+
+
+
+
+
+
+Mission Council on Alcohol Abuse for the Spanish Speaking, Inc.
+Mission Council on Alcohol Abuse for the Spanish Speaking, Inc., a non-profit organization, has been committed to the prevention and treatment of alcohol and other drug-related problems for individuals, families, and groups of underserved members of San Francisco communities by providing leadership and community care needs in a safe and culturally relevant setting. www.missioncouncil.org
+To Get Connected
+Contact Person: Intake Coordinator
+Phone: (415) 826-6767, (415) 920-0721
+Email: jla@missioncouncil.org 
+Hours: Intake, Monday – Friday, 3:00pm to 5:00pm 
+Location: 154-A Capp Street, San Francisco, CA 94110
+Notes: No referral needed. 
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: All individuals and family members, 18 and older.
+Faith Based: No.
+
+Direct Services: Culturally Specific Assessments; Outpatient Counseling; Individual/Group Counseling; Drug and Alcohol Education Classes; Drug and Alcohol Testing; Alcoholics Anonymous; Narcotics Anonymous; Employment Services Referrals; Housing Referrals; Collaboration with the San Francisco Drug Court; Domestic Violence Counseling; Dual Diagnosis Assessment and Counseling.  Referrals to other resources available as needed.
+
+
+Mission Neighborhood Health Center   Clinica Esperanza
+To provide culturally and linguistically appropriate services to under-served members of the community that reside primarily in the Mission District, with an emphasis on Spanish-speaking and bilingual clients. Our services of HIV care, treatment and prevention, and support to those infected and affected by HIV seeks to improve the lives and health of the community.  www.mnhc.org 
+To Get Connected
+Contact Person: Allison Rojas
+Phone: (415) 552-1013   
+Fax: (415) 552-0529 
+Email: allisonrojas@mnhc.org 
+Hours: Intake, Monday – Friday, 3:00pm to 5:00pm 
+Location: 240 Shotwell Street, San Francisco, CA  94110 
+Notes: No referral needed. Drop-ins allowed between 3-5pm, M-F.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of SF Residency. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: All individuals and family members, 18 and older.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Permanent Housing; Rental Move-in Assistance; Transitional Housing; Clothing vouchers; Food vouchers; Shower Facilities referrals; Transit Vouchers for case management or health-related appointments as needed; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Medical Care; Dental Care; Health & Wellness Education; Intensive Case Management; Individual Counseling/Therapy; Outreach; Post-Incarceration Support. Referrals to other resources available as needed.
+
+
+New Skin   Adult Tattoo Removal
+New Skin Adult Tattoo Removal program is a non-profit that removes visible tattoos at a low cost for adults that may hinder them from gainful employment and a peace of mind lifestyle.  www.newskinatr.org
+To Get Connected
+Phone: (408) 899-9695
+Fax: (415) 552-0529 
+Email: adam.king@newskinadulttattooremoval.org 
+Hours: Each Month: 2nd Saturday 8am-4pm; 3rd Saturday & Sunday 2pm-5pm
+Location: 1060 Willow Street, San Jose, CA  95125
+Notes: No referral needed. Drop-ins allowed between 3-5pm, M-F.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: All forms are provided by New Skin Adult Tattoo Removal
+Accessibility: Wheelchair accessible. 
+Client fees: $80 for 3 minutes or $100 for 5 minutes.
+Eligible Population: All individuals and all ages. Clients under the age 18 years old must be accompanied by a parent or guardian. 
+Faith Based: No.
+
+Direct Services: Tattoo removal.
+
+South of Market Health Center  
+South of Market Health Center is a non-profit community health center that provides comprehensive medical, dental and podiatry services to individuals, children and families who have difficulty getting healthcare. We are a full-service clinic in the South of Market Area, providing high quality healthcare to over 5,000 patients every year.
+To Get Connected
+Contact Person: Any staff
+Email: info@smhcsf.org
+Main Clinic: 
+229 7th Street, San Francisco, CA  94104
+Phone: (415) 503-6000
+Hours: Monday through Thursday, 8:00am-5:00pm; Friday through Saturday 8:00am-3:30pm.
+Senior Clinic (For patients 55+): 
+317 Clementina, San Francisco, CA 94103
+Phone: (415) 284-2270
+Hours: Monday through Thursday, 8:00am-5:00pm; Friday 8:00am-3:30pm.
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Farsi, and Chinese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: Families and individuals with little or no health coverage.
+Faith Based: No.
+
+Direct Services: SMHC provides a wide range of high quality primary medical, disease prevention, dental and podiatry care. Pre-natal and well-baby care, patient education and outreach are also available. 
+Transitions Clinic   
+Transitions Clinic is a unique primary care clinic dedicated to recently released chronically-ill men and women and their families. Transitional and primary care services are available within the first two weeks upon release from prison. Patients are supported by community health workers who have a history of incarceration.  www.transitionsclinic.org
+To Get Connected
+Contact Persons: Ron Sanders, Juanita Alvarado, Joseph Calderon: Community Health Workers
+Phone: (415) 671-7087 – office; Ron: (415) 933-4403 (cell); Juanita: (415) 730-5357 (cell); Joseph: (415) 676-0816 (cell)  
+Email: ronald.sanders@sfdph.org, juanita.alvarado@sfdph.org,  joseph.calderon@sfdph.org
+Clinic Hours: Wednesday 8am-12pm, Thursday 8am-12pm, Friday 8am-12pm
+Location:  Southeast Health Center
+2401 Keith Street, San Francisco Ca 94124  
+Public Transportation: T Train, 54, 29
+Notes: Community Health Workers are available by phone Monday through Friday 8am-5pm.  No drop-ins, must have appointment scheduled. Can be screened by community health workers by phone. For future doctor’s appointments, please contact community health workers.
+Things To Know
+Languages Spoken: English, Spanish, others.
+What to Bring: State-issued ID, Social Security Card, and Proof of SF Residency. No additional documentation needed prior to entry, but will need these documents in 30 days for San Francisco insurance program. Program will assist entering clients.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: Men, Women, Transgender people, Pregnant women, and families.
+Faith Based: No
+Community Health Workers Services: All patients are supported by trained community health workers with a history of incarceration. Our clinic partners with many community organizations and are we not funded by the criminal justice system.
+
+Direct Services: Medical Care; Health & Wellness Education; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration support. Referrals to other resources available as needed; including referral for employment, housing, mental health and substance use treatment. Medical care on site: buprenorphine (suboxone), optometry, podiatry, acupuncture, smoking cessation classes, lab services and nutrition. Clothing & food access upon request.
+
+U.S. Department of Veteran Affairs   San Francisco VA Downtown Clinic
+The SFVAMC Downtown Clinic offers primary care and a wide array of mental health services, including group and individual counseling, substance abuse, PTSD, and compensated work therapy. The clinic is one of VHA’s first Comprehensive Homeless Veterans Centers providing a full range of services to homeless veterans, and it provides special care to homeless veterans through the Health Care for Homeless Veterans program. The Downtown Clinic is a part of the San Francisco VA Medical Center System. www.sanfrancisco.va.gov
+To Get Connected
+San Francisco VA Downtown Clinic Location: 401 3rd Street, San Francisco, CA 94107
+Phone: (415) 281-5100
+Hours: Monday-Friday, 8:00am to 4:30pm
+Notes: No referral needed. Drop-ins welcome.
+San Francisco VA Medical Center
+Location: 4150 Clement Street, San Francisco, CA 94121
+Phone: (415) 221-4810
+Things To Know
+Languages Spoken: English, Tagalog. Translation services available for other languages.
+What to Bring: Discharge form DD214. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None collected here, means test determines fees.
+Eligible Population: All Veterans of the U.S. Military.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Transitional Housing CWT/TR Program; Access to Internet; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Phone/Voicemail; Shower Facilities; Storage Facilities; Mental Health Treatment; Substance; Abuse Treatment; Medical Care; Anger Management; Group Counseling/Therapy; Outreach. Referrals to other resources available as needed.
+Westside Community Services   Services for Adults
+Westside Community Services has been providing an array of community-based prevention, mental health, substance abuse, and social services to clients in the City and County of San Francisco for 40 years. Incorporated in 1967, Westside is one of the oldest community-based mental health agencies in the nation. The range of programs and services has varied over the years, while a commitment to providing excellent, high-quality, culturally and community appropriate programs has remained central to the core of the organization.  www.westside-health.org
+
+To Get Connected
+Behavioral Health Services
+Location: 245 11th Street, San Francisco, CA 94103
+Phone: (415) 355-0311 
+Fax: (415) 355-0349 
+Email: crisisclinic@westside-health.org 
+outpatient@westside-health.org 
+ACT@westside-health.org 
+Methadone Maintenance & Detoxification
+Location: 1301 Pierce Street, San Francisco, CA 94115 
+Phone: (415) 563-8200 
+Fax: (415) 563-5985 
+Email: methadone@westside-health.org 
+HIV Testing, Counseling & Linkages 
+AIDS Case Management & Home Care 
+Location: 1153 Oak Street, San Francsico, CA
+Phone:  (415) 355-0311 
+Fax: (415) 355-0358 
+Email: AIDS@westside-health.org 
+CTL@westside-health.org 
+
+Things to Know 
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.
+What to Bring: Program may require photo ID or other documentation. Contact Westside for specifics.
+Client Fees: Sliding scale. Medi-Cal share of cost, if appropriate. 
+Eligible Population: San Francisco residents; other eligibility requirements may apply. Contact program for specifics.
+Faith Based: No.
+
+
+
+Direct Services: Advocacy; Chemical Dependency Services; Outreach; In-Home Support; Therapeutic Interventions; Care Coordination; Medication Monitoring and Health Screening; Crisis Assessment; Crisis Intervention.
+
+Women's Community Clinic   Women's Community Clinic Outreach Services
+The mission of the Women’s Community Clinic is to improve the health and well-being of women and girls. We believe preventive, educational care is essential to lifelong health and that all women deserve excellent health care, regardless of their ability to pay. We work hard to ensure that each client feels comfortable and safe using her voice to direct the care she receives. www.womenscommunityclinic.org
+To Get Connected
+Phone: (415) 379-7800
+Phones staffed: Monday – Friday, 1:00pm to 9:00pm; Tuesday, Friday and Saturday, 9:30am to 1:00pm
+Appointment Hours: Monday and Wednesday, 5:00pm to 9:00pm; Tuesday and Thursday, 1:00pm to 9:00pm; Friday, 9:00am to 5:00pm; Saturday, 9:00am to 1:00pm.
+Drop-in Hours: Tuesdays, beginning at 8:30am. Open until full.
+Location: 1833 Fillmore Street, San Francisco, CA  94115
+Notes: No referral needed. Drop-ins allowed. See above.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: All services are free.
+Eligible Population: Women, Transgender people, 12 years and older, Women with children.
+Faith Based: No.
+
+Direct Services: Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Medical Care; Health & Wellness Education. Referrals to other resources available as needed.
+
+Asian American Recovery Services    
+Our primary goal is to change an individual's substance-abusing lifestyle. This change comes about through four fundamental processes. First, individuals must acknowledge their problems, their own roles and responsibilities in abusing substances. Second, they must have the willingness to resolve and change their substance abusing behavior. Third, there needs to be an understanding and reconciliation of any conflict within themselves, their families and cultural traditions. Finally, they need to develop abilities and skills in managing their lives in the social, economic and political reality of their environment and community. The AARS-residential is a therapeutic community which recognizes the need for providing structure, support and opportunity within a multi-cultural environment. It is a highly structured environment with defined boundaries, both moral and ethical. The program employs community imposed sanctions as well as earned advancement of status and privileges as part of the recovery and growth process. Being part of something greater than oneself is an especially important factor in facilitating positive growth. www.aars.org 
+To Get Connected
+Contact Persons: Stephen Fields, Program Manager
+Phone: (415) 541-9404 
+Fax: (415) 776-1011
+Email: sfields@aars.org 
+Facility Hours: 24 hours/7days. Intake hours Monday – Friday, 9:00am to 5:00pm
+Location: 2024 Hayes Street, San Francisco, CA 94117 
+Notes: No referral needed. Call or write for appointment. No drop-ins.  This is a smoke free facility.
+Things To Know
+Languages Spoken: English, Cantonese. 
+What to Bring: Proof of SF Residency, TB Clearance. Program will assist entering clients in getting these.
+Accessibility: Wheelchair accessible. Other disabilities accommodated.
+Client fees, if any: No fee.
+Eligible Population: Men, Women, 18 and older. May not have criminal conviction for sex offense, gang-related offense, or arson. May not be a registered sex offender.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/ Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Shower Facilities; Substance; Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Anger Management; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach; Assessment & Application for Food Stamps; Assessment & Application for General Assistance; Family Reunification. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+CITYTEAM   Men’s Residential Recovery Program
+Cityteam of San Francisco’s Men’s recovery program serves men who are seeking treatment in their drug and alcohol addiction.  This long-term, residential program takes a holistic approach, addressing addictions as well as psychological, spiritual, education and vocational issues.  We provide individual and group counseling, GED prep classes, computer skills training, medical treatment and community involvement.  www.cityteam.org/san-francisco/
+To Get Connected
+Contact Person: Recovery Program
+Phone: (415) 861-8688 
+Email:  sanfrancisco@cityteam.org
+Intake Hours: Monday-Friday, 9am to 5pm
+Location:  164 6th Street, San Francisco, CA 94103
+Notes: Please call first for an intake.   
+ 
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: State-Issued ID
+Accessibility: No.
+Client fees: Program fee is 30% of Net income not to exceed 500 dollars a month. 
+Eligible Population: Men ages 18 and older.  
+Faith Based: Yes.
+
+
+Direct Services: Residential Substance Abuse Treatment; 12 Step Program; Health and Wellness Education; Anger Management; Case Management; Mentorship; Therapy; Clothing; Meals; Hygiene/Personal Care Items.  Referrals to other services available as needed.
+
+
+
+
+
+
+
+
+
+
+Delancey Street Foundation    
+Delancey Street is a residential education center for former substance abusers and ex-convicts. Its philosophy is that the people with the problems can teach themselves to become the solution. The program requires a minimum two-year commitment, and many individuals stay for longer. 
+
+url: www.delanceystreetfoundation.org 
+To Get Connected
+Contact Persons: Sonny Rendall, Intake Coordinator
+Phone: (415) 512-5104 
+Fax: (415) 512-5141
+Facility Hours: 24 hours/7 days
+Location: 600 Embarcadero, San Francisco, CA 94107 
+Notes: No referrals needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities accommodated.
+Client fees, if any: No fee.
+Eligible Population: Men, Women, Transgender people, ages 18 older. May not have a criminal conviciton for arson; may not be a registered sex offender; may not have a serious medical/mental health condition requiring medication.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Medical CareEmergency; Anger Management; Mentorship; Basic/Remedial Education; College & Graduate Education; GED & High School; Education; Reading/Literacy; Vocational Education; Employment Training; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Inmate & Parolee Legal Issues; Voting Outreach & Education; Parenting Support/Education. Referrals to other resources available as needed.
+
+
+
+
+
+Friendship House
+Residential treatment facility dedicated to serve American Indian communities, and all people with alcohol/drug abuse issues who would benefit from pro-social model of treatment influenced by American Indian traditions.  www.friendshiphousesf.org
+To Get Connected
+Contact Person: Laura Gutierrez, Intake 
+Phone: (415) 865-0964 
+Fax: (415) 575-4065
+Hours: Monday-Friday, 8:00am-5:00pm
+Location: Must call first – Intake done over the phone.
+Notes: No referral needed. No drop-ins. Must call for appointment first.
+Things To Know
+Languages Spoken: English, Navajo, and other American Indian languages. 
+What to Bring: California-Issued ID and TB Clearance, current within last 6 months. (If ID is from any state other than Calif., a Tribal ID is required.)
+Accessibility: Wheelchair accessible. Other disabilities are accommodated. 
+Client fees, if any: Sliding scale.
+Eligible Population: All individuals with no convictions for arson, no serious medical, psychological or emotional conditions that could interfere with participation in social-model treatment program. Must be clean and sober for at least 72 hours. Women may bring 1 or 2 children ages 0-5.
+Faith Based: Yes.
+ 
+Direct Services: Substance Abuse Treatment; Housing; Intensive Case Management; Life Skills Development; Relapse Prevention; Family Counseling/Reunification; Job Readiness Training; Assistance with Transition Back into the Community. Referrals to other resources available as needed.
+
+HealthRIGHT 360   Residential Substance Abuse Treatment Services
+The mission of HealthRIGHT 360 is to give hope, build health, and change lives for people in need. We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community.    www.healthright360.org
+
+To Get Connected
+Contact Person: Michael Davila, Admissions Director. 
+Phone: (415) 226-1775 
+Fax: (415) 701-7913 
+Email: mdavila@healthright360.org
+Hours: Monday – Friday, 8:00am to 5:30pm. Intakes end at 5:00pm daily.
+Location: Centralized Intake Department, 1735 Mission Street, San Francisco, CA 94103
+Notes: No referral needed. Drop-ins welcome. Please come to Centralized Intake Department.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of San Francisco Residency, TB Clearance. Program will assist entering clients in getting these. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Sliding scale.
+Eligible Population: Women, Transgender people, 18 and over, Pregnant Women. May not be a registered sex offender.
+Faith Based: No.
+
+Direct Services: Residential Substance Abuse Treatment; Transitional Housing; Gender Responsive Facilities; Trauma-Informed Treatment for Women; Hygiene/Personal Care Items; Co-Occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Mentorship; Trauma Recovery Services; GED & High School Education; Application Assistance with Food Stamps, GA & SSI; Job Readiness/Life Skills; Representative Payee Services; CJ Referrals; Couples/Family Counseling; Family Reunification; Parenting Support/Education; Clothing; Meals. Referrals to other resources available as needed.
+
+Jelani, Inc.  
+Residential drug treatment program for families.  
+
+url: www.jelaniinc.org
+To Get Connected
+Contact Person: Norman Mathis, Intake Coordinator. 
+Phone: (415) 822-5945 
+Fax: (415) 822-5943 
+Email: nmathis@jelaniinc.org 
+Facility Hours: 24 hours/7 days. Intake hours: Monday – Friday, 9:00am-5:00pm.
+Locations: 
+Jelani House Prenatal Program
+1601 Quesada Avenue, San Francisco, CA
+Jelani House Family Program
+1638 Kirkwood Avenue, San Francisco, CA
+Notes: Referrals from family agencies or criminal justice system.
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Social Security Card; Proof of Residence; TB Clearance. Preferable, but not completely necessary at intake. Some assistance may be available to help gather these documents. 
+Accessibility: Only the Quesada Ave. address is wheelchair- and other disability-accessible.
+Client fees, if any: 80% of public assistance received.
+Eligible Population: All Individuals and families, including adults with children, and pregnant women. Must not be convicted of sex offense or arson.
+Faith Based: No.
+
+Direct Services: Alcohol/Drug Treatment; Access to Benefits (SSI, GA, TANF, et al); Accompany to Court Dates; Anger Management; Childcare; Co-Occurring Disorder/Dual Diagnosis; Counseling; Family Reunification; Life Skills; Parenting Support; Perinatal Services; Residential Housing; Services for Children; Trauma Recovery Services. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+The Latino Commission
+The Latino Commission program design and methodology are derived from models of culturally-sensitive treatment for Latinos which have been developed and implemented in the last decade by the Latino Commission. The model incorporates current best practices in services delivery to Latinos utilizing a solid family-centered approach, one that integrates the concepts of conocimiento (self-awareness), respeto (respect for others), and confianza (mutual trust) to create a traditional peer support system. www.thelatinocommission.org
+To Get Connected
+Contact Person: Camilo Gonzalez, Intake Coordinator 
+Phone: (650) 244-0305 
+Intake Hours: Monday-Friday, 9am to 3pm
+Intake Address:  301 Grand Ave., Suite 301, S. San Francisco, CA  94080
+Locations: Casa Quetzal: 635 Brunswick, San Francisco, CA 94112; Casa Ollin: 161 Margaret Avenue, San Francisco, CA 94112; Aviva House: 1724 Bryant Street, SF, CA 94110
+Notes: No referral needed. Appointments are recommended. 
+Things To Know
+Languages Spoken: Spanish, English. 
+What to Bring: State-Issued ID; TB Clearance. Will assist client in getting these. 
+Accessibility: Some sites in San Francisco are not wheelchair accessible.
+Client fees: Sliding scale.
+Eligible Population: All individuals, including adults with children, and pregnant women. Must not be convicted of sex offense.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Access to Internet; Assistance Getting Driver’s License/Other ID; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Substance Abuse Treatment; Group Counseling/Therapy; Individual Counseling/Therapy; Access to Benefits; Parenting Support/Education. Referrals to other resources available as needed.
+
+Progress Foundation 
+Progress Foundation offers medication education, symptom management (mental health), case management, and referrals to other resources. www.progressfoundation.org
+To Get Connected
+General Information:  Main Office:  (415) 861-0828; La Amistad (415) 285-8100; Clay Street: (415) 776-4647; Progress House: (415) 668-1511; Seniors: (415) 821-0697; Ashbury (women & children): (415) 775-6194; Supported Living Program: Phone: (415) 752-3416 Fax: (415) 752-3483
+Residential Treatment Facility Hours: 24 hours/7 days
+Supported Living Office: 9:00am to 5:00pm, case manager on-call at all times.
+Location: Various Locations. Main Office is 368 Fell Street, San Francisco, CA 94102
+Notes: Referral required from any case manager, therapist or psychiatrist.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of San Francisco residency; TB Clearance; a physical within the past 12 months. Program can assist with physical and TB tests.
+Accessibility: Avenues, Clay and Ashbury are wheelchair accessible.
+Client fees, if any: Sliding scale; free for individuals with no income.
+Eligible Population: All individuals and families, including seniors (age 60 and older) with an Axis I mental health disorder. Must not be registered sex offender, must not have a criminal conviction for arson.  
+Faith Based: No. 
+Direct Services: Access to Benefits (SSI, GA, TANF, et al); Accompany to Court Dates; Anger Management; Co-occurring Disorder/Dual Diagnosis; Counseling; Family Reunification; Food/Meals; Healthcare; Life Skills; Parenting Support; Phone/Voicemail; Residential/Housing; Showers; Transit Vouchers; Trauma Recovery. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+St. Anthony Foundation   Father Alfred Center    
+The St. Anthony Foundation’s Father Alfred Center provides the Bay Area’s only licensed no-fee residential recovery program to homeless men who are ready to build sober, stable futures. The program serves men from San Francisco, Marin, Alameda, Contra Costa and San Mateo counties.  The Father Alfred Center’s year-long work-structured program empowers men with no income or resources with the tools to overcome addiction, and the support to establish productive and healthy lives. The multi-program access available through St. Anthony’s own services is rare in the field of recovery, and allows the speedy assessment and resolution of clients’ medical, legal, vocational and educational needs, most or all of which have been affected profoundly by their cycles of poverty and addiction. www.stanthonysf.org/RecoveryProgram
+To Get Connected
+Contact Persons: Intake
+Phone: (415) 592-2831
+Intake Hours: Monday through Friday, 8:00am-10:00am
+Intake Location: 121 Golden Gate Avenue, San Francisco, CA  94102
+Notes: No referrals needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish. 
+Client fees, if any: No fee.
+Eligible Population: Men ages 18 and older. May not have a criminal conviciton for arson; may not be a registered sex offender; may not have a serious medical/mental health condition requiring medication.  Client must be able to pass a physical examination given by St. Anthony’s medical Clinic as part of the intake process.
+Faith Based: 12-Step based program.
+
+Direct Services: Residential Recovery Program; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Medical Care; Anger Management; GED; Vocational Education; Employment Training; Employment Retention; Job Readiness/Life Skills. Referrals to other resources available as needed.
+
+
+Bay Area Addiction Research and Treatment   BAART Programs
+BAART's/BBHS's mission is to provide people with cost effective, short-term substance abuse treatment and other health care services, including primary medical care, at its clinics or through community linkages, and to make such services available to as many people as possible who seek them. www.baartprograms.com 
+To Get Connected
+Contact Person: Kevin Houston, Intake Coordinator
+Phone: (415) 863-3883 
+Fax: (415) 863-7343
+Email: khouston@baartprograms.com 
+Location: 1111 Market Street, San Francisco, CA  94103
+Market Street Hours: Weekdays except Wednesday ,6:00am to 2:00pm (Wednesday, 6:00am to 12:00pm); Saturday and Sunday, 8:00am to 12:00pm.
+Notes: No referral needed.  Drop-ins welcome
+
+Contact Person: Intake Coordinator
+Phone: (415) 928-7800 
+Location: 433 Turk Street, San Francisco, CA 94102 
+Turk Street Hours: Weekdays except Wednesday, 7:00am to 3:00pm (Wednesday, 7:00am to 1:00pm); Saturday and Sunday, 8:00am to 12:00pm
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Russian. 
+What to Bring: State-Issued ID.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client Fees:  Based on sliding scale.  Private insurance, Medi-Cal.
+Eligible Population: All individuals and family members, ages 18 and older 
+Faith Based: No.
+Direct Services: Mental Health Treatment; Substance Abuse Treatment (Methadone/Suboxone); Individual Counseling/Therapy. Turk Street location offrers FACET program for pregnant clients on methadone.  Referrals to other resources available as needed.
+Asian American Recovery Services   Comprehensive Outreach Program for Pacific Islanders and Asian Substance Abusers (COPPASA)
+Asian American Recovery Services COPPASA's, a program of Healthright360, provides challenged and underserved community members with mental health and substance abuse pretreatment services for direct placement into San Francisco based community programs. 
+
+url: www.aars.org 
+To Get Connected 
+Contact Persons: Stephen Fields, Program Manager.
+Phone: (415) 541-9404 
+Fax: (415) 876-6850
+Email: sfields@aars.org 
+Hours: Monday – Friday, 9:00am to 5:00pm 
+Location:  2166 Hayes Street, Suite 206, San Francisco, CA  94117
+Notes: No referral needed. Drop-ins are welcome.
+Things To Know
+Languages Spoken: English. 
+What to Bring: TB Clearance. Program will assist clients in getting these.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Public Health Funded, no client is turned away for lack of money or insurance.
+Eligible Population: All individuals who do not have a criminal conviction for arson and are not registered sex offenders.
+Faith Based: No.
+ 
+Direct Services: Transit Vouchers; Counseling and Referral to Treatment; Prevention and Pretreatment Counseling; Family Crisis Intervention; Mental Health and AOD Intervention. Referrals to other resources available as needed.
+Asian American Recovery Services   Lee Woodward Counseling Center
+Asian American Recovery Services LWCC, a program of Healthright360, is committed to providing services that will support women, children, and their families to develop strengths, skills and self determination in an addiction-free life. We provide a safe haven where women and children can rebuild their lives through a program of recovery and learn to break the intergenerational cycle of addiction. 
+
+url: www.aars.org 
+To Get Connected
+Contact Persons: Nicole Richards or Stephen Fields for program information and intakes.
+Phone: (415) 776-1001 
+Email: sfields@aars.org 
+Location: Lee Woodward Counseling Center, 2166 Hayes Street, Suite 303, San Francisco, CA 94117
+Notes: No referral needed. Drop-ins are welcome.
+Things To Know
+Languages Spoken: English. 
+What to Bring: Proof of SF Residency, TB Clearance. Program will assist clients in getting these.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Public Health funded, no clients is turned away for lack of money or insurance.
+Eligible Population: Mothers and children, women of color, transgender individuals, women with co-occurring disorders and physical health problems; Women seeking non-residential treatment services. May not have a criminal conviction for arson; may not be a registered sex offender.
+Faith Based: No.
+
+Direct Services: Access to Internet; Food/Prepared Meals; Phone/Voicemail; Substance Abuse Treatment; Anger Management; Individual Counseling and group sessions; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Childcare (provided for participating clients while in program);  Parenting Support/Education. Referrals to other resources available as needed.
+Asian American Recovery Services   Project ADAPT
+Asian American Recovery Services Project ADAPT, a program of Healthright360, provides outpatient drug and alcohol treatment to individuals that adheres to a holistic approach intended to promote the development of a healthy body, mind and spirit. The aim is to help individuals reduce substance use and develop a clean and sober lifestile. www.aars.org 
+To Get Connected
+Contact Persons: Nicole Richards or Stephen Fields for program information and intakes. 
+Phone: (415) 541-9404 
+Email: sfields@aars.org 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 2020 Hayes Street, San Francisco, CA 94117
+Notes: No referral needed. Call or write for appointment. No drop-ins.
+Things To Know
+Languages Spoken: English, Cantonese, Mandarin, Tagalog, Korean.
+What to Bring: TB Clearance.
+Accessibility: Wheelchair accessible.
+Client fees, if any: Sliding scale.
+Eligible Population: Must be a resident of San Francisco, over the age of 18, have a drug or alcohol problem.
+Faith Based: No.
+
+Direct Services: Substance Abuse Treatment; Individual Counseling and Group Sessions; Group Counseling/Therapy. Referrals to other resources available as needed.
+
+Bay Area Addiction Research And Treatment   Community HealthCare
+BAART Community HealthCare is a non-profit entity established to provide medical care through a network of community clinics. BCH focuses primarily on providing low cost primary care services to indigent populations. BCH and its predecessors have been providing services for 35 years. www.baartprograms.com   www.baarthealthcare.org/index.html
+To Get Connected
+Contact person:  Medical Secretary
+Phone: (415) 863-3883 
+Fax: (415) 863-7343
+Location: 1111 Market Street, San Francisco, CA  94103
+Market Street Hours: Weekdays except Wednesday ,6:00am to 2:00pm (Wednesday, 6:00am to 12:00pm)
+Notes: No referral needed.  Drop-ins welcome
+
+Contact Person: Medical Secretary
+Phone: (415) 928-7800 
+Location: 433 Turk Street, San Francisco, CA 94102 
+Turk Street Hours: Weekdays except Wednesday, 7:00am to 3:00pm (Wednesday, 7:00am to 1:00pm)
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Russian.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Medi-Cal, SFHP, Sliding fee scale, BCC
+Eligible Population: All individuals and family members, ages 18 and older.
+Faith Based:  No.
+
+
+Direct Services: Medical Care; Mental Health Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Assessment & Application for SSI. Referrals to other resources available as needed.
+
+HealthRIGHT 360   Outpatient Services
+The mission of HealthRIGHT 360 is to give hope, build health, and change lives for people in need. We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community.    www.healthright360.org
+
+To Get Connected
+Contact Person: Mario Bandes, OP Director 
+Phone: (415) 226-1775  x 2239  
+Fax: (415) 701-7913 
+Email: mbandes@healthright360.org
+Hours: Monday – Friday, 8:45am to 7:00 pm 
+Notes: No referral needed. Drop-ins for orientation welcome. Orientations take occur Monday through Friday  8:45am-9:15am.
+
+
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of San Francisco Residency, TB Clearance. Program will assist entering clients in getting these.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Sliding scale.
+Eligible Population: Adults 18 and over.
+Faith Based: No.
+
+Direct Services: Trauma-Informed Treatment for Women; Transitional Housing; Residential Substance Abuse Services referrals; Hygiene/Personal Care Items; Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Mentorship; Trauma Recovery Services; GED & High School Education; Application assistance with Food Stamps, GA & SSI; Job Readiness/Life Skills; Representative Payee Services; CJ referrals/ mandated; Couples/Family Counseling; Family Reunification; and Parenting Support/Education. Referrals to other resources available as needed.
+
+
+Horizons Unlimited of San Francisco, Inc.   Outpatient Substance Abuse Treatment Program
+The purpose of the substance abuse outpatient treatment program is to provide culturally affirming and linguistically sensitive, strength-based, family-focused and biopsychosocial intervention strategies to support and assist dual diagnosis Latino and other youth and young adults, who have demonstrated emotional and behavioral problems that impede their ability to function in their home, school, community and mainstream society. Horizons’ primary goal is to engage, educate and inspire youth. www.horizons-sf.org 
+To Get Connected
+Contact Persons: Shirley Maciel, Director
+Phone: (415) 487-6702 
+Fax: (415) 487-6724
+Main Phone:  (415) 487-6700
+Email: shirley16maciel@gmail.com 
+Specific Intake Days and Times: Monday-Friday, based on appointment.	
+Hours: Monday – Thursday, 10:00am to 7:00pm; Fridays, 10:00am to 6:30pm
+Location: 440 Potrero Avenue, San Francisco, CA 94110 
+Notes: Clients can get a referral off our website.  Appointment preferred.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of San Francisco Residency. Program will assist entering clients in getting this. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: Men, Women, ages 12-25, involved in criminal justice system.
+Faith Based: No.
+Direct Services: Access to Internet; Food/Prepared Meals; Phone/Voicemail; Transit Vouchers; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Outreach; Post-Incarceration Support; Job Readiness/Life Skills; Culturally appropriate referrals to legal services. Referrals to other resources available as needed.
+Hyde Street Community Services, Inc.   Tenderloin Outpatient Clinic
+The mission of the Hyde Street Community Services, Inc., is to provide comprehensive integrated behavioral services to adult residents of San Francisco who are in need of these services to achieve and maintain the maximum quality of life and greatest degree of independence possible.  We provide behavorial health services to an adult population in San francsico to improve the quality of life for those with chronic and severe behavioral health issues.www.hydestreetcs.org 
+To Get Connected
+Contact Persons: On duty staff
+Phone: (415) 673-5700 
+Fax: (415) 292-7140
+Email: info@hydestreetcs.org
+Hours: Monday – Friday, 9:00am to 5:00pm 
+Location: 815 Hyde Street, Suite 100, San Francisco, CA  
+Notes: Clients may drop-in to apply for services.
+Things To Know
+Languages Spoken: English, Spanish, Vietnnamese, Chinese, Arab.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: The Clinic accepts MediCal, MediCare, Healthy San Francisco.  Clients may be charged according to the state UMDAP scale.
+Eligible Population: We welcome all residents of San Francisco who do not have private insurance.
+Faith Based: No.
+
+Direct Services: Mental Health Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach; Trauma Recovery Services; Victim/Survivor Services; Assessment & Application for SSI Program. Referrals to other resources available as needed.
+
+
+
+Instituto Familiar de la Raza
+Substance abuse and related treatment services. www.ifrsf.org
+To Get Connected
+Contact Person: Adriana Guzman, Intake Specialist
+Phone: (415) 229-0500	
+Fax: (415) 647-3662
+Email: info@ifrsf.org
+Hours: Monday – Friday, 9:00am to 7:00pm; Saturday, 9:00am to 2:00pm 
+Drop-in Hours:  Tuesday 2pm-4pm; Wednesday-Friday 12pm-2pm
+Location: 2919 Mission Street, San Francisco, CA 94110 
+Notes: No referral needed. The first step to access services is to come during our drop-in hours (no appointment necessary). 
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Proof of San Francisco residency. Program will assist clients in obtaining this.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None if client has Medi-Cal/Medicare. Very low sliding scale based on income. No Private Insurance accepted.
+Eligible Population: Individuals with mental health diagnosis. Must not be a danger to others. Must not have private medical insurance.
+Faith Based: No.
+
+Direct Services: Substance Abuse Treatment; Counseling; Mental Health Treatment; Parenting Support. Referrals to other resources available as needed.
+Positive Directions Equals Change
+Our mission is to inspire personal and social responsibility in the African American community through advocacy, education and results-oriented service. Outpatient substance abuse treatment program certified by the State, based on 12-step recovery principles, combined with non-traditional treatment modalities that address the whole individual. Other services include life skills, re-socialization training, parenting education groups, anger management/violence prevention, relapse prevention, drug education, HIV/AIDS awareness, and harm reduction education.
+To Get Connected
+Contact Person: Cedric Akbar, Executive Director.
+Phone: (415) 401-0199	
+Fax: (415) 401-0175
+Email: cantgetright94124@yahoo.com 
+Hours:  Monday-Friday, 10:00am to 5:00pm
+Location: 1663 Newcomb Ave., San Francisco, CA 94124 
+Notes: No referral needed. Drop-in preferred.
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.
+Client fees, if any: Call for fee schedule.
+Eligible Population: All individuals and family members. 
+Faith Based: No. 
+
+Direct Services: Anger Management; Case Management; Counseling; Life Skills; Literacy/Basic Education; Mentoring; Substance Abuse Treatment; Trauma Recovery; Victim Services; Violence Prevention. Referrals to other resources available as needed.
+San Francisco Department of Public Health   Chinatown North Beach Mental Health Services
+Chinatown North Beach Mental Health Services offers an array of outpatient mental health services to adolescents, adults and older adults. Many clients served are immigrants or refugee survivors of war. The program operates from the basic philosophy that services need to be accessible and culturally appropriate. A harm reduction approach is offered to help persons who have both substance abuse and mental health issues. Goals are to help people in their recovery from psychiatric illness, and co-occurring disorders when present, building on the strengths of the individual and family and supporting persons to have productive lives in the community.  
+To Get Connected
+Contact Persons: On-Duty Clinician or “OD”
+Phone: (415) 352-2000 
+Fax: (415) 352-2050
+Clinic Hours: Monday – Friday, 8:30am to 5:00pm; Drop-in hours Monday ­– Friday 9:00am to 11:00am; Wednesday and Friday 1:00pm to 3:00pm
+Location: 729 Filbert Street, San Francisco, CA 94133
+Notes: No referral needed. Okay to drop-in.
+Things To Know
+Languages Spoken: English, Mandarin, Vietnamese, Cantonese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+What to Bring: Medi-Cal card, Medicare card, Healthy San Francisco card or other insurance information, if applicable.
+Client fees: Sliding scale.
+Eligible Population: San Francisco resident
+Faith Based: No.
+ 
+Direct Services: Assessment; Individual Therapy/Counseling; Clinical Case Management; Medication Services; Urgent Care; Crisis Outreach; Family intervention; Acupuncture; Group Services; Adult Socialization Program; Mental Health Services. 
+
+San Francisco Department of Public Health   Central City Older Adult Clinic
+Central City Older Adult Clinic provides mental health services to clients 60 years of age or older who reside in the Civic Center, South of Market, and the Tenderloin areas of the city. Services include medication management, crisis intervention, dual diagnosis treatment, consultation and case management services. 
+To Get Connected
+Contact Persons: Officer of the Day
+Phone: (415) 558-5900 
+Fax: (415) 558-5959
+Clinic Hours: Monday – Friday, 8:30am to 5:00pm
+Location: 90 Van Ness Avenue, San Francisco, CA 94102 
+Notes: No referral needed. Drop-in.
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Cantonese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees: City and County Billing based on set fees – Medi-Care/Medi-Cal share of cost.
+Eligible Population: Men, Women, Transgender people, 60 years of age and older, who live the South of Market or Tenderloin areas of San Francisco, or are homeless.
+Faith Based: No.
+ 
+Direct Services: Assistance Getting Drivers License or Other ID; Transit Vouchers; Mental Health Treatment; Substance Abuse Tratment for Co-occurring Disorder/Dual Diagnosis; Medical Care; Intensive Case Management; Individual and Group Counseling/Therapy (time-limited); Anger Management; Outreach; Assistance with Assessment & Application for SSI; Referrals to other resources available as needed.
+San Francisco Department of Public Health   Mission Mental Health 
+Mission Mental Health is an outpatient mental health clinic that provides services to adults age 18 and older.  
+To Get Connected
+Contact Persons: Nora Zapata Krey, LCSW 
+Phone: (415) 401-2700 
+Fax: (415) 401-2741
+Hours: Monday – Friday, 9:00am to 11:00am.  Intakes are on a first come basis.
+Location:  2712 Mission Street, San Francisco, CA 94110
+Notes: No referral needed. Drop-in during intake hours.
+Things To Know
+Languages Spoken: English, Spanish. Accessibility: Wheelchair accessible. Other disabilities area accommodated.
+Client fees, if any: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients. In some situations, clients may have a co-payment based on income or requirement of their coverage provider.
+Eligible Population: Men, Women, Transgender people, 18 and older. Program does not serve convicted sex offenders whose offense involved a child or minor.
+Faith Based: No.
+
+Direct Services: Medication; Case Management; Harm Reduction Groups; Seeking Safety Groups; Dialectical Behavior Therapy Groups.
+
+San Francisco Department of Public Health   South of Market Mental Health Services
+The Department of Public Health focuses on disease prevention and health promotion of communities throughout San Francisco. We work to achieve the vision of healthy people in healthy communities by performing the following functions: Employ a systematic approach to identify the health conditions and needs of communities; Determine priorities, and develop policies and programs that address the health conditions and needs of communities; Assure that quality health resources and services are available to all San Francisco communities.  
+To Get Connected
+Contact Persons: Officer of the Day 
+Phone: (415) 836-1700 
+Fax: (415) 836-1737
+Hours: Monday – Friday, 8:30am to 5:00pm. Intake on Monday, Tuesday, Thursday and Friday, 8:30am to 10:30am. Wednesday, 1:00pm to 2:30pm. 
+Location:  South of Market Mental Health Services, 760 Harrison Street, San Francisco, CA 94107
+Notes: No referral needed. Drop-in during intake hours.
+Things To Know
+Languages Spoken: English, Tagalog, Spanish, Cantonese. 
+Accessibility: Wheelchair accessible. Other disabilities area accommodated.
+Client fees, if any: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients. In some situations, clients may have a co-payment based on income or requirement of their coverage provider.
+Eligible Population: Men, Women, Transgender people, 18 and older. Program does not serve convicted sex offenders whose offense involved a child or minor.
+Faith Based: No.
+
+Direct Services: Mental Health Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment;  Medical Care; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Assessment & Application for SSI. Referrals to other resources available as needed.
+
+San Francisco Department of Public Health   Southeast Mission Geriatric Services
+The goal of Southeast Mission Geriatric Services is to identify and serve individuals 60 years and older who, without mental health intervention and treatment, are at risk of hospitalization or institutionalization.
+
+To Get Connected
+Contact Persons: Front Desk 
+Phone: (415) 337-2400 
+Fax: (415) 337-2415
+Hours: Monday – Friday, 8:30am to 5:00pm. 
+Location:  3905 Mission Street, San Francisco, CA 94112
+Notes: No referral needed. Call in advance for appointment.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility: Wheelchair accessible. Other disabilities area accommodated.
+Client fees, if any: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and indigent clients. In some situations, clients may have a co-payment based on income or requirement of their coverage provider.
+Eligible Population: Individuals over the age of 60 who have several mental disorders and those who are dually diagnosed who reside primarily but not exclusively in the Southeast area of San Francisco.
+Faith Based: No.
+
+Direct Services: Mental Health Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment;  Case Management; In-Home and Clinic Based Intervention and Therapy. Referrals to other resources available as needed.
+San Francisco Department of Public Health   Sunset Mental Health Clinic
+Sunset Mental Health Clinic welcomes individuals and families who request assistance with mental health, substance abuse, and co-occurring disorders and to ensure the provision of integrated, quality, linguistically-appropriate, culturally competent services and support.
+
+To Get Connected
+Contact Persons: Jane Ma, LCSW or Officer of the Day 
+Phone: (415) 753-7400 
+Fax: (415) 753-0164
+Hours: Monday – Friday, 8:30am to 5:00pm. Drop-in hours 9:00am to 11:00am.
+Location:  1990 41st Ave., San Francisco, CA 94116
+Notes: Best to call in for an appointment to avoid waiting.
+
+Things To Know
+Languages Spoken: English, Cantonese, Mandarin, Russian and Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities area accommodated.
+What to Bring: Health insurance information and list of current medications.
+Client fees, if any: Program accepts Medi-Cal, Medi-Care, Healthy San Francisco and Healthy Worker. Sliding scale for uninsured clients. 
+Eligible Population: Residents of San Francisco who meet medical necessity.
+Faith Based: No
+Direct Services: Assessment; Crisis Intervention; Case Management; Individual Therapy; Medication Services; Group Therapy; Wellness and Recovery Program
+
+San Francisco Department of Public Health   Transitional Youth Services
+Provide direct clinical services, including individual/group/family therapy, medication monitoring and case management to mentally ill youth. TAY strives to empower and educate youth to increase their level of independence and functioning.  
+
+To Get Connected
+Contact Persons:  Intake Coordinator
+Phone: (415) 642-4522 
+Fax: (415) 695-6961
+Notes: No drop-ins. Please call for referral information.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.
+Eligible Population: Men, Women, Transgender people, 16-25 years old, including individuals involved in the criminal justice system.
+Faith Based: No.
+
+Direct Services: Community Education & Mediation; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration Support. Referrals to other resources available as needed.
+
+Tom Waddell Clinic   OBOT
+Substance abuse treatment under the harm reduction model.
+
+To Get Connected
+Contact Persons: Margaret Farny RN, OBOT Program Coordinator
+Phone: (415) 647-6327 
+Hours: Monday – Friday, 8:30am to 4:30pm
+Location: OBOT Program, Tom Waddell urban Health Clinic, 230 Golden Gate Avenue, San Francisco, CA  94102
+Notes: Clients are referred from Ward 93, PCP, OBIC, UC, other CHC Sites. Drop-ins allowed, but appointments are preferred. Please call or write for appointment.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of SF Residency. Program will assist entering clients in getting this. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: Tom Waddell accepts medicare, medical, HSF (sliding scale)
+Eligible Population: All individuals with an opiate dependence.
+Faith Based: No.
+
+Direct Services: Hygiene/Personal Care Items; Mental Health Treatment; Substance Abuse Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment; Medical Care; Health & Wellness Education; Group Counseling/Therapy; Individual Counseling/Therapy. Referrals to other resources available as needed.
+
+UCSF   Citywide Case Management Forensic Program
+The program is one of three intensive case management programs co-located at 982 Mission Street, under the umbrella of the UCSF Department of Psychiatry's Community Services Division.  Mission Statement: "The Citywide Focus Center is a UCSF site in which the Citywide Focus programs provide compassionate, respectful, culturally and clinically competent, and comprehensive psychiatric services to individuals with severe and persistent mental illnesses and to their families and support networks."
+www.cw-cf.org/Home/citywide-forensics-project   psych.ucsf.edu
+To Get Connected
+Contact Person: Marta Gilbert, Clinical Supervisor
+Phone: (415) 597-8071 
+Fax: (415) 597-8004
+Email: marta.gilbert@ucsf.edu 
+Hours: Monday – Friday, 8:30am to 4:45pm; Saturday, 10:00am to 1:00pm
+Location: 982 Mission Street, San Francisco, CA 94103 
+Notes: Clients must have a referral from the San Francisco Behavioral Health Court, Jail Reentry Services, or Community Behavioral Health Services. Clients who wish to self-refer should first contact SF Mental Health Access at (415) 255-3737.
+Things To Know
+Languages Spoken: English, Spanish, Russian. Onsite translation in Chinese dialects, Vietnamese, and Tagalog.
+Accessibility: Wheelchair accessible. Other disabilities accommodated.
+Client fees: Client fees are determined by Community Behavioral Health Services. Services are billed through Medi-Cal if available. No one is refused services due to lack of income or benefits.
+Eligible Population: Must meet Community Behavioral Health Services’s medical necessity for a serious mental illness. For employment services only, must meet Department of Rehabilitation’s criteria for mental illness.
+Faith Based: No.
+
+Direct Services: Mental Health Treatment; Co-Occurring Disorder/Dual Diagnosis Treatment; Anger Management; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach; Post-Incarceration Support; Trauma Recovery Services; Assistance with Assessment & Application for General Assistance and SSI; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Representative Payee Services. Referrals to other resources available as needed.
+
+UCSF   Citywide Case Management Forensic NoVA Therapy Program
+The purpose of this program is to provide culturally competent mental health services in support of the Sheriff’s Department NoVA Program’s goals of aiding offenders’ successful reentry into the community and reducing recidivism, treating all individuals with dignity, compassion and respect. www.cw-cf.org
+To Get Connected
+Contact Person: Yasi Shirazi, MFT, Clinical Supervisor
+Phone: (415) 597-8027 
+Fax: (415) 597-8004
+Email: yasaman.shirazi@ucsf.edu 
+Hours: Monday – Friday, 8:30am to 4:45pm; Saturday, 10:00am to 1:00pm
+Location: 982 Mission Street, San Francisco, CA 94103 
+Notes: Clients must all be enrolled in the San Francisco Sheriff's Department NoVA program and be referred by his or her community-based case manager. No drop-ins.
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees: There are no client fees for NoVA therapy services.
+Eligible Population: Individuals who are enrolled in the SF Sheriff Department’s NoVA program.
+Faith Based: No.
+
+Direct Services: Mental Health Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Group and Individual Counseling/Therapy; Outreach; Post-Incarceration Support; Trauma Recovery Services; Assistance with Assessment & Application for SSI; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Couples/Family Counseling. Referrals to other resources available as needed.
+
+
+    
+Arab Cultural and Community Center
+Assist immigrant families in adjusting/adapting to hardships in American societies, and aim to provide any services needed through referrals. 
+To Get Connected
+Phone: (415) 664-2200 
+Fax: (415) 664-2280
+Email: info@arabculturalcenter.org
+Hours: Monday - Friday, 10:00am to 5:00pm
+Location: 2 Plaza Street, San Francisco, CA 94116
+Notes: No referral needed. By appointment only. No drop-ins.
+Things To Know
+Languages Spoken: English.
+What to Bring: State-Issued ID; Proof of San Francisco residency.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None. 
+Eligible Population: All individuals, and family members.
+Faith Based: No.
+
+Direct Services: Referrals to range of community resources and social services.
+
+Bay Area Women’s & Children’s Center
+BAWCC offers a variety of direct services that address immediate needs and assists with achieving long-term stability. BAWCC's advocacy, planning and policy work on issues of low-income children and families has had a positive impact on the lives of thousands since we opened in 1981. BAWCC's long-term projects have resulted in the creation of playgrounds, a recreation center, school, and family center. www.bawcc.org
+To Get Connected
+Contact Persons: Diane Van Stralen, Nancy Ong or Midge Wilson 
+Phone: (415) 474-2400 
+Fax: (415)474-5525
+Hours: Tuesdays and Thursdays, 8:30am to 12:30pm (drop-in)
+Location: 318 Leavenworth Street, San Francisco, CA 94102
+Notes: No referral needed. Drop-ins are welcome. Appointments can be made.
+Things To Know
+Languages Spoken: English, Cantonese, Mandarin, Limited Spanish, & Vietnamese.
+What to Bring: Some form of I.D. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: Women, Transgender individuals, including those pregnant or with children.
+Faith Based: No.
+Direct Services: Clothing, Dental Care (in partnership with UCSF), Food pantry, Literacy/Basic Education, Scholarship fund for Tenderloin college age students,. Referrals to other resources available as needed.
+
+Black Coalition on AIDS    
+The Black Coalition on AIDS (BCA) focuses on reducing health disparities in the Black community, most notably, the spread of HIV/AIDS. BCA strives to achieve this focus by providing health and wellness services including, but not limited to, transitional housing, health education, advocacy, health case management and other health-promoting activities. www.bcoa.org
+
+To Get Connected
+Contact Persons: Francis Broome, Coordinator of Prevention and Education
+Phone: (415) 615-9945, ext. 114
+Email: fbroome@bcoa.org or bcoa@bcoa.org
+Location: 601 Cesar Chavez Street, San Francisco, CA 94124
+Things To Know
+Languages Spoken: English.
+Eligible Population: African Americans, HIV + individuals and those at risk for HIV and other health disparities
+Faith Based: No.
+
+Direct Services: Transitional housing; health case management; counseling; community outreach; health education workshops; drop-in and support groups; health enhancement and stress reduction classes; complementary alternative medicine; wellness services; dinner-and-a-movie night; women’s HIV prevention education; and referrals for health screening, treatment and primary care.
+
+Central City Hospitality House   
+Hospitality House is a community center for San Francisco’s Tenderloin neighborhood, providing opportunities for personal growth and self-determination to homeless people and neighborhood residents. The agency’s mission is to build community strength by advocating policies and rendering services which foster self-sufficiency and cultural enrichment. We encourage self-help, mutual respect, and increased self-esteem. The goal of these efforts is to make the heart of San Francisco a better place for us all. Facilities include the Tenderloin Self-Help Center (TSCH), the Sixth Street Self-Help Center, a shelter, and the Community Arts Program (CAP) , the Employment Program (EP), and the Community Building Program (CBP.  www.hospitalityhouse.org 
+To Get Connected
+Office Phone: (415) 749-2100 
+Office Fax: (415) 749-2136
+TSHC: (415) 749-2143
+Sixth Street: (415) 369-3040
+Shelter: (415) 749-2103
+CAP: (415) 749-2133
+Employment Program: (415) 749-2175
+CBP:  (415) 749-2102
+Email: info@hospitalityhouse.org 
+Hours: 
+TSHC: Mon-Fri, 7:00am to 7:00pm
+Sixth Street: Mon-Fri: 9am-5pm
+Shelter: Mon-Fri, 4:00pm to 8:00am; 24-hours Weekends & Holidays
+CAP: M/W/F: 1-6pm; Tue/Thurs: 10am-3pm
+CBP:  Mon-Fri 9:00 -5:00pm 
+Location: 
+Main Office, TSHC & Community Building Program: 290 Turk Street, San Francisco, CA 94102 
+Sixth Street Self-Help Ctr: 169 & 181 Sixth St., San Francisco, CA 94103
+Shelter: 146 Leavenworth St., San Francisco, CA 94102 
+Community Arts Program: 1007 Market St., San Francisco, CA 94102
+Employment Program: 146 Leavenworth, San Francisco, CA  94102
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish, Chinese. 
+Accessibility: All programs wheelchair accessible.  Other disabilities are accommodated.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+
+Direct Services: Emergency Shelter; Rental Move-in Assistance; Access to Internet; Assistance Getting Drivers License or Other ID; Hygiene/Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Transit Vouchers; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Group Counseling/Therapy; Individual Counseling/Therapy; Post-Incarceration Support; Employment Placement; Employment Retention; Job Readiness/Life Skills; Couples/Family Counseling; Meals; Shower Facilities. Referrals to other resources available as needed.
+
+Center for Restorative Justice Works   Get On The Bus
+The Center for Restorative Justice Works unites children, families and communities separated by crime and the criminal justice system. CRJW calls the community to set aside pre-judgments about women and men in prison in order to work together to accompany families torn apart by the crime and the criminal justice system; create awareness about the negative impacts of incarceration on children and families; and advocate for programs and policies that restore relationships.  CJRW re-weaves the web of relationships that have been torn apart by crime and the policies of the criminal justice system. Get on the Bus is a program of The Center for Restorative Justice Works. Get On The Bus brings children and their guardians/caregivers from throughout the state of California to visit their mothers and fathers in prison. An annual event, Get On The Bus offers free transportation for the children and their caregivers to the prison, provides travel bags for the children, comfort care bags for the caregivers, a photo of each child with his or her parent, and meals for the day (breakfast, snacks on the bus, lunch at the prison, and dinner on the way home) — all at no cost to the children’s family. On the bus trip home, following a four-hour visit, each child receives a teddy bear with a letter from their parent and post-event counseling.  www.crjw.us     www.getonthebus.us
+
+To Get Connected
+Contact Persons:
+Main Office:  Southern California Office
+Phone: (818) 980-7714 
+Fax: (818) 980-7702
+Email: info@getonthebus.us
+Hours: Monday – Friday, 9:00am to 5:00pm Intake Tuesday – Friday.
+Location: 6400 Laurel Canyon Blvd. Ste 304
+North Hollywood, CA  91606
+Notes: No referral needed.  Applications are received from the incarcerated parent at select institutions.  Call for more info..
+Things To Know
+Languages Spoken:  English, Spanish.
+Accessibility: ADA compliant.
+Eligible Population: Children (Infant to 18 yrs.) of incarcerated Mothers & Fathers (including caregivers).
+Faith Based: Inter-Faith.
+
+Direct Services: Each year around Mothers Day and Father’s Day, hundreds of children and their caregivers board buses and travel from cities all over the State of California to be united. 
+
+Center for Young Womens Development   Sisters Rising & GDAP  
+For 20 years, the Center for Young Women’s Development has empowered and inspired thousands of young women experiencing incarceration or life on the streets to create positive personal and social change.  CYWD offers a paid internship program for young women exiting the juvenile justice system or underground street economy.  Our mission is to empower and inspire young women who have been involved with the juvenile justice system and/or the underground street economy to create positive change in their lives and communities. www.cywd.org
+To Get Connected
+Contact Person:  Program Director
+Phone: (415) 703-8800 
+Fax: (415) 703-8818
+Email: info@cywd.org 
+Hours: Monday – Friday, 9:00am to 5:00pm Intake Monday – Friday.
+Location: 832 Folsom Street, Suite #700, San Francisco, CA 94107
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible.
+Eligible Population: Women and girls ages 12-24, Pregnant women, Women with children who are involved in the criminal/juvenile justice system.
+Faith Based: No.
+
+Direct Services: Employment Program; Access to Internet; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Phone/Voicemail; Community Education & Mediation; Post-Incarceration Support; Employment Training. Referrals to other resources available as needed. 
+
+
+Center on Juvenile and Criminal Justice   NoVA Services
+The Center on Juvenile Justice’s NoVA mission is to provide high-quality professional pre-release planning and intensive case management to individuals who are returnign to the community from San Francisco’s Jails. www.cjcj.org
+To Get Connected
+Contact Persons: Gerald Miller, Director of Community-Based Services
+Phone: (415) 621-5661
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 40 Boardman Street, San Francisco, CA 94103
+Notes: All referrals are made through San Francisco Pre-Trial Diversion. No drop-ins.
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility: Wheelchair accessible.
+Eligible Population: All individuals incarcerated in or recently released from San Francisco County Jail and referred by Pre-Trial Diversion.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Driver’s License, other ID; Clothing; Hygiene/Personal Care Items; Intensive Case Management; Individual and Group Therapy/Counseling; Mentorship; Outreach; Post-Incarceration Support; Employment Training.
+
+
+
+
+
+
+
+
+
+																				                                                        
+
+Centerforce   Positive Connections Program/Project Start
+Centerforce’s Positive Connections Program provides intensive transitional case management services for HIV+ individuals who are leaving prison and returning to either San Francisco or Alameda County. www.centerforce.org
+
+To Get Connected
+Contact Person:  Jessica McGhie-Osorio Phone: (415) 456-9980 ext 204 
+Email: jmcghie@centerforce.org
+Specific Intake Days and Times: 
+Intakes are completed on an ongoing basis, either during incarceration in prison or shortly after release, in the community.
+Service Areas: Bay Area
+Administrative Office Mailing Address: PO Box 415, San Quentin, CA 94964
+Notes:  For other Centerforce programs call 415-456-9980.
+ 
+
+Things To Know
+Languages Spoken: English, Spanish. Translation services will be arranged when possible.
+Client fees: None.
+Eligible Population: HIV+ individuals   
+currently incarcerated in – or recently    
+released from – state prison, returning to
+Bay Area Counties.
+Faith Based: No.
+Direct Services: Pre- and Post-Release Transitional Case Management to link HIV+ clients with housing, food, clothing, transportation, benefits assistance, case management and primary HIV care in the community.
+
+Community Assessment and Services Center (CASC)   A Partnership of the San Francisco Adult Probation Department (APD) and Leaders in Community Alternatives (LCA)
+The CASC is a one-stop community corrections reentry center that bridges APD probation supervision services with comprehensive case management, barrier removal, and income benefits acquisition assistance. The CASC co-locates services that build self-sufficiency, including a charter high school, vocational and employment readiness training, mental health, and substance abuse prevention services, batterers’ intervention programs, cognitive behavioral interventions, and meeting space for community partners.   The goals of the CASC are to reduce recidivism, build self-sufficiency skills, and increase public safety.   APD provides on-site probation supervision services. Leaders in Community Alternatives is the CASC’s primary services provider and coordinates all CASC services.  Other key partners include the 5 Keys Charter School, Center on Juvenile and Criminal Justice, America Works, Community Works West, Senior Ex Offender Program, OTTP, Transitions Clinic, Healthright360, Tenderloin Housing Clinic, RSN, the Department of Public Health, Human Services Agency and Department of Child Support Services.
+
+To Get Connected
+Contact Person: Intake
+Phone:  415-489-7300
+CASC Hours: Monday, Tuesday, Thursday, Friday 8am-8pm; Wednesday 8am-5pm
+Location:  564 6th Street, San Francisco, CA  94103
+Notes: For referrals, please contact your DPO at 415-553-1706.  For general CASC services information, please contact CASC Program Director Melissa Gelber at (415) 489-7301 or by email at mgelber@lcaservices.com or the Asst. Program Director Roth Johnson at 415-489-7302 or by email at rjohnson@lcaservices.com
+ 
+
+Things To Know
+Languages Spoken: English, Spanish. Language access for limited English proficient (LEP) individuals is available.
+Client fees: None.
+Eligible Population: Clients of the San Francisco Adult Probation Department.
+Faith Based: No.
+
+Direct Services: Case Management; Education (literacy services, high school and GED instruction); Employment Readiness; Job Placement; Job Readiness/Life Skills; Vocational Training; Parenting; Anger Management; Behavioral Health Assessments and Treatment; Cognitive Behavioral Services. Referrals to other services as appropriate.
+
+
+
+
+
+
+
+
+
+
+
+
+Community Works West   Young Men’s Reentry Program/Voices on the Rise
+The Young Men’s Reentry Program is a full-service reentry program for 18-25 year old, previously incarcerated men.  Voices on the Rise is a restortaive justice theater ensemble for formerly incarcerated young men ages 18-25 years old.  The program starts in late Fall/early Winter and meets twice a week at the San Franscisco Sheriff’s Department (SFSD) Community Programs and culminates in several public performances in the Spring.  Voices on the Rise is a paid job opportunity.   www.communityworkswest.org
+
+To Get Connected
+Contact Person: Teeoni Newsom
+Phone:  (415)-575-6409
+Email:  tnewsom@communityworkswest.org
+Location:  San Francisco Sheriff’s Department Community Programs, 70 Oak Grove, San Francisco, CA  94103
+Hours:  Monday-Friday 8:30am-4:30pm
+ 
+
+Things To Know
+Languages Spoken: English.
+Client fees: None
+Eligible Population: Men ages 18-25.
+Faith Based: No.
+
+Direct Services: Intensive Case Management; Individual Service Plans;  Short term and long term goals around employment, housing, education, counseling, and substance abuse; Job Development; Life Skills; Thinking for a Change and Manalive Classes; Restorative Justice Theater Program for Young Men.
+
+Community Works West   Women Rising/Rising Voices
+Women Rising/Rising Voices provides formerly incarcerated young women with the tools/resources to lead healthy and productive lives, as well as reducing their rates of re-arrest, by providing a full continuum of services, combining the principles of restorative justice and youth development through a paid theater internship and case management.  Rising Voices is a restorative justice theater ensemble for formerly incarcerated young women ages 18-25.  Rising Voices is a paid job opportunity.    www.communityworkswest.org
+
+To Get Connected
+Contact Person: Chloe Turner
+Phone:  (415)-734-3150
+Email:  cturner@communityworkswest.org
+Location:  San Francisco Sheriff’s Department Women’s Resource Center, 930 Bryant Street, San Francisco, CA  94103
+Hours:  Monday-Friday 8:00am-4:00pm
+ 
+
+Things To Know
+Languages Spoken: English.
+Client fees: None
+Eligible Population: Open to all formerly incarcerated women ages 18-25 years old.
+Faith Based: No.
+Direct Services: Case Management; Individual Service Plans that address short term and long term goals around employment, housing, education, counseling, and substance abuse; Job Development;  Restorative Justice Theater Program for Young Women.
+
+
+
+
+Compass Family Services   Compass Connecting Point
+Compass Connecting Point (CCP) is a unique program that gives any San Francisco family experiencing a housing crisis quick access to the services that they need most, including eviction prevention, emergency shelter, health care, child care and eductional programs.  CCP manages the shelter waiting list for the City funded long-term family shelters.  Our goals are to place families into shelter and provide supportive services during that wait, including emergency food, diapers, transportation assistance, and intensive supoort with housing search.  Additionally CCP provides a one time interest free loan for move in funds and eviction prevention.  
+
+url: www.compass-sf.org/programs/connecting-point
+
+To Get Connected
+Contact Person: Any hotline worker or Crisis Intervention Counselor
+Phone: (855) 234-2667
+Fax:  (415) 442-5138
+Specific Intake Days/Times:  Monday 9am-12pm and 1pm-5pm; Tuesday 9am-12pm and 3pm-5pm; Wednesday 9am-12pm and 1pm-5pm; Thursday 9am-12pm and 2pm-5pm; and Friday 9am-12pm and 1pm-5pm
+Note:  No referral required.  All clients are required to do a 15 minute phone intake over the hotline at (855) 234-2667.  Drop-in services are available Monday 9am-12pm, Wednesday 10:30am-12pm, Friday 9am-12pm..  Families are typically on the waitlist for 6 to 8 months during which we provide supportive services.
+
+
+Things To Know
+Languages Spoken: English, Spanish, Cantonese, Mandarin, German.  We are able to arrange ASL interpreters.
+Accessibility:  Wheelchair accessible.
+Client fees: None
+Eligible Population: All families, pregnant women, women with children.  Eligible families have at least one legal adult plus either a minor child in their custody or a preganancy.  There is no maximum family size.  For shelter wait list, families must be homeless and receiving public benefits in SF or willing to transfer to SF.  For rental assisitance, families must be SF residents.  For move in funds, they must be homeless in SF and have a unit they have been accepted into.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Rental Move-in Assistance; Access to Internet; Assistance Getting Driver’s License and Other ID; Clothing; Food/Prepared Meals; Hygeine/Personal Care Items; P.O. Box/Mail Service; Transit Vouchers; Mental Health Treatment; Health & Wellness Education; Assistance Applying for Calfresh/Food stamps.
+
+Deaf Community Counseling Services  (DCCS)
+DCCS, formally known as the UCSF Center on Deafness,a program of Family Service Agency of San Francisco/Felton Institute, provides outpatient mental health and substance abuse services for individuals who are Deaf, Deaf-Blind, Hard of Hearing and Late Deafened.  
+url: felton.org/social-services/adult/dccs/
+
+To Get Connected
+Phone: (415) 474-7310
+Phone: (415) 255-5854 
+Fax:  (415) 447-9701
+Email:  dccs@felton.org
+Hours: Mon-Fri, 9am-5pm
+Location: 1500 Franklin Street, San Francisco, CA  94109 
+Notes: Please call for information.
+Things To Know
+Languages Spoken: English, American Sign Language.
+What to Bring: Proof of SF residency.
+Eligible Population: Services are for people who are deaf, hard of hearing, and deaf/blind.  Adluts, seniors, and children.
+Faith Based: No.
+
+Direct Services: Mental Health & Substance Abuse Assessment and Therapy; Psychiatric & Medication Services; Co-Occurring/Dual Diagnosis Treatment; Health and Wellness Education; Group and Individual Counseling/Therapy; Intensive Case Management; Basic/Remedial Education; Support with Assessment and Application for Food Stamps, General Assistance and SSI; Money Management and Personal Finance Education; Couples Counseling/Therapy; Parenting Support/Education; Counseling/Therapy for Children. Referrals to other resources available as needed.
+
+Dress For Success San Francisco
+The mission of Dress for Success is to promote the economic independence of disadvantaged women by providing professional attire, a network of support and the career development tools to help women thrive in work and in life.  www.dressforsuccess.org/sanfrancisco
+
+To Get Connected
+Contact Person:  Gia Barsi, Program Manager
+Phone: (415) 362-0034 
+Fax: 415-362-0035
+Email: sanfrancisco@dressforsuccess.org 
+Hours: Monday – Friday 9am -5pm
+ Location: 500 Sutter Street # 218, San Francisco, CA  94102
+Notes: Written Referral required for a Suiting Appointment. No walk-in’s, by appointment only. Suiting appointments are Tuesday – Thursday, 11am – 3pm. No children or visitors are allowed to accompany you to your appointment.   All items are based on inventory.  
+Things To Know
+Languages Spoken: English.
+What to Bring: Dress for Success San Francisco does not require ID at check-in. Check in at security desk required. 
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None. 
+Eligible Population: Female only; 16 years and older; must be actively job searching, attending a job fair/networking event, or enrolled in a job training/internship program. Clients are eligible to be seen twice a year for clothing services (once for an initial interview outfit; again when you have secured part-time/full-time employment). 
+Faith Based: No.
+
+Direct Services: Professional and Working Wardrobe Attire, Job Mentorship Program, Professional Women’s Group Networking Program, 
+
+Aging and Disability Resource Center 
+Aging and Disability Resource Centers (ADRCs) offer the general public a single source for connecting to free information and assistance on issues affecting older people and people with disabilities, regardless of their income. These resource centers are welcoming and convenient locations for you and your family to get objective and accurate information, advice, and have access to a wide variety of services.  With hubs throughout San Francisco, the ADRC Information and Assistance Specialists provide a wide range of services in multiple languages. www.sfdaas.org
+
+To Get Connected
+Office Phone:  Intake
+(415) 487-355-6700 
+Location:  1650 Mission St. San Francisco, CA 94103
+Notes:  For more info visit one or our ADRC’s or contact ADRC Supervisor at 415-750-4111.
+
+Things To Know
+Languages Spoken: English and other languages.  Please call for information.
+Accessibility:  All out stations are accessible
+Eligible Population:  Seniors (60+) and Young Adults with Disabilities (18-59).
+Faith Based:  No.
+
+Location and Hours:
+Richmond Senior Center:  Golden Gate Senior Services, 6221 Geary Boulevard, 3rd Floor, San Francisco, CA  94121, (415)-404-2938 or (415)-752-6444, Monday-Friday 9am-3pm (by appointment 8:30am-9am, 3pm-3:30pm)
+
+Aquatic Park Senior Center:  Northern California Presbyterian Homes and Services, 890 Beach Street, San Francisco, CA  94109, Spanish (415)-202-2982 or Chinese (415)-202-2983, Monday-Friday 9am-12:30pm, 1pm-3pm (by appointment until 4pm)
+
+Toolworks—Main Office:  25 Kearney Street, Suite 400, San Francisco, CA  94108,(415)-733-0990 x613, Monday, Tuesday, Thursday, Friday 8:30am-4:30pm (Closed Wednesday)
+
+Self Help for the Elderly—Main Office:  601 Jackson Street, San Francisco, CA  94108U, (415)-677-7585, Monday, Wednesday, Friday 8:30am-12:30pm , 1:15pm-5:15pm; Tuesday, Thursday 8:30am-12:30pm
+
+Geen Mun Activity Center:  Self Help for the Elderly,  777 Stockton Street, San Francisco, CA  94108,
+(415)-438-9804, Monday, Wednesday, Friday 8:30am-12:30pm , 1:15pm-5:15pm; Tuesday, Thursday 1:15pm-5:15pm
+
+South Sunset Activity Center:  Self Help for the Elderly, 2601 40th Avenue, San Francisco, CA  94116,
+(415)-566-2845, Monday-Thursday 8:30am-3:00pm , Friday 9am-3pm
+
+Bayview Senior Connections:  Bayview Hunters Point Multipurpose Senior Services, 5600-A 3rd Street, San Francisco, CA  94124,(415)-647-5353, Monday-Friday 10am-5pm 8:30am-3:00pm 
+
+Downtown San Francisco Senior Center:  Northern California Presbyterian Homes and Services, 481 O’Farrell Street, San Francisco, CA  94102, Spanish (415)-202-2982 Chinese (415) 202-2983
+Monday-Friday 9am-12:30pm, 1:00pm-3:30pm (by appointment until 4pm)
+
+
+OMI Senior Center:  Catholic Charities, 65 Beverly Street, San Francisco, CA  94132, (415)-334-5550 
+	Monday-Friday 8:30am-2:30pm (by appointment 2:30pm-4pm)
+ 
+	Openhouse—Main Office:  Openhouse (LGBT Hub), 1800 Market Street, 4th Floor, San Francisco, CA  	94102, (415)-347-8509, Monday-Friday 9am-5:30pm (by appointment 9am-11:30am, drop-ins 	1pm-4:30pm)
+
+	30th Street Senior Center:  225 30th Street, 3rd Floor, San Francisco, CA  94131, (415)-550-2221
+	Monday-Friday 8:30am-3pm
+ 
+	Western Addition Senior Center:  Bayview Hunters Point Multipurpose Senior Services, 1390 ½ Turk 	Street, San Francisco, CA  94115, (415)-921-7805, Monday-Friday 10am-5pm
+
+	Direct Services: The ADRC’s can support individuals with information, referral, and/or assistance in 	the following areas:  Caregiver Assistance and Support; Case Management Services; Employment 	and Training Opportunities; Financial Assistance and Planning; Food and Nutrition; Health and 	Wellness; Housing and Shelter; In-home Care; Legal Assistance; Lesbian, Gay, Bisexual and 	Transgender (LGBT) Programs and Services, Medical and Dental Care; Mental Health and 	Counseling Services; Paperwork and Application Assistance; Prescription Drug Coverage; Senior 	Centers, Translation Services; Transportation.
+
+
+Episcopal Community Services   SF START
+SF-START is designed to provide coordinated and integrated services to support recovery in partnership with Episcopal Community Services’ Skills Center, permanent housing placement support, and benefits advocacy in San Francisco’s single adult homeless shelters. 
+
+url: www.ecs-sf.org
+
+To Get Connected
+Person to Contact: Contact an SF-START case manager working inside one of the shelters listed below.
+Hours: Monday through Saturday, 9:00am to 7:30pm
+Location: SF-START operates inside each of the three largest adult homeless shelters: Next Door, MSC-South, and Sanctuary.
+Notes: No referral needed. SF-START does not provide shelter beds; it serves people who are already inside the emergency shelter system.
+Things To Know
+Languages Spoken: English, Spanish. Accessibility: Sanctuary is not fully wheelchair accessible. Other shelters have elevators.
+Client fees: None.
+Eligible Population: Adults. 
+Faith Based: No.
+
+
+Direct Services: START team provides case management for individuals with mental health and substance abuse disorders; Group Counseling and Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach. Referrals to other resources available as needed.
+
+Episcopal Community Services   Adult Education Center
+The Adult Education Center specializes in providing a stable, caring and individualized learning environment for students who are coping with the inter-related challenges of homelessness, illiteracy, learning disabilities, substance abuse, and mental health issues. While created particularly for homeless adults and those formerly homeless adults living in supportive housing, the Adult Education Center is open to all low-income individuals in San Francisco who would like to further develop their academic skills or need job counseling, training and placement.  
+
+url: www.ecs-sf.org/programs/skills.htm
+
+To Get Connected
+Person to Contact: Staff
+Phone: (415) 487-3300 ext. 1101 
+School Hours: Monday -Thursday, 9am to 3pm  Friday, 9am-12pm.
+Location: 165 8th Street, San Francisco, CA  94103
+Notes: No referral needed. Drop-ins welcome. Orientations are drop in every Monday-Thursday at 1:00pm
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: Adults, age 18 and older. 
+Faith Based: No.
+
+
+Direct Services: Access to Internet; Food/Prepared Meals; Hygiene/Personal Care Items; Health and Wellness Education; Basic/Remedial Education; GED preparation; High School Diploma; Reading and Literacy Assistance; Job Readiness and Life Skills; Money Management and Personal Finance Education. Referrals to other resources available as needed.
+
+Glide Foundation   Glide Daily Free Meals Program
+The goal of this program is to provide three nutritious meals a day, 364 days a year, to anyone in need. www.glide.org
+To Get Connected
+Person to Contact: Bruce McKinney, Manager
+Phone: (415) 674-6043 
+Fax: (415) 921-6951
+Hours: 
+Monday – Friday
+Breakfast: 8:00am to 9:00am
+Lunch: 12:00pm to 1:30pm
+Dinner: 4:00pm to 5:30pm 
+Saturday & Sunday
+Breakfast:  8am-9am
+Lunch:  12:00pm-1:30pm
+Bagged dinner provided after lunch 
+Location: 330 Ellis Street, San Francisco, CA  94102
+Things To Know
+Languages Spoken: English, Spanish 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals and family members. 
+Faith Based: No.
+Notes: No referral needed. Drop-ins welcome.
+
+Direct Services: Prepared Meals. Referrals to other resources available as needed.
+
+
+Glide Foundation   Men In Progress
+Men In Progress is a Violence Intervention Program dedicated to working with all men in straightforward and practical ways on issues that affect their lives. The goal is to support men to gain understanding and strength in their relationships with themselves, partners, family, friends and community. www.glide.org
+To Get Connected
+Person to Contact: Group Facilitator
+Phone: (415) 674-6195  
+Fax: (415) 771-8420
+Hours: Tuesday and Thursdays 5pm-8pm
+Location: 330 Ellis Street, San Francisco, CA  94102 (go to Freedom Hall)
+Notes: To join the group you must show up on a Tuesday at 4:30pm.  No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals and family members. 
+Faith Based: No.
+
+Direct Services: Anger Management; Community Education and Mediation; Group Counseling/Therapy; Post-Incarceration Support. Referrals to other resources available as needed.
+
+Glide Foundation   Walk-In Center
+To provide clients with immediate assistance to prevent their situations from escalating, and to engage them in more extended, intensive services when they are ready. www.glide.org
+To Get Connected
+Person to Contact: Client Advocate
+Phone: (415) 674-6033 
+Fax: (415) 771-8420
+Hours: Monday – Thursday, 8:00am to 1:00pm, 2:00pm to 4:30pm; Friday, 8:30am to 12:45pm
+Emergency Shelter Bed Reservations: 365 days/year, 7:00am to 10:30am and 4:00pm to 9:00pm
+Location: 330 Ellis Street, Room 101, San Francisco, CA  94102 
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals and family members. 
+Faith Based: No.
+
+Direct Services: Rental Move-in Assistance.  The Walk-In Center assists clients in obtaining rental assistance through Season of Sharing, HPRP, Catholic Charities, FEPCO, HOME, etc.  Staff screen for eligibility, and assist clients with the full application process.  Emergency Shelter Bed Reservations; Permanent Housing; Transitional Housing; Assistance Getting Drivers License or Other ID; Clothing; Phone/Voicemail Access; Food/Prepared Meals; Hygiene/Personal Care Items; Intensive Case Management. Referrals to other resources available as needed.
+
+Glide Foundation   Women's Center
+To introduce Afro-centric and socio/historical/political contexts for a culturally sensitive and holistic approach to healing and transformation for African American women impacted by domestic violence. www.glide.org
+To Get Connected
+Contact Persons: Case Manager
+Phone: (415) 674-6026
+Hours: Tuesday, 9:00am to 10:30am; Wednesday, 9:00am to 10:30am, 3:00pm to 4:30pm; Thursday and Friday, 9:00am to 10:30am
+Location: 330 Ellis Street, San Francisco, CA  94102 
+Notes: No referral needed. Drop-ins are welcome. 
+Things To Know
+Languages Spoken: English.
+Client fees, if any: None.
+Faith Based: No.
+
+Direct Services: Emergency Shelter Bed Reservations; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Health and Welness Education; Group Counseling; Intensive Case Management; Individual Counseling/Therapy; Outreach; Victim/Survivor Services; Post-Incarceration Support. Referrals to other resources available as needed.
+
+Homeless Prenatal Program   
+In partnership with our families, we work to break the cycle of childhood poverty. By seizing the motivational opportunity created by pregnancy and parenthood, HPP joins with families to help them recognize their strengths and trust in their capacity to transform their lives. www.homelessprenatal.org
+To Get Connected
+Phone: (415) 546-6756 
+Fax: (415) 546-6778 
+Hours: Monday – Thursday, 9:00am to 5:00pm; Friday, 9am-4pm. Closed from 12-1pm daily. Intake hours vary by day.
+Location: 2500 18th Street, San Francisco, CA  94110 
+Notes: No referral needed. Drop-ins are welcome for intake.
+Things To Know
+Languages Spoken: Spanish, English, French, Tagalog, Cantonese, Mandarin.
+What to Bring: Proof of residency is required for housing deposits. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fee to clients.
+Eligible Population: Men, Women, Transgender people with a child under 18 yrs old, Pregnant women.
+Faith Based: No.
+
+Direct Services: Hotel Vouchers for pregnant women in the last trimester and DV clients when no shelter beds are available; Rental & Move-in Assistance; Access to Internet; Assistance Getting Driver’s License/Other ID; Clothing; Food/Prepared Meals; Health & Wellness Education; Intensive Case Management; Outreach; English as a Second Language; Assessment & Application for Food Stamps, SSI; Credit Repair; Money Management/Personal Financial Education/Personal Income tax preparation; Housing Advocacy (refer out for eviction defense); Couples/Family Counseling; Family Reunification; Parenting Support/Education. Referrals to other resources available as needed.
+
+Jireh Technologies, Inc. 
+As a social enterprise venture, Jireh Technologies, Inc. (Jireh Tech) serves as a public benefit 501(c)3 organization that was incorporated in February 2004. As social entrepreneurs, the Jireh Tech management team is engaged in creating a sustainable model of mitigating the digital divide and utilizing information and communications technology as a tool for community development. www.jirehtech.org
+To Get Connected
+Contact Person: IT Director
+Phone: (925) 338-1832
+Email:  mail@jirehtech.com 
+Hours: Monday – Friday, 10:00am-6:00pm.
+Location: 2070 North Broadway Stuite 4082, Walnut Creek, CA 94596
+Notes: No referral needed. Appointments are preferred but drop-ins are acceptable.
+Things To Know
+Languages Spoken: English, some Spanish. 
+What to Bring: State-issued ID and TB clearance. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees: No fee to clients.
+Eligible Population: Everyone welcome.
+Faith Based: No, but the organization is housed within a faith-based Christian facility.
+
+Direct Services: 8-12 week digital literacy course which teaches and assesses basic computing concepts and skills so that people can use computer technology in everyday life. Program also provides: Access to Internet; Assistance Getting Driver’s License/Other ID; Job Readiness/Life Skills. Referrals to other resources available as needed.
+
+
+Lavender Youth Recreation & Information Center (LYRIC)    
+LYRIC is an organization for lesbian, gay, bisexual, transgender, queer and questioning youth, ages 24 and younger. LYRIC’s mission is to build community and inspire positive social change through education enhancement, career training, health promotion and leadership development with LGBTQQ youth, their families, and allies of all races, classes, genders and abilities. LYRIC works to meet youth where they are and support them in getting what they need. www.lyric.org
+To Get Connected
+Contact Persons: Youth Advocates
+Phone: (415) 703-6150  
+Fax: (415) 703-6153
+Email:  lyricinfo@lyric.org
+Hours: Monday – Friday, 10:00am to 6:00pm 
+Location: 127 Collingwood St, San Francisco, CA 94114 
+Notes: No referral needed. Drop-ins welcome.
+Things To Know
+Languages Spoken: English, Spanish, French. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No
+Eligible Population: All individuals (Men, Women, Transgender people), up to 24 years old, Pregnant women, Women with children.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Hygiene/Personal Care Items; Health & Wellness Education; Community Education & Mediation; Outreach; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills. Referrals to other resources available as needed.
+Leaders in Community Alternatives, Inc. (LCA)   Electronic Monitoring
+LCA allows participants to serve their time in the community working, supporting family and receiving treatment while still being accountable.  www.lcaservices.com
+To Get Connected
+Contact Person: Intake 
+Phone: (415) 525-5587 or (800) 944-1170 
+Fax: (415) 546-4147 or (800) 925-8049
+Location:  160 Franklin St., Oakland, CA  94607
+Hours: Monday – Friday, 8:30am to 5:30pm
+Referrals: May self-refer, or be referred by Court, supervising authority, or community based program.
+Things To Know
+Languages Spoken: English, Spanish, Tagalog.
+Eligible Population: All individuals involved in the juvenile or criminal justice system, in custody and in community programs or alternative custody programs.
+Faith Based: No. 
+
+Direct Services: Electronic Monitoring; GPS Monitoring and Tracking; Continuous Alcohol Monitoring; Substance Abuse Testing; Parolee Monitoring.
+
+
+Mission Neighborhood Resource Center
+Harm reduction drop-in center in the Mission district, targeting the homeless and those at risk in the neighborhood with a focus on Latino immigrants. Peer-led and professionally-supported staff. Entry point to single-adult shelter system; showers and laundry room; provides bilingual case management, mental health support, groups, community building and organizing; part-time medical clinic, including TB screening, urgent care, primary care, acupuncture, and HIV counseling and testing. Women’s program on Thursday nights (6-8pm) provides dinner, hygiene kits, needle exchange, and social support for women. www.mnhc.org
+To Get Connected
+Contact Persons: Any intake staff
+Phone: (415) 552-1013 
+Fax: (415) 863-1882
+Email: info@mnhc.org 
+Hours: Monday - Friday, 7:00am to 7:00pm; Women only: Thursday, 6:00pm to 8:00pm (biological and transgender females)
+Location: 165 Capp Street (between 16th& 17th), San Francisco, CA 94110
+Notes: No referral needed. Drop-in only.
+Things To Know
+Languages Spoken:  English, Spanish.
+Accessibility: Wheelchair accessible; other accommodations made as needed.
+Client fees, if any: None.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+Direct Services: Access to Benefits (SSI, GA, TANF, etc.); Case Management; Co-occurring Disorder/Dual Diagnosis; Healthcare; Mental Health Treatment; Phone/Voicemail; Showers; Support Groups. Referrals to other resources available as needed.
+
+	
+San Francisco Department of Public Health   With Open Arms a Second Chance Act Program 
+With Open Arms, a San Francisco Initiative for Women, offers case management services for women sentenced to state prison or county jail, including drug treatment, mental health services, trauma recovery, housing, benefits enrollment, child reunificaiton, child behavioral health assistance, job training and immediate placement, legal assistance, continuing education opportunities, social support, and family strengthening and empowerment. The program represents a collaborative effort by Healthright360, Homeless Prenatal Program, Lawyers’ Committee for Civil Rights, SF Clean City, San Francisco Adult Probation Department, and San Francisco Parole. 
+To Get Connected
+Contact Persons: Program Director
+Phone: (415) 449-0501 
+Hours: Monday-Friday, 8:00am to 4:30pm
+Location: 1735 Mission Street, San Francisco, CA 94103
+Notes: May self refer, or be referred by parole, probation, or community based organization.
+Things To Know
+Languages Spoken: English 
+What to Bring: TB Clearance. Program will assist entering clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: You may be eligible if you are a woman in SF County Jail who has been sentenced to State Prison or to serve a local prison sentence under PC § 1170(h)5(a) or (b); you are currently incarcerated in a state prison and will be released to San Francisco on parole or post-release community supervision (PRCS); you are currently on parole or PRCS in San Francisco. Transgender women welcome.
+Faith Based: No.
+
+
+Direct Services: (only for program participants) Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Phone/Voicemail; Shower Facilities; Storage Facilities; Transit Tokens; Health & Wellness Education; Case Management; Anger Management; Mentorship; Outreach; Post-Incarceration Support; Vocational Education; Assessment & Application for Food Stamps, General Assistance, and SSI; Employment Training; Employment Placement; Job Readiness/Life Skills; Money Management/Personal Financial Education; Representative Payee Services; Inmate & Parolee Legal Issues; Voting Outreach & Education; Family Reunification; Parenting Support/Education. Referrals to other resources available as needed.
+
+San Francisco Pretrial Diversion, Inc.   Court Accountable Homeless Services (CAHS)
+To continually strive to provide the highest quality of pre- and post-release court alternatives.  Providing Court-referred clients with immediate access to services while maintaining a strong awareness of community safety and restorative justice. www.sfpretrial.com 
+To Get Connected
+Phone: (415) 626-4995 
+Fax: (415) 626-3871
+Hours: Monday-Friday, 8:30am-5:00pm
+Location: 115 10th St., San Francisco, CA 94103
+Notes: Superior Court referral needed. Once referred, clients may drop in.
+Things To Know
+Languages Spoken: English, Spanish, and Chinese. Additional languages served by interpreter.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated. 
+Client fees, if any: None.
+Eligible Population: Individuals, 18 and older, referred by Superior Court
+Faith Based: No.
+
+Direct Services: Clients with severe mental health issues are provided with close monitoring of mental health treatment and medication compliance; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Post-Incarceration Support. Referrals to other resources available as needed.
+
+
+San Francisco Sheriff’s Department   Community Programs  
+The San Francisco Sheriff’s Department established the Community Programs to provide educational, vocational, substance abuse treatment, and batterers’ intervention classes, as well as a variety of specialized services designed to help ex-offenders successfully reenter the community. The goal is to achieve successful community reintegration on all levels. We nurture ongoing collaborations with a wide range of community-based agencies to help address the needs of the clients. Further, clients are provided the opportunity to participate in the Five Keys Charter School. www.sfsheriff.com
+To Get Connected	
+Phone: (415) 575-6450 
+Fax: (415) 575-6451
+Intake Hours: Monday – Friday, 8:00am to 1:30pm
+Program Hours: Monday-Friday, 8:00am to 4:00pm
+Location: 70 Oak Grove Street, San Francisco, CA 94107 
+Notes: No referrals required; Drop-ins only Monday-Friday 8:00am-4:00pm otherwise by appointment.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible, first floor only. Limited service to vision-impaired.
+Client fees, if any: None.  Fees are only charged for SWAP or Electronic Monitoring
+Eligible Population: All individuals, ages 18 and older.
+Faith Based: No.
+ 
+Direct Services: Anger Management; Counseling; Employment Placement; GED Preparation; AA/NA; Life Skills; Literacy/Basic Education; Mentoring; Transit Vouchers. Referrals to other resources available as needed. Community Works provides job development and Manalive, a 52-week, DV certified batterers intervention program. 
+
+San Francisco Sheriff’s Department   No Violence Alliance (NoVA)
+The primary goal of the NoVA Project is to address the violence plaguing San Francisco and in particular, the significantly high crime communities of Bayview Hunters Point, Western Addition, and the Mission Districts, by providing intensive services to formerly incarcerated individuals with a history of violence to aid in their reentry into the community and reduce recidivism. The NoVA Project approach engages men and women, and encourages them to take control of their violent behavior through rehabilitation, and to the extent possible, successfully reenter the community as a productive member of society. The comprehensive approach stresses offender accountability and violence prevention education. www.sfsheriff.com
+To Get Connected
+Contact Person:  Sgt. Dunn
+Phone:  (415) 575-6450 
+Fax: (415) 558-2490
+Email: Nova.SFSD@sfgov.org	
+Hours: Monday – Friday, 8:00am to 4:00pm
+Location: No drop-ins
+Notes: Referrals are required. No first-time drop-ins.
+Things To Know
+Languages Spoken: English.
+Client fees, if any: None.
+Eligible Population: Men and Women who have been convicted of a violent crime(s). Must be soon to be/recently released from County Jail.
+Faith Based: No.
+
+Direct Service: Case Management; Anger Management; Employment Training; Employment Placement; Transitional Housing; Mentoring.
+
+San Francisco Sheriff’s Department   Women's Resource Center
+A collaboration between the San Francisco Sheriff's Department, Community Works West, and Five Keys Charter School.  This is a multi-service drop-in center for women and LGBTQ.  WRC provides substance abuse counseling, anger management, Healthy Relationship claases, Seeking Sfatey, AA/NA, artisic craft therapy, as well as intensive case management. www.sfsheriff.com 
+To Get Connected
+WRC Main Phone: (415) 734-3150 
+Location: 930 Bryant Street, San Francisco, CA 94102
+Hours: Monday-Friday, 8:30am to 4:30pm (open later on some days for some programs)
+Note: No referrals needed. Drop-ins are welcome.  If you have questions contact Aida McCray at 415-734-3150
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+Client fees, if any:  None.
+Eligible Population: Women and LGTBQ ages 18 and older are eligible.
+Faith Based: No.
+
+Direct Services: Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Phone (no voicemail); Substance Abuse Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Outreach; Post-Incarceration Support; Trauma Recovery Services; GED & High School Education; Vocational Education; Job Readiness/Life Skills; Parenting Support/Education; Rising Voices is a paid writing and performance internship for 18-25 year-old women. Referrals to other resources available as needed.
+Saved by Grace 
+Saved by Grace is a faith-based structured program dealing with all of life’s issues. Our focus is to rebuild self-esteem and help individuals readjust into society as productive citizens. We take a faith based approach toward recovery and education. We mirror our beliefs in our actions. We teach faith but it is not a requirement for entrance. We focus on teaching a positive outlook toward rebuilding families torn by crime, drugs, and abuse to others as well as self. Our mission is to educate, rehabilitate, graduate, and restore the youth and adults back into the life they were meant to live. www.sbgm.vpweb.com
+To Get Connected
+Contact Person: Pastor Ronnie Muniz
+Phone: (415) 955-7713 
+Email: pastor.muniz@aol.com
+Location: Call for information.
+Notes: No referrals required.
+
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.
+Eligible Population: Formerly incarcerated people. 
+Faith Based: Yes.
+Direct Services: Clean and Sober Living; Life skills; Anger Management; Relapse Prevention; Parenting Skills; Assistance Getting Driver’s License or Other ID; Restorative Justice Services. 
+
+
+
+
+
+
+
+
+
+Senior Ex-Offender Program
+Senior Ex-Offender Program (SEOP) gives direct and referral services to older adult offenders and formerly incarcerated individuals ages 50 and over.  SEOP is the first program in the nation to specifically work with older offenders who are transition back to the community.   A program of the Bay View Hunter’s Point Multipurpose Senior Services, the Senior Ex-Offender program provides counseling, information, and referrals for ex-offenders who are seniors. www.seopsf.org
+To Get Connected
+Contact Person: Frank Williams
+Phone: (415) 822-1444 (Office)
+Phone: (415) 826-4774 (Administration) 
+Fax: (415) 822-5327
+Email: info@seopsf.org
+Hours: Monday and Friday, 9:00am to 4:30pm
+Location: 1706 Yosemite Avenue, San Francisco, CA 94124
+Notes: No referrals required; Drop-ins welcome.
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: All formerly incarcerated people who are older adults. Men ages 50 and older and Women ages 45 and older. Housing is not provided for sex offenders.
+Faith Based: No.
+
+Direct Services: Case Management; Transitional Housing; Counseling; Clothing; Personal Care/Hygiene Items; Substance Abuse Counseling; Food/Meals; Counseling; Food/Meals; Phone/Voicemail. Referrals to other resources available as needed. 
+
+
+
+SF Bay Counseling and Education    
+Behavior is learned, re-enforced and sanctioned. Change is possible, understanding is credible, so hope can be conceivable. Our mission is to help those who come through our doors to help themselves, change recover and restore and return to their homes families and community with the tools, resources to thrive and sustain wellness in a positive non violent capacity.
+To Get Connected
+Contact Person: Tim Karo, Program Director
+Phone: (415) 759-9500 
+Fax: (415) 871-2211
+Specific Intake Days and Times: Tues, Thurs, Fri and Sat	
+Hours: Tuesday – Saturday, by appointment only. Intake Tuesday, Thurdsay, Friday and Saturday.
+Location: 1700 Irving Street, San Francisco, CA 94122
+Notes: Referrals sometimes required. No drop-ins. Please call for more information and appointments. 
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: State-Issued ID. Program may be able to assist clients in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Based on documented income, GA, SSI, SSDI, employment. Fees range from $10 - $60 per session based on proof of income.
+Eligible Population: Men, Women, Transgender people, ages 18-65.
+Faith Based: No.
+
+Direct Services: Emergency Shelter - linkage to shelter system, access points; Rental Move-in Assistance - season of sharing and catholic charities rental assistance; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Anger Management; Group Counseling/Therapy; Outreach; Batterers Counseling (Domestic Violence) certified; certified Parenting Program DHS approved provider; Representative Payee Services; Housing & Eviction Defense - referrals to community partners; Restraining/Stay Away Orders - referrals to community partners; Parenting Support/Education – DHS-approved Parent Education Program. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+San Francisco Department of Public Health   Mobile Crisis Treatment Team
+To provide acute mobile psychiatric crisis evaluation and intervention for adults in San Francisco, regardless of insurance.  We are strongly committed to delivering family focused and consumer driven care, and developing a safety network within San Francisco County. 
+To Get Connected
+Phone: (415) 970-4000 
+Hours: Monday - Friday, 8:30am to 11:00pm.  Saturday 12:00pm-8:00pm
+Notes: No referral needed. Please call for assistance.
+Things To Know
+Languages Spoken: English, Spanish, Chinese, Taglog, Vietnamese. Other languages can  be accommodated.
+What to Bring: Clients must exhibit psychiatric emergencies. 
+Client fees, if any: Sliding scale. Accept MediCal, private insurance
+Eligible Population: All individuals over the age of 18 who have psychiatric or mental health emergencies.
+Faith Based: No.
+
+Direct Services: Psychiatric Inpatient Hospital bed; Mental Health Treatment. Referrals to other resources available as needed.
+
+
+St. Anthony Foundation   Free Clothing Program
+We are happy to announce that the Free Clothing Program will be moving to our new building located at 121 Golden Gate Ave. As of February 3rd, 2015, we will be on the 2nd floor above the new Dining Room and next to the new Social Work Center. It is our hope that centralizing our services will greatly improve our guests’ experience here at St. Anthony’s thus enabling us to fully serve each and every man, woman and child who comes through our doors with immediate, accessible and responsive wrap-around services. 
+St. Anthony Foundation’s Free Clothing Program is San Francisco’s largest free clothing program, providing warm clothes, interview or employment apparel, and children’s clothing to homeless and low-income families and individuals.   www.stanthonysf.org/FreeClothingProgram
+
+To Get Connected
+Phone: (415) 241-2600 
+Location: 121 Golden Gate Avenue 
+Hours:  Please call for updated hours.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility: Wheelchair accessible
+Client fees, if any: None
+Eligible Population: All individuals needing clothes
+Faith Based: Yes.
+
+Direct Services:  The free clothing program offers clothing to men, women, and children.
+
+
+
+
+St. Anthony Foundation   Social Work Center
+The Social Work Center provides comprehensive services for families and individuals under 60 who are dealing with issues related to homelessness and poverty. The primary goal of the Center is to provide services that support, stabilize, and improve the quality of life for homeless, low income, undocumented, and working poor individuals and families. www.stanthonysf.org
+To Get Connected
+Contact Person: David Monterde, Intake Coordinator
+Phone: (415) 592-2855	
+Fax:  (415) 766-6081
+Email: dmonterde@stanthonysf.org
+Hours: Monday, Tuesday, Thursday, Friday, 8:30am to 12:00pm, 1:00pm to 4:00pm; Wednesday, 8:30am to 12:00pm; closed the 2nd Thursday of each month at 2:30pm
+Location: 121 Golden Gate Avenue, 2nd Floor, San Francisco, CA 94102
+Notes: No referral needed. By appointment.  Call or walk-in to schedule.  Limited drop-in spaces available on Tuesdays and Thursdays at 8:30am and Fridays at 1:00pm.
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: All individuals 18 and older and families with the city and county of San Francisco.
+Faith Based: Yes.
+
+Direct Services: Substance Abuse Intake (Father Alfred Center, Monday-Thursday, 8:30am-10am); Case Management; Counseling; Crisis Intervention; Advocacy; ID Assistance (limited monthly DMV vouchers, Birth Certificates, SF City ID Program); Housing/Rental Assistance; Supplemental Food program; Clothing Vouchers.  Information about eligibility for benefits (SSI, CalWorks, CalFresh,CAAP).  Referrals to other resources available as needed.
+St. Anthony Foundation   Tenderloin Tech Lab
+The Tenderloin Tech Lab (TTL) is the Tenderloin’s only free technology center specializing in bridging the digital divide and looking for technology solutions for issues of poverty.  The TTL we offer free intensive computer classes, one-on-one tutoring, job search counseling and life skills courses, all designed specifically for the learning style of adults struggling with poverty, addiction, mental health challenges or homelessness.  In addition to the work in our physical space, we also work with developers to create mobile technology solutions for challenges this population is facing. www.stanthonysf.org/TechLab
+To Get Connected
+Contact Person: Program Assistant
+Phone: (415) 592-2766	
+Fax:  (415) 440-7773
+Email: gbickel@stanthonysf.org
+Hours: Monday-Friday 8:30am-11:45am, 1:30pm-4:15pm; closed Wednesday afternoon; Saturday 10am-3pm
+Location: 150 Golden Gate Avenue, 3rd Floor, San Francisco, CA 94102
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.  Call for info.
+Client fees, if any: None.
+Eligible Population: Open to the public.
+Faith Based: Yes.
+Notes: 30 minute orientation required for all first time guests and guest who have not visited in past 12 months.  Call for info.
+
+Direct Services:  Access to Internet; Computer Classes; Computer Training.
+St. Vincent de Paul   Wellness Center
+St. Vincent De Paul Society’s Wellness Center is dedicated to responding to the call of our community, embracing a holistic healing approach to the needs our participants carry daily.  Inspired by our core values of compassion, social justice and spirituality, we are committed to bringing wellness, recovery and clinical best practices to all who come through our doors. Using a harm reduction model, the Wellness Center strives to meet people where they are by focusing on lending continued support to those who are struggling with substance abuse issues and other debilitating diagnoses. Our daily program consists of stress reduction techniques, exercise, selections of personal and spiritual development as well as health topic sessions. Good nutritional guidelines play a pivotal role at the Wellness Center. We offer healthy free snacks and lunch based on a thoughtfully designed menu of fresh local foods with high/dense nutritional value. All are welcome and encouraged to participate on the level that best fits their needs.  svdp-sf.org/what-we-do/wellness-center/
+
+To Get Connected
+Contact Person: Tyler Butterfield, Program Manager
+Phone: (415) 552-5561	ext.403
+Hours: Business Hours:  8:30am-4:30pm; Class Hours:  9am-4pm.  
+Location: 1175 Howard Street, San Francisco, CA  94103
+Notes:  All sessions are free.  Drop-ins welcome.  Lunch is provided for those participating in morning sessions.  For class schedule visit:  svdp-sf.org/what-we-do/wellness-center/.
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible.  
+Client fees, if any: None.
+Eligible Population: All individuals 18 years of age and older.  Open to the public.
+Faith Based: Yes.
+
+Direct Services:  Classes on Stress Reduction; Personal Development; Healthy Eating and Fitness; Substance Abuse Support Groups; Men’s and Women’s Support Groups; Holistic Healing appointments; Case Management.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Swords to Plowshares   Health and Social Services
+The vision of Swords to Plowshares is that all veterans will have access to the care and services they need and deserve to rebuild their lives. War causes wounds and suffering that last beyond the battlefield. Swords to Plowshares’ mission is to heal the wounds, to restore dignity, hope and self-sufficiency to all veterans in need, and to significantly reduce homelessness and poverty among veterans. Founded in 1974, Swords to Plowshares is a community-based not-for-profit organization that provides counseling and case management, employment and training, housing, and legal assistance to veterans in the San Francisco Bay Area. We promote and protect the rights of veterans through advocacy, public education and partnerships with local, state and national entities.  www.swords-to-plowshares.org
+To Get Connected
+Contact Person: James Robinson, Intake/ Eligibility Specialist
+Phone: (415) 252-4788 
+Fax: (415) 252-4790
+Email: jrobinson@stp-sf.org 
+Hours: Monday-Friday, 9:00am to 12:00pm and 1:00pm to 5:00pm
+Location: 1060 Howard Street, San Francisco, CA 94103
+Transitional and Permanent Housing programs at other sites and not available for drop-in.
+Employment services at 401 Van Ness, Suite 302 
+Notes: No referral required. Drop-ins are welcome. (Transitional and permanent housing are off-site, and not available for drop-ins.)
+Things To Know
+Languages Spoken: English, Spanish, Tagalog, Mandarin.
+What to Bring: State-Issued ID, military discharge form DD-214. Program will assist entering clients in getting these, and will see clients before the documentation is complete.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No client fees.
+Eligible Population: All individuals, 18 and older, who are veterans of the U.S. Military. Discharge status irrelevant.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Hotel Vouchers; Permanent Housing; Rental Move-in Assistance; Transitional Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Mail Service; Phone/Voicemail; Transit Vouchers; Move in/out assistance; Mental Health Treatment; Substance Abuse Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Medical Care; Anger Management; Community Education & Mediation; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship; Outreach; Post-Incarceration Support; Trauma Recovery Services; Vocational Education; Assessment & Application for Food Stamps, General Assistance, SSI; Credit Repair; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Representative Payee Services; Housing & Eviction Defense; VA benefits assistance; Family Reunification; Parenting Support/Education; Visits of Family Members in Jails & Prisons. Referrals to other resources available as needed.
+Tenderloin Neighborhood Development Corporation   Social Work Unit
+Tenderloin Neighborhood Development Corporation’s (TNDC) mission is to provide safe, affordable housing with support services for low-income people in the Tenderloin community and to be a leader in making the neighborhood a better place to live. The Social Work Unit provides services with a Harm Reduction approach and operates under the philosophy of "meeting clients where they are at." Tenants are not required to participate in support services and all tenant participation is 100% voluntary. www.tndc.org 
+To Get Connected
+Phone: (415) 358-3938 
+Hours: Monday - Friday; 8:30am-5pm
+Office Location: 215 Taylor Street, San Francisco, CA 94102. 
+Notes: No referral needed. Drop-ins welcome. Individuals must be housed at TNDC to receive services from the Social Work Unit.
+Things To Know
+Languages Spoken: English. Some Spanish, Tagalog, Cantonese, Mandarin, German, Vietnamese.
+What to Bring: State-Issued ID, Social Security Card.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fees. Rent is based on regulatory requirements of each site.
+Eligible Population: All currently homeless individuals with multiple diagnoses, referred by Human Services Agency. May not have a criminal conviciton for a violent offense within five years. May not have a criminal conviction for a sex offense (lifetime), and may not be a registered sex offender. No drug-related convictions within three years.
+Faith Based: No.
+
+Direct Services: Permanent Housing; Assistance Getting Drivers License or Other; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Tenants have access to Social Worker office phones during business hours; Shower Facilities; Transit Vouchers; Health & Wellness Education; Group Counseling/Therapy; Intensive Case Management; Outreach; Money Management/Personal Financial Education; Representative Payee Services; After-school Program. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+Tenderloin Housing Clinic   Representative Payee Program
+Tenderloin Housing Clinic’s Representative Payee program provides representative payee and money management services to low-income individuals residing in San Francisco and receiving benefits from the Social Security Administration (this includes SSA, SSDI, and SSI).  Clients must be permanently housed or must be willing to seek permanent housing at the time of program entry.  The program assists clients with their housing search.  The program helps clients receiving Social Security benefits budget their income amount in a way that allows them to pay their essential bills and meet essential needs, first and foremost.  This includes rent, food, and utility bills.  www.thclinic.org
+
+To Get Connected
+Contact Person: Epifanio Ruiz
+Phone: (415) 336-6171  x114  
+Fax: (415) 928-1058
+Email: epifanio@thclinic.org
+Hours: Monday – Friday, 9:30am to 4:00pm
+Location: 447 Turk Street, San Francisco, CA  94102
+Notes: Clients may drop-in to inquire about services, but will need an appointment for an intake.  Clients can be placed on the waitlist through a referral from a community agency or a client self-referal.  Individuals who are mandated by Social Security to have a payee and those in Housing First buildings, are priortized on the waitlist. 
+Things To Know
+Languages Spoken: English, Spanish, Cantonese, Mandarin, Assamese. 
+Accessibility: The Representative Payee office has a small step at the front door.  There is an office across the street from the payee office that is wheelchair accessible and services can be rendered there for mobility impaired clients. 
+Client fees, if any: No fees.
+Eligible Population: Clients must reside in San Francisco and must receive Social Security benefits in order to be eligible for the program.  Housing is not a requirement at program entry but clients must be willing to and obtain housijng after enrollment in the program.
+Faith Based: No.
+
+Direct Services:	 SRO Housing Placement Assistance; Assistance Getting Driver’s License and Other ID; Representative Payee Services; Money Management/Personal Financial Education; Assistance and Advocacy Maintaining Social Security Benefits.
+
+This Sacred Space
+This Sacred Space is an organization whose objective is to share with those who are currently or formerly incarcerated the message that spiritual freedom is available now. Using dialogue, contemplation and meditation, our program points to this sacred space where the mind and heart experiences the peace that is eternally present.   www.thissacredspace.org
+To Get Connected
+Contact Person: Kenneth Dale Johnson 
+Phone: (415) 706-3782	
+Fax: (707) 933-8846
+Email: kenny@thissacredspace.org
+Hours: Monday – Friday, 9:00am to 5:00pm
+Mailing Address Only: Box 3, Fairfax, CA 94930
+Notes: No referral needed. Contact to set up an appointment. 
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: No fees.
+Eligible Population: All individuals currently in prison or jail or recently released. Must be clean and sober.
+Faith Based: Yes.
+
+Direct Services:	 Counseling and Mentoring. Referrals to other resources available as needed.
+
+
+Veterans Justice Outreach 
+Veterans Justice Outreach (VJO) is a VA outreach program designed to collaborate with local justice system partners to help veterans who enter the criminal justice system and are in need of treatment services and/or alternatives to incarceration.
+To Get Connected
+Contact Person:  Kyong Yi, LCSW or 
+Phone: (415) 281-5159 or 
+Email: kyong.yi@va.gov or
+
+Contact Person:  Ken Miller, LCSW
+Phone:  (415) 281-5163
+Email:  Kenneth.miller3@va.gov
+
+Hours: Monday – Friday, 8:00am to 4:30pm
+Address: San Francisco VA Med Center 
+Downtown Clinic 401 3rd Street, San Francisco, CA 94107 
+Notes: No referral needed. Contact to set up an appointment. 
+Things To Know
+Languages Spoken: English. 
+Accessibility: Wheelchair accessible.
+Client fees: No fees.
+Eligible Population: Vets who served before 1980; Vets who served after 1980 for at least 2 years and received an honorable discharge. Other Vets may still get help with housing and service referrals. 
+Faith Based: No.
+
+Direct Services:	 Social Work Services:  Assistance Accessing VA Benefits; Housing; Referrals; Employment Services; Residential Treatment Referrals.  Health Care Services: Medical; Dental; Pharmacy; Inpatient Hospital Services.  Mental Health Services: Sexual Trauma Counseling; Veteran Center Counseling Referrals; Substance Abuse Treatment; PTSD & TBI Treatment.  Other Services: Showers & Laundry; Free Telephone Access (local); Mail Box Service.
+
+
+Village Connect   Culture Based Transformative Coaching (CBTC) 
+Village Connect’s CBTC’s mission is to build capacity of people to become more self-aware and self-directed resulting in sustainable positive transformation.  Our philosphy of change is steeped in a culturally competent approach that is client-centered and sensitive to the gender-specific and inter-generational dynamics critical to the individual and group.    CBTC is a strength-based coaching model that maximizes personal, professional, and academic potential.  Coaches/Facilitators trained in the CBTC model support clients to meet life’s opportunities and challenges by providing insights and guidance from an inside/out perspective rather than outside/in.  Utilizing a culturally proficient curriculum and community-based interdisciplinary approach, Village Connect effectively transforms the individual, family, and community.  www.village-connect.org/
+To Get Connected
+Contact Person: Gaylon Logan
+Phone: (510) 564-4240 
+Email:  gl@village-connect.org
+Hours: Varies
+Location: San Francisco/Oakland/Berkeley 
+Notes: CBTC is offered to individuals, groups and families.  Please call for information.   
+Things To Know
+Languages Spoken: English.
+What to Bring: Desire to grow 
+Accessibility: Wheelchair accessible
+Client fees, if any: None
+Eligible Population: Men, women, youth ages 12 and older
+Faith Based: No.
+
+Direct Services: Life Skills; Self-Empowerment; Personal Development.
+
+Village Connect   Human Sustainability Groups (HSG)  
+Aligned with our mission to build the capacity of people to become more self-aware and self-directed resulting in sustainable positive transformation, HSG is a peer support network and mentoring model of men, women, and youth coming together for the purposes of healing and self-development through interactive processes, networking, and education.  Subsequently providing leadership and excellence that ignites and transforms community.  www.village-connect.org/
+To Get Connected
+Contact Person:  Gaylon Logan
+Phone: (510) 564-4240 
+Email:  gl@village-connect.org
+Hours: Varies
+Location: San Francisco/Oakland/Berkeley 
+Notes: There are 3 variations of HSG: (1) Ongoing drop-in groups, (2) closed cohort based groups, which operates on 6-month cycles, and (3) closed cohort based groups, which requires a 12-month commitment.  Please call for information. 
+Things To Know
+Languages Spoken: English.
+What to Bring: Desire to grow. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: Men, women, youth 12 yrs. and older
+Faith Based: No.
+
+Direct Services: Life Skills; Self-Empowerment; Personal Development.
+
+
+A Better Way  
+A Better Way (ABW) provides counseling to children and their families.  The agency is a private, non-profit organization.  We mainly service children who are in foster care or at risk of being paced in out of home care.  We have three mental health programs: Therapeutic Visitation Services for families recently separated and in the process of reunification; Outpatient Mental Health Services for children needing individual therapy or families needing family therapy; and Early Childhood Mental Health Services for infants and young children to address their emotional and behavioral development.  Children seen through our program need to be Full-Scope Medi-Cal eligible. www.abetterwayinc.net 
+To Get Connected
+Contact Person: Ann Chu, Program Director
+Phone: (415) 715-1050 
+Fax: (415) 715-1051
+Email: achu@abetterwayinc.net 
+Hours: Monday – Friday, 8:00am to 6:00pm. 
+Location: 1663 Mission Street, San Francisco, CA  94611
+Notes: All clients are referred from Human Service Agency and authorized for services through Foster Care Mental Health. We also provide mental health outpatient services for children ages 0-5 who are at risk of emotional and behavioral development difficulties.  These children need to be Full Scope Medi-Cal eligible.
+
+Berkeley Office:
+Things To Know
+Languages Spoken: English, Spanish, Mandarin. 
+What to Bring: Medi-Cal or approval from Foster Care Mental Health
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Client fees are paid by Medi-Cal or per HSA work order.
+Eligible Population: Children are the primary clients; family or adult involvement is through a child.
+Restrictions: None.
+Faith Based: No.
+Phone:  510-601-0203  
+Fax:  510-601-4002
+Hours:  Monday-Friday, 8:00am-7:00pm.
+Location:  3200 Adeline Street, Berkeley, CA  94703
+
+Direct Services:  Access to Internet; Clothing; Food/Prepared Meals (snacks and juice for clients); Phone/Voicemail; Mental Health Treatment; Intensive Case Management; Individual Counseling/Therapy; Visitation; Couples/Family Counseling; Family Reunification; Parenting Support/EducationServices for Children. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+Children’S Council of San Francisco
+Children’s Council connects families to child care that meets their needs and works with parents, providers, and community partners to make quality child care and early education a reality for all children in our city.   www.childrenscouncil.org/
+
+To Get Connected
+Contact Person: Any Resource and Referral Counselor
+Phone: (415) 343-3300
+Email: rr@childrenscouncil.org
+Hours:  Monday-Thursday, 8:30am to 4:00pm; Friday, 8:30am to 12:00pm
+Location: 445 Church Street, San Francisco, CA  94114
+Notes:  No referral needed.  Drop-ins welcome.
+Things To Know
+Languages Spoken:  English, Spanish, Cantonese, Mandarin, Russian, Vietnamese.
+What to Bring: Nothing required; helpful documents are anything showing household income or employment.
+Accessibility:  Wheelchair accessible.
+Eligible Population: Any parent who needs child care for one of these reasons:  working, looking for work, attending vocational training.
+Faith Based: No.
+
+Direct Services: Resources for parents and families.  Referrals to other resources available as needed. 
+Community Works West, Inc.   One Family/Parenting Inside Out
+One Family is an initiative led by Community Works in collaboration with the San Francisco Children of Incarcerated Parents Partnership (SFCIPP) and the San Francisco Sheriff ’s Department. The goal of One Family is to strengthen families impacted by incarceration. 
+url: www.communityworkswest.org/index.php/one-family
+
+To Get Connected
+Contact Person: Sarah Carson, LCSW
+Phone: (415) 407-5130
+Email: scarson@communityworkswest.org
+Location: SFSD’s Women’s Reentry Center (mothers), SFSD’s Community Programs (fathers and mothers), CASC (fathers and mothers)
+Hours/Meeting times: Call for times
+Things To Know
+Eligible Population: Any parent.
+Primary Community Served: Open to all formerly incarcerated parents (custodial and noncustodial) with children under 18
+Faith Based: No
+
+Direct Services: One Family provides Parenting Inside Out, a CPS certified parent education program. One Family also provides Family Transition Circles and Restorative Circles for reunification of families after release from incarceration.
+
+
+Community Works West, Inc.   Project WHAT!
+Project WHAT! is a paid job and leadership development program that works to empower youth ages 13-18 who currently or in the past have had parents incarcerated by raising awareness about the impacts of parental incarceration on children, families, and communities. www.communityworkswest.org/index.php/project-what
+
+To Get Connected
+Contact Persons: Zoe Willmott, Program Manager
+Phone: (510) 486-2340  
+Fax:  510-647-5860
+Email: zwillmott@communityworkswest.org
+Location:  Community Works' Project WHAT!
+4681 Telegraph Avenue, Oakland, CA 94609 
+Note: Application process is required.  No drop-ins, appointment required. 
+Things To Know
+Languages Spoken:  English, Spanish.
+Accessibility: Wheelchair accessible. 
+Client fee, if any:  None
+Eligible Population: Youth, ages 13-18, who have had a parent incarcerated (currently or in the past), living within or going to school in San Francisco.
+Faith Based: No.
+
+Direct Services: Paid Internship; Snacks Provided During Meetings; Transit Vouchers; Job Readiness/Life Skills; Personal Financial Education; Services for Children. The program is a job, peer support group, and leadership development all in one. Referrals to other resources available as needed.
+
+
+
+
+
+Compass Family Services   ACCESS Child Care 
+ACCESS  (Accessible Child Care Expediated for the Shelter System) is a child care subsidy that provides quality child care to families in San Francisco with the greatest need. 
+compass-sf.org/programs/family-resource-center
+
+To Get Connected
+Contact:  Compass Family Services
+Phone: (415) 644-0504
+Notes:  ACCESS uses the SF3C list to enroll participants.  It is important that you are on the list and that your contact information is up to date.  To get onto the SF3C:
+Contact a shelter case manager
+Contact Compass at (415) 644-0504
+Apply online at www.sf3c.org or by phone at (415) 343-3300 or (415) 391-4956
+
+Things To Know
+Languages Spoken: English, Spanish, Mandarin, cantonese.  We are all able to request translation services for languages outside of our capacity.
+What to Bring: Please bring verification of shelter stay within the last 6 months, ID’s for all adults, and birth certificates for children.
+Accessibility: Wheelchair accessible.
+Client fees, if any: There are no client fees to receive the subsidy.  Childcare providers have their own set of policies that may include fees and/or other responsibilities asked of the family.
+Eligible Population: Must have one child 0-3 years old and have lived in homeless/ domestic violence shelter within past 6 months.  Please call for more information.
+Faith Based: No.
+
+Direct Services: Full- or part-time child care at designated family child care homes or centers for all children (ages 0-13 years) needing care until the youngest child turns 3 years old.
+
+
+
+
+Holy Family Day Home   Infant, Toddler and Pre-K Program and Family Support Service
+Our mission is to provide affordable, high-quality early childhood education and family support services in a stable, nurturing environment, thereby providing children of working families skills and hope for lifelong development. Seventy percent of our families are either homeless, in CalWorks Program or are the working poor.    www.holyfamilydayhome.org
+To Get Connected
+Infant, Toddler & Preschool 
+Phone: (415) 861-5361
+Fax:  (415) 861-8926 
+Email: intake@holyfamilydayhome.org
+Mailing Address: 299 Dolores Street, San Francisco, CA 94103
+Notes: Call, email or write for more information.
+Things To Know
+Eligible Population: All individuals and family members with an infant, toddler or pre-kindergarten age child. Individuals must reveal criminal conviction for violent or sex offenses, as well as registration as sex offender status. 
+Faith Based: No.
+Direct Services:  Preschool, Infant, and Toddler program.
+
+Homeless Children's Network (HCN)  
+Early Periodic Screening, Diagnosis, and Treatment
+In collaboration with a network of homeless services providers, HCN seeks to decrease the trauma of homelessness and domestic violence, to increase the strength and effectiveness of the HCN Collaborative, and to provide early childhood education and consultation to shelter-based child care and family child care providers. HCN provides flexible, well-coordinated and culturally competent services to homeless and formerly homeless children and their families. Funding and services provided through Early Periodic Screening, Diagnosis and Treatment Program (EPSDTP). www.hcnkids.org 
+To Get Connected
+Contact Persons: Kathy O'Shea, Program Director
+Phone: (415) 437-3990 
+Fax: (415) 437-3994
+Email: kathy@hcnkids.org 
+Hours: Monday - Friday 9:00am to 6:00pm
+Location: 3450 3rd Street, Unit 1C, San Francisco, CA 94124
+Notes: No referral needed. Please call or write for an appointment. No drop-ins.
+Things To Know
+Languages Spoken: English, Spanish, ASL and Japanese. 
+What to Bring: Medi-Cal ID card.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: Serves homeless individuals from birth to age 17 with mental health diagnosis that meets medical necessity, such as Adjustment Disorder, Depression, or PTSD. May not have criminal conviction for sex offense or be a registered sex offender. Current abuse cases are referred to CPS.
+Faith Based: No.
+
+
+Direct Services: Up to Two Years of Mental Health Treatment; Co-occurring Disorder/Dual Diagnosis Treatment; Group Counseling/Therapy; Individual Counseling/Therapy; Outreach; Trauma Recovery Services; Victim/Survivor Services; Couples/Family Counseling; Parenting Support/Education; Services for Children; Facilitation of Visits in Jails and Prisons. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+San Francisco Department of Child Support Services   
+Compromise of Arrears Program (COAP) 
+The Department's mission is to empower parents to provide for the economic and medical support needs of their children. COAP is a program for eligible noncustodial parents to reduce past-due child support (arrears) debt owed to the State.  This debt is owed because the State supported the family while the dependent children were on public assistance (welfare) or in foster care.  If you qualify for COAP you may offer to pay an amount that is less than the full amount you owe.  Any reduction in your arrears and interest owed will be based on your income and assets.  Arrears may be paid in a lump sum or in monthly installments over 36 months, depending on the individual circumstances.  www.sfgov.org/dcss or www.facebook.com/sfdcss
+To Get Connected
+Contact Person: Mary Mora, Child Support Officer/COAP Coordinator 
+Phone: (415) 356-2871 
+Fax: (415) 356-2773  Email: mary.mora@sfgov.org
+Hours: Monday – Friday, 8:00am to 5:00pm
+Location: 617 Mission Street, San Francisco, CA 94105
+Notes: No referral needed. Drop-ins are welcome.
+Things To Know
+Languages Spoken: English, Spanish, Cantonese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals with an open child support case with child support arrears owed to the State.
+Faith Based: No.
+
+Direct Services:   Intensive Case Management; Family Law; Establishment of Paternity; Child Support Orders; Health Insurance Orders. 
+
+San Francisco Department of Child Support Services   
+Customer Service Outreach (Community & Jail Outreach Program)
+The Department's mission is to empower parents to provide for the economic needs of their children. The Community and Jail Outrech  Program holds workshops with various groups in the community, including treatment facilities, to educate and assist noncustodial parents with their child support cases, obligations and issues. The Jail Outreach Program assists incarcerated non-custodial parents with outstanding child support issues that arise as a result of their incarceration.  www.sfgov.org/dcss or www.facebook.com/sfdcss
+To Get Connected
+Contact Person: George J. Smith, III Public Relations Assistant
+Phone: (415) 356-2950  
+FAX:  (415) 356-2773 
+Email: GeorgeJ.Smith@sfgov.org
+Hours: Monday – Friday, 8:00am to 5:00pm
+Locations: 617 Mission Street, San Francisco, CA 94105; 3120 Mission Street, San Francisco, CA 94110 
+Notes: No referral needed. Drop-ins are welcome.
+Things To Know
+Languages Spoken: English, Spanish, Cantonese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals with an open child support case. Any parent of a minor child can open a case.
+Faith Based: No.
+
+Direct Services: Intensive Case Management; Outreach; Child Support Orders, Health Insurance Orders; Post-Incarceration Support; Family law.
+
+
+San Francisco Department of Child Support Services   
+Noncustodial Parent Employment & Training Program (C-NET)
+The C-NET program was developed to assist custodial and noncustodial parents with resolving barriers to employment, parenting, and their child support obligations. www.sfgov.org/dcss or www.facebook.com/sfdcss
+To Get Connected
+Contact Person: Tyrone Owens, Child Support Officer, C-NET Coordinator 
+Phone: (415) 356-2945 
+Fax: (415) 356-2774 
+Email: tyrone.owens@sfgov.org
+Hours: Monday - Friday, 7:00am to 4:00pm
+Locations: 617 Mission Street, San Francisco, CA 94105; 3120 Mission Street, San Francisco, CA 94110 
+Notes: No referral needed. No appointment necessary. Drop-ins are welcome.
+Things To Know
+Languages Spoken: English, Spanish, Cantonese.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Population: An individual with an open child support case. Any parent of a minor child can open a case.
+Faith Based: No.
+
+Direct Services: Access to Internet; Releases of Driver’s License or other professional licenses, if suspended due to Child Support Enforcement Activities; Outreach; Education Regarding Child Support Obligations and Resources Available for Employment.
+
+San Francisco Department of Public Health   Child Crisis Services
+To provide acute mobile psychiatric crisis evaluation and intervention for children and youth in San Francisco, regardless of insurance, up to age 18.  We are strongly committed to delivering family focused and consumer driven care, and developing a safety network within San Francisco county. 
+To Get Connected
+Phone: (415) 970-3800 
+Hours: Monday - Thursday, 8:30am to 9:00pm; Friday, 8:30am to 7:00pm; After hours, on-call mobile team
+Location: 3801 Third Street, Building B, Suite 400, San Francisco, CA 94124 
+Notes: No referral needed. Please call first.  
+Things To Know
+Languages Spoken: English, Spanish, Chinese, Taglog, Vietnamese. Other languages can  be accommodated.
+What to Bring: Clients must exhibit psychiatric emergencies. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: Sliding scale. Accept MediCal, private insurance, Healthy Families, Healthy Kids.
+Eligible Population: All individuals up to age 18 who have psychiatric or mental health emergencies.
+Faith Based: No.
+
+Direct Services: Psychiatric Inpatient Hospital Bed; Mental Health Treatment; Crisis Case Management Referrals to other resources available as needed.
+
+
+
+
+
+
+
+Westside Community Services   Services for Children and Youth
+Westside Community Services has been providing an array of community-based prevention, mental health, substance abuse, and social services to clients in the City and County of San Francisco for 40 years. Incorporated in 1967, Westside is one of the oldest community-based mental health agencies in the nation. The range of programs and services has varied over the years, while a commitment to providing excellent, high-quality, culturally and community appropriate programs has remained central to the core of the organization. 
+www.westside-health.org
+
+To Get Connected
+Child Youth & Family Outpatient Services and AJANI program (Afrocentric Family Focused Treatment) 
+1140 Oak Street 
+San Francisco, CA 94117 
+(415) 431-8252 Phone 
+(415) 431-3195 Fax
+AJANI@westside-health.org 
+Notes:  For general info please call (415) 431-9000. 
+Things to Know: 
+Languages Spoken: English, Spanish.
+What to Bring: Please call for information. 
+Accessibility:  Wheelchair accessible.
+Client fees, if any: Sliding scale. Accept MediCal, private insurance, Healthy Families, Healthy Kids.
+Eligible Population: Youth up to 24 years of age who are exhibiting emotional problems and are at risk of developing more serious problems such as mental illness and substance abuse.
+Faith Based: No.
+
+
+Direct Services: Individual/Group/Family Therapy; Clinical Case Management (school and community-based); Medication Support Services; Substance Abuse Prevention, Education, and Intervention; Social Skills Training; Anger Management; Vocational Resource Referrals; Educational and Literacy Support; Independent Living Skills Support; Housing Assistance; School Readiness Assistance. 
+
+
+
+
+
+
+
+
+
+
+
+AIDS Legal Referral Panel (ALRP)  
+ALRP works to improve or maintain the health of people living with HIV/AIDS in the San Francisco Bay Area by addressing their legal issues. It provides free and low-cost legal services in areas including housing, employment, insurance, confidentiality matters, family law, credit, government benefits or public accommodations, among others. www.alrp.org
+To Get Connected
+Phone: (415) 701-1100 
+Fax: (415) 701-1400
+Email: info@alrp.org 
+Specific Intake Days and Times: M-F, 9:00am-5:00pm
+Hours: Monday – Friday from 9:00am-5:00pm.
+Location: 1663 Mission Street, Suite 500
+San Francisco, CA 94103 
+Notes: No referral needed. Please call or write to make an appointment.
+Things To Know
+Languages Spoken: English, Spanish, Russian. Other languages can be accommodated.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: All ALRP services provided by ALRP staff attorneys are free. Depending on the income and the nature of the case, if the client is referred to an ALRP Panel Attorney, a fee may be charged according to ALRP's Fee Protocol.
+Eligible Population Served: All individuals and family members who have HIV/AIDS and live in Alameda, Contra Costa, Marin, San Francisco, San Mateo, Sonoma or Solano Counties.
+Primary Community Served: People living with HIV/AIDS/Lesbian/Gay/Bisexual/Transgender
+Faith Based: No.
+
+Direct Services: ALRP assists clients with HIV/AIDS with legal issues related to their housing, including eviction defense. ALRP also provides assistance with legal issues related to private and public health and disability income insurance.  Referrals to other services provided, as appropriate.
+ 
+Asian Law Caucus
+The mission of the Asian Law Caucus is to promote, advance, and represent the legal and civil rights of Asian and Pacific Islander (API) communities. Recognizing that social, economic, political and racial inequalities continue to exist in the United States, the Asian Law Caucus is committed to the pursuit of equality and justice for all sectors of our society, with a specific focus directed toward addressing the needs of low-income, immigrant and underserved APIs.
+Since the vast majority of Asians and Pacific Islanders in America are immigrants and refugees, the Caucus strives to create informed and educated communities empowered to assert their rights and to participate actively in American society. This perspective is reflected in our broad strategy which integrates the provision of legal services, educational programs, community organizing initiatives and advocacy. www.asianlawcaucus.org
+To Get Connected
+Contact Persons: Phil Van, Intake Coordinator
+Phone: (415) 896-1701 
+Fax: (415) 896-1702
+Email: philipv@asianlawcaucus.org 
+Hours: Monday – Friday from 9:00am-5:00pm. Some evening and weekend clinics.
+Location: 55 Columbus Ave , San Francisco, CA 94111
+Notes: No referral needed. Please call or write for an appointment.
+Things To Know
+Languages Spoken: Cantonese, Mandarin, Tagalog, Vietnamese, Gujarati, Thai. 
+What to bring: Proof of income.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population Served: 
+All individuals and family members.
+Faith Based: No.
+
+
+Direct Services: Community Education & Mediation; Know Your Rights Trainings; Inmate & Parolee Legal Issues, mainly juvenile and deportation cases; employment law and employment discrimination; Housing & Eviction Defense; Restraining/Stay Away Orders; Voting Outreach & Education; Census and Redistricting advocacy. Referrals to other services provided, as appropriate.
+
+Bay Area Legal Aid (BayLegal)
+BayLegal's clients are low- and very low-income members of our communities. BayLegal's clients are spread across our seven county service area, from San Francisco to Livermore, Gilroy to Napa. They include the working poor, our elderly neighbors, military veterans, people with disabilities, and single mothers. www.baylegal.org
+To Get Connected
+Legal Advice Line for Screening: 
+(415) 354-6360 
+Hours: 
+Monday and Thursday, 9:30am-3:00pm
+Tuesday and Wednesday, 9:30am-1:00pm
+Location: No drop-in services provided. Please call Legal Advice Line for screening.
+1035 Market St., San Francisco, CA 94103
+Notes: No referrals needed.
+Things To Know
+Languages Spoken: English, Spanish, Vietnamese, Mandarin, Cantonese, Tagalog, French. BayLegal will serve clients in any other languages through use of Language Line or other assistance. 
+What to Bring: If you receive an appointment after being screened by the Legal Advice Line, identification and documentation of U.S. citizenship or non-citizen status. BayLegal may assist in securing these documents.
+Accessibility: Wheelchair accessible. Will provide whatever ADA accommodation is necessary for any disability.
+Client fees: None.
+Eligible Population: Must be out of custody.
+Faith Based: No.
+
+Direct Services: Housing & Eviction Defense; Access to Public Benefits; Law for Domestic Violence Survivors; For PAES recipients, any civil legal issue that makes it harder to get or keep a job, such as driver's license suspension, child support orders, or credit issues (including referrals to Clean Slate/Conviction Expungement Services). Will not provide assistance with contesting a Temporary Restraining Order for people with prior criminal convictions for violence. For health care access issues such as Medi-Cal, Medi-Care, Covered California or private health insurance, contact our Health Consumer Center at (855) 693-7285. Referrals to other services provided, as appropriate.
+
+Cooperative Restraining Order Clinic
+Cooperative Restraining Order Clinic provides information on and assistance in applying for Domestic Violence restraining orders. 
+To Get Connected
+Contact Person: Tara Berta, Supervising Attorney 
+Phone: (415) 864-1790 
+Fax: (415) 241-9491
+Email: tara@roclinic.org 
+Hours: By Appointment Only. Call Intake Phone, (415) 255-0165.
+Location: 3543 – 18th Street, San Francisco, CA 94110
+Notes: No referrals needed. Please call Intake Phone for appointment.
+Things To Know
+Languages Spoken: English, Spanish, other languages as needed. 
+What to Bring: CA ID and any other relevant documents for the restraining order.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+Direct Services: Legal Assistance/Advocacy. Referrals to other resources available as needed.
+Eviction Defense Collaborative (EDC) and Rental Assistance (RADCo)
+The Eviction Defense Collaborative is the principal organization in San Francisco helping low-income tenants to respond to eviction lawsuits. Each year we provide emergency legal services, through EDC, and rental assistance, through RADCo, to more than 5,000 tenants in San Francisco. www.evictiondefense.org
+To Get Connected
+Phone: 415-947-0797
+Hours: Monday – Friday from 9:30am-11:30am; 1:00pm-3:00pm
+Location: 995 Market, #1200, San Francisco, CA 94103
+Notes: No referrals needed. Drop-In only.
+ Things To Know
+Languages Spoken: English, Spanish, Chinese, French, Russian 
+What to Bring: Proof of San Francisco Residency
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Certain services have sliding-scale fees. Nobody turned away for lack of funds.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+Direct Services: EDC’s legal services include counseling and legal help to tenants during the eviction process: programs include preparing a response to the lawsuit, limited representation at the settlement conference, and preparation of requests for delays of the sheriff’s eviction. RADCo’s provides rental assistance to more than 600 families each year, in the form of interest-free loans and grants. Please note: The Eviction Defense Collaborative does not provide the services of a lawyer – clients act as their own lawyer. Referrals to other services provided, as appropriate.
+
+Golden Gate University School of Law   Women’s Employment Rights Clinic
+The Clinic provides free or low-cost legal services to people with employment-related legal problems, with an emphasis on problems affecting women and low-wage immigrant workers. Law students provide legal services. www.ggu.edu/law/werc
+
+To Get Connected
+Contact Person: Law Student Hotline 
+Phone: (415) 442-6647 
+Fax: (415) 896-2450
+Email: werc@ggu.edu
+Hours: Monday – Friday from 9:00am-5:00pm, January-April and September-November, only.
+Location: 40 Jessie Street, 5th Floor, San Francisco, CA 94105
+Notes: No referrals needed. Please call the hotline for an appointment first. No drop-ins. 
+Things To Know
+Languages Spoken: English. Other languages can be accommodated.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: No fees for legal services. Possible costs for photocopying, etc.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+Direct Services: Legal Assistance/Advocacy. Referrals to other services provided, as appropriate.
+
+Homeless Advocacy Project (HAP)
+The Homeless Advocacy Project (HAP) may be able to help you if you have legal issues and are homeless, or threatened with homelessness, especially if you have a disability or minor children living with you. HAP also provides supportive social services to its legal clients to address underlying psychosocial needs. We primarily assist clients with federal disability and other benefit issues; eviction prevention; and immigration documentation. www.sfbar.org/volunteer/homeless_article.aspx
+
+To Get Connected
+Phone: (415) 575-3130
+Phone: (800) 405-4427   
+Fax: (415) 703-8639
+Hours: HAP is closed on Monday. Tuesday - Friday, 9am to 5pm. Intake for new clients on Tuesday 1:30pm to 4:00pm.
+Location: 1360 Mission Street Suite 201, San Francisco, CA  94102 (between 9th and 10th Streets)
+Notes: No referrals needed. Please drop in during Tuesday intake hours.
+Things To Know
+Languages Spoken:  Spanish, Vietnamese, Mandarin.
+What to Bring:  Any documents related to your case (eviction papers; social security notices)
+Client fees, if any:  None if low-income.
+Eligible Population:  Homeless or at risk of homelessness, with priority to individuals who have mental health disabilities and families.
+Faith Based: No.
+
+Direct Services: HAP is only able to provide assistance with certain types of legal issues. These include: Applications for Supplemental Security Income (SSI – federal disability benefits) and issues related to SSI applications; Eviction defense, especially if you are accused of causing a nuisance or your landlord has obtained a default judgment against you; Immigration documentation, if you are in the country legally but have lost your immigration documents or have not taken the steps needed to get proper immigration documents; Brief advice and referrals to other projects or agencies that can help you.
+
+Housing Rights Committee of San Francisco
+We provide “self-help” tenants’ rights counseling. Clients are provided with information on laws affecting their rights as tenants, as well as resources and referrals. For public housing and Section 8 renters, we offer case management and advocacy. We provide referrals to attorneys as necessary. We will help with applications for Section 8 and Public Housing, as well as rent board petitions. www.hrcsf.org
+To Get Connected
+Contact Person: Counselor
+Phone: (415) 703-8634
+Phone: (415) 703-8644 
+Fax: (415) 703-8639
+Email:  info@hrcsf.org 
+Counseling Hours: Monday – Thursday from 1:00pm-5:00pm
+Location: 417 South Van Ness Avenue, San Francisco, CA 94103
+Notes: No referrals needed. Please call or drop in during counseling hours.
+Things To Know
+Languages Spoken: English, Spanish, Cantoniese and Mandarin. Russian by special arrangement.
+What to Bring: Please bring any relevant papers, including eviction notices or other landlord/property manager notices.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: All renters of public and private housing.
+Faith Based: No.
+
+Direct Services: Counseling/Advocacy—Housing Applications to Public Housing & Section 8. Please note: no direct legal services. Program does not provide housing or rental assistance. Referrals to other services provided, as appropriate.
+
+La Raza Centro Legal
+La Raza Centro Legal is community-based legal organization dedicated to empowering Latino, immigrant and low-income communities of SF to advocate for their civil and human rights. We combine legal services and advocacy to build grassroots power and alliances toward creating a movement for a just society. www.lrcl.org 
+To Get Connected
+Phone: (415) 575-3500 
+Fax: (415) 255-7593
+Intake Hours: Monday –Thursday from 10am-12pm and 1pm-4pm; Fridays from 10am-12pm.
+Location: 474 Valencia Street, Suite 295
+San Francisco, CA  94103 
+Notes: No referrals needed. Please call for appointment. Drop-ins are allowed, but appointments are preferred. 
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: All individuals and family members.
+Faith Based: No.
+
+Direct Services: Employment Law, solely regarding SF-specific labor laws; Immigration and Senior Law (Immigration in San Francisco and San Mateo County, senior law in San Francisco only). Referrals to other services provided, as appropriate.
+
+
+Lawyers' Committee for Civil Rights   Second Chance Legal Clinic 
+The Second Chance Legal Clinic assists clients who are working to overcome barriers to employment and housing because of their criminal records. www.lccr.com  www.lccr.com/programs/racial-justice/direct-services/second-chance-legal-clinic/
+
+To Get Connected
+Contact Person: Clinic Coordinator
+Phone: (415) 814-7610
+Hours: Clinic held last Tuesday of every month at 6 pm. Questions about clinic answered Monday through Friday from 9:00am-5:00pm.
+Location: West Bay Community Center, 1290 Fillmore Street, San Francisco, CA 94115
+Mailing Address: 131 Steuart Street, Suite 400, San Francisco, CA 94105
+Notes: To receive the best legal advice, we encourage walk-in clients to come with a recent RAP sheet. Please contact Lawyers’ Committee to find out how to get a RAP sheet.  Drop-in okay.  No referral required.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: All individuals.
+Faith Based: No.
+
+
+Direct Services: Clean Slate/Conviction Expungement; Employment Law; Housing and Eviction Defense; Voting and Outreach Education; Occupational licensing – applications and denials; Criminal background reports – errors and violations; Public and private housing – applications and denials; Employment – applications, terminations and denials; Assistance with Driver’s License Citations and Suspensions.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Prison Law Office
+The Prison Law Office strives to improve the living conditions of California state prisoners by providing free legal services.  The Prison Law Office represents individual prisoners, engages in class action and other impact litigation, educates the public about prison conditions, and provides technical assistance to attorneys throughout the country.  www.prisonlaw.com
+. www.lrcl.org 
+To Get Connected
+Phone: (415) 280-2621 
+Hours: Monday-Friday
+Location: 1917 5th Street, Berkeley, CA 94710
+Notes:  If you or a family member have an issue that you believe we can assist with, please free to contact our office.  Letters concerning individual prisoners and prison conditions can be addressed to:
+Prison Law Office
+General Delivery
+San Quentin, CA  94964
+Things To Know
+Languages Spoken: English.
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated, please contact.
+Client fees, if any:  None.
+Eligible Population:  California state prisoners, and occasionally to California state parolees.
+Faith Based: No.
+Do to the large number of inquiries, we cannot accept telephone calls from prisoners and their families.
+
+Services: For over 35 years this nonprofit public interest law firm has been in the forefront of legal efforts to enforce the Constitution and other laws inside the walls of California's prisons. With a small staff of attorneys and support personnel, the Prison Law Office represents individual prisoners, engages in class action and other impact litigation, educates the public about prison conditions, and provides technical assistance to attorneys throughout the country. (The office generally does not handle criminal appeals or habeas corpus petitions challenging criminal convictions.) 
+
+California's prisons remain dangerously overcrowded at 147% of design capacity with over 122,000 prisoners crammed into 33 institutions, plus another 12,000 prisoners housed out-of-state and in community facilities. Basic necessities of life, such as medical and mental health care, are often lacking. Prisoners with disabilities are not recognized as disabled, and many are not provided reasonable accommodations as required by the Americans with Disabilities Act. Through both individual and impact litigation, the Prison Law Office has changed many California Department of Corrections and Rehabilitation policies and practices, and has alleviated many of the cruel and unusual conditions that have been inflicted upon tens of thousands of state prisoners.
+
+
+
+Direct Services:
+
+
+
+
+
+
+
+Root & Rebound    Legal Advocacy & Direct Services
+Root & Rebound’s mission is to reduce barriers and maximize opportunities for people returning from prison and jail in the Bay Area, throughout California, and beyond.  Though our Legal Advocacy and Direct Services Program we work with clients to identify barriers that make reintergation most challenging and address these needs by providing legal sericvices in-house and by collaborating with service providers across the bay Area to provide extra legal services.  www.rootandrebound.org
+
+To Get Connected
+Contact Person:  Aiashi Khalid
+Phone: (510) 279-4662 
+Fax: (510) 666-4903
+Email:  info@rootandrebound.org
+Intake Hours: Monday –Friday, 1pm-4pm
+Location: 1900 Addison St., Berkeley, CA 94704, San Francisco, CA 94104-0390
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. 
+Faith Based: No
+Eligible Population: All individuals 18 yrs and older
+Notes: Walk-ins at our Berkeley office.
+
+Direct Services:  post-incarceration support; clean slate/conviction expungement services; inmate and parolee legal issues; employment law/discrimination; family law; housing & eviction defense.
+
+
+
+Rosen, Bien, Galvan & Grunfeld LLP
+Rosen, Bien, Galvan & Grunfeld LLP has a unique practice blending public interest and private sector litigation.  The firm represents individuals and companies in complex trial and appellate litigation
+in state and federal courts.  Practice areas include:  Constitutional and civil rights; class action; work-place disputes in cases of discrimination, harassment, wrongful termination, non-competition agreements and wage and hour enforcement; commercial litigation. www. rbgg.com
+
+To Get Connected
+Phone: (415) 433-6830 
+Fax: (415) 433-7140
+Hours: Monday –Friday, 8:30am-5:30pm 
+Mailing Address: PO Box 390, San Francisco, CA 94104-0390
+Notes: No dop-ins.  Clients seen by appoinmnet only. 
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. 
+Faith Based: No.
+
+Direct Services:  Legal Representation; Litigation.
+
+
+San Francisco Office of Citizen Complaints    
+The mission of the Office of Citizen Complaints is to promptly, fairly and impartially investigate complaints of police misconduct. In addition to complaint investigation, the office provides a volunteer mediation program, performs policy analysis for recommendations to the Police Commission, and runs community outreach efforts. www.sfgov3.org/index.aspx?page=419
+To Get Connected
+Phone: (415) 241-7711 
+Fax: (415) 241-7733
+Hours: Monday to Friday, 8:00am - 5:00pm
+Location: 25 Van Ness Avenue, #700, San Francisco, CA  94002 
+Notes: No referrals needed. Drop-ins allowed.
+Things To Know
+Languages Spoken: Spanish, Cantonese, Tagalog, Russian. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: All individuals and family members who wish to make a complaint regarding a sworn San Francisco Police Department officer.
+Faith Based: No.
+Direct Services: Mediation and Investigation of complaints against SF Police Officers. Referrals to other resources available as needed.
+
+San Francisco Office of the District Attorney   Back on Track Initiative
+The San Francisco District Attorney’s Back on Track Initiative is a court-driven program for offenders ages 18-30 who are charged with their first adult felony drug sales offense.   Defendants accepted into Back on Track spend a minimum of one year attending progress hearings and commit to complete community service, obtain their high school diploma/GED, and find employment.  We partner with Criminal Justice Specialists at Goodwill Industries, who both monitor individuals’ progress and assist with job training, job placement and other critical supports.  Successful participants have their cases dismissed and arrest records sealed.
+ www.sfdistrictattorney.org
+To Get Connected
+Contact Person: Ranon Ross, Back on Track Manager
+Phone: (415) 553-9665 
+Fax: (415) 553-9700
+Email: ranon.ross@sfgov.org
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: 850 Bryant Street, 3rd Floor, San Francisco, CA  94103
+Notes: Referrals are required for program; call for referrals.
+ 
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.
+Client fees: None.
+Eligible Population: Young adults in the criminal justice system. There are additional requirements; please call for more information.
+Faith Based: No.
+
+Direct Services: Referrals into Back on Track program; referrals to other resources as needed.
+
+San Francisco Office of the District Attorney   Victim Services Division
+The Victim Services Division of the District Attorney’s Office provides comprehensive advocacy and support to victims of crime and witnesses to crime. Our Victim Advocates provide services in English, Cantonese, Mandarin, Spanish, and Vietnamese. We start by assessing each victim’s needs.  This can mean crisis intervention, counseling, accompanying a victim to court, assistance with victim compensation, making funeral arrangements, intervening with employers and creditors when victims cannot work, and providing many other services needed to restore a crime victim’s life.  Our Victim Services staff is diverse and committed to providing culturally competent services.   www.sfdistrictattorney.org
+
+To Get Connected
+Contact Persons:  Jackie Ortiz
+Phone: (415) 553-9044 
+Fax: (415) 553-9700
+Email: jacqueline.ortiz@sfgov.org
+Hours: Monday – Friday 9:00 am – 5:00 pm
+Location: 850 Bryant Street, 3rd Floor, San Francisco, CA  94103
+Notes: Individuals who are currently on probation or parole are not eligible to receive 
+State Victim Compensation Funds during the period of their probation or parole.
+ 
+Things To Know
+Languages Spoken: English, Cantonese, Mandarin, Spanish, and Vietnamese; other translation available.
+Accessibility: Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: Victims of crime; victims’ family members; witnesses to crime
+Faith Based: No.
+
+
+
+Direct Services: Assistance with "Victim Compensation Program" claims; crisis intervention and emergency assistance; help navigating the criminal justice system; resources and referrals; restitution and property return; witness relocation; transportation; and more.
+
+
+San Francisco Office of the Public Defender   Clean Slate Program
+Clean Slate is a program of the San Francisco Public Defender’s Office that can help people “clean up” their criminal records. http://sfpublicdefender.org/services/clean-slate/
+To Get Connected
+Clean Slate Phone: (415) 553-9337 
+Fax: (415) 553-9646
+Main Phone: (415) 553-1671
+Application: Applicants must complete the one-page “Clean Slate Program Application” which can be obtained at the Public Defender’s office or by viewing the website: www.sfpublicdefender.org. Applicants will also need a copy of their RAP sheet, available from the SFPD Identification Bureau for free. Send applications to:
+PUBLIC DEFENDER’S OFFICE
+Attn: Clean Slate Program
+555 Seventh Street, 2ndFloor
+San Francisco, CA 94103
+Notes: No appointment required. Walk-in clinics are listed below:
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Must obtain copy of RAP Sheet from Identification Bureau, Hall of Justice, 850 Bryant Street, Room 475, San Francisco, CA 94103 (can request by mail or in person, Monday – Friday, 8:00am-3:00pm).
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees: None.
+Eligible Population: All people with a criminal arrest and/or conviction, or juvenile matter, from the County of San Francisco. Do not need to be a former client of the Public Defender, but must meet financial eligibility criteria. 
+
+
+Free Walk-in Clinic Hours and Locations:
+2nd and 4th Monday of the month, 10:30am-12:30pm: Arriba Juntos, 1850 Mission St. (English and Spanish)
+Every Tuesday, 9am-11am: Office of the Public Defender, 555 Seventh St.
+4th Wednesday of the month, 3pm-5pm: Village Community Center, 1099 Sunnydale Ave.
+1st Thursday of the month, 9am-11am: Southeast Community Center, 1800 Oakdale Ave.
+1st Thursday of the month, 9am-11am: Ella Hill Hutch Community Center, 1050 McAllister Street, SF
+1st and 3rd Monday of the month: 10am-11am, Community Justice Center, 555 Polk St., 2nd Floor
+
+Direct Services: Dismissal of convictions; Prop 47 reductions; seal and destroy arrest records (subject to capacity limits); Certificate of Rehabilitation; early termination of probation; and reduction of felony conviction to misdemeanor. Representation at court dates. Referrals to other services as appropriate. 
+San Francisco Office of the Public Defender   Reentry Unit
+Children of Incarcerated Parents Social Worker and Adult Social Workers work with current and former clients of the Public Defender. www.sfpublicdefender.org
+To Get Connected
+Contact Person: Simin Shamji, Manager of Reentry Unit 
+Phone: (415) 553-1671  
+Fax: (415) 553-9810
+Specific Intake Days and Times: 
+Hours: Monday – Friday, 8:00am to 5:00pm
+Location: 555 Seventh Street, San Francisco, CA 94103
+Notes: Referral required from Public Defender Attorney. By appointment only. 
+Things To Know
+Languages Spoken: English, Spanish, and other languages accommodated as needed.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Faith Based: No.
+
+
+
+Direct Services: Assistance with access to Benefits (SSI, GA, TANF, et al); Accompany to Court Dates; Counseling; Parenting Support; Help/Vouchers to Get State ID, etc.; Legal Assistance/Advocacy; Referrals to Treatment, Housing, Medical and Other Services. 
+
+Superior Court of California, County of San Francisco   ACCESS Center (Legal Self-Help)
+To provide linguistically and culturally appropriate self-help services to individuals seeking to access and navigate the legal system in the county of San Francisco. Areas of law are limited to Family Law and Civil Law  www.sfsuperiorcourt.org/self-help
+To Get Connected
+Info Line:  (415) 551-5880
+Hours: Monday, Tuesday, Thursday 8:30am – 12:00pm and 1:30pm - 4:00pm; 
+Location: 400 McAllister Street, Room 509
+San Francisco, CA 94102 
+Notes: No referrals needed. Drop-ins available.
+
+Things To Know
+Languages Spoken: Cantonese, Mandarin, Toisanese, Spanish, Italian. Volunteers also speak Russian, French, Portuguese, Tagalog, French, and other languages. Materials are multilingual.
+Accessibility: Wheelchair accessible. ASL interpreters available. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Populations: All individuals and family members.
+Faith Based: No.
+
+Direct Services: Family Law Services: Dissolution of Marriage/Domestic Partnership,  Legal Separation, Annulment/Nullity of Marriage, Established Paternity/Parental Relationship, Child Support, Domestic Violence Restrating Orders,Step-Parent Adoptions; Civil Law, Small Claims, Civil Harassment Restraining Orders, Name Changes, Gender Changes, Evictions, Guardianship of the Person, Conservationship of the Person.
+
+Swords to Plowshares   Legal Department
+War causes wounds and suffering that last beyond the battlefield. Our mission is to heal the wounds, to restore dignity, hope and self-sufficiency to all veterans in need, and to significantly reduce homelessness and poverty among veterans. Many veterans never receive the benefits for which they are eligible. The Legal Department of Swords to Plowshares helps veterans to cut through the extremely arduous VA benefits application process by providing free attorney representation, case management, and advocacy to indigent veterans by seeking benefits. www.swords-to-plowshares.org
+To Get Connected
+Phone: (415) 252-4788  
+Fax: (415) 252-4790
+Hours: Tuesday to Thursday, 9:00am-11:45am
+Location: 1060 Howard Street, San Francisco, CA 94103
+Notes: No referrals needed. Drop-ins available.
+
+Things To Know
+Languages Spoken: English.
+What to Bring: TB Clearance; Proof of homelessnes and veteran status (Defense Department Form 214). Program will assist clients in obtaining these documents.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None.
+Eligible Populations: All veterans of the U.S. military. Must be homeless or veteran of the wars in Iraq or Afghanistan.
+Faith Based: No.
+Direct Services: Legal Assistance/Advocacy—access to benefits for veterans of the U.S. Military. Referral to other services provided, as appropriate.
+
+Tenderloin Housing Clinic   Legal Services
+The Tenderloin Housing Clinic law office represents low-income tenants in San Francisco in all aspects of landlord-tenant and housing law. We primarily represent seniors, the disabled, and minority and immigrant families, often as defendants in unlawful detainer actions and in affirmative lawsuits for wrongful eviction, and to address substandard housing conditions. THC's attorneys are some of the most experienced and well-respected attorneys in San Francisco, with decades of experience representing low-income tenants. The law office also provides limited free legal counseling to tenants. www.thclinic.org
+To Get Connected
+Contact Person: Steven Shubert, Legal Manager
+Phone: (415) 771-9850 
+Fax: (415) 771-1287
+Email: steven@thclinic.org
+Hours: Monday-Friday, 9:00am to 5:00pm
+Location: 126 Hyde Street, San Francisco, CA 94102
+Notes: No referrals needed. Drop-ins welcome.
+
+Things To Know
+Languages Spoken: English, Spanish, Cantonese, Mandarin, Tagalog, Assamese.
+What to Bring: State-Issued ID, Social Security card, Rental Agreement and/or lease, any late rent notices and/or Unlawful Detainer.
+Accessibility: No wheelchair access. Reasonable attempts to provide accommodations will be provided as needed.
+Client fees, if any: None.
+Eligible Populations: San Francisco tenants facing landlord-tenant and housing issues.
+Faith Based: No.
+Direct Services: Free legal services for qualified participants.
+
+
+
+Legal Services for Prisoners with Children   California Coalition for Women Prisoners (CCWP)
+CCWP is a grassroots social justice organization, with members inside and outside prison, that challenges the institutional violence imposed on women, transgender people, and communities of color by the prison industrial complex (PIC). We see the struggle for racial and gender justice as central to dismantling the PIC and we prioritize the leadership of the people, families, and communities most impacted in building this movement. www.womenprisoners.org www.prisonerswithchildren.org
+To Get Connected
+Contact Persons: Samantha Rogers and Hafsah Al-Amin, Program Coordinators
+Phone: (415) 255-7036 x4  
+Fax: (415) 552-3150
+Email: samantha@womenprisoners.org; hafsah@womenprisoners.org 
+Hours:  Monday – Friday from 9:00am – 5:00pm
+Notes: No referrals needed. Not a formal service site, but individuals can make appointments to come for support and referrals to other resources.
+Things To Know
+Languages Spoken: English. In addition, Compañeras Program hightlights and supports issues of Spanish speakers. 
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+Client fees, if any: None.
+Eligible Population: All individuals and family members, in and out of custody. 
+Faith Based: No.
+
+
+Direct Services: Assistance finding emergency shelter; Assistance finding permanent housing prior to or upon release; Some Access to Internet; Mentorship; Outreach to a wide cross-section of people including students, domestic violence workers, community service providers, and others; Other Post-Incarceration Support; Restorative Justice/ Survivor Impact efforts with violent offenders in San Francisco Jails; Coordinate with All Of Us or None to spread the word about clean slate efforts; Assist with Inmate & Parolee Legal Issues; Coordinate annual event for family members to visit prisoners. Referrals to other resources available as needed.
+
+Legal Services for Prisoners with Children    
+We generally do not represent people in court or other legal matters. We are committed to training people to advocate for their own rights. prisonerswithchildren.org
+To Get Connected
+Phone: (415) 255-7036
+Email: info@prisonerswithchildren.org 
+Hours: Monday - Friday, 9:00am to 5:00pm
+Location: 1540 Market Street, Suite 490
+San Francisco, CA 94102 
+Notes: No referrals needed. Call or write first for an appointment.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+Client fees, if any: None. Voluntary donations accepted.
+Genders/Family Composition/Ages Served: 
+All individuals and family members.
+Faith Based: No.
+
+Direct Services: Pregnancy information for incarcerated women; Inmate & Parolee Legal Issues for California prisoners and their families; Support letters for older women in state prison; Family law manuals/advice; Workshops on family law issues; Prison advocacy, including support letters for incarcerated people who are experiencing problems in custody, such as lack of or substandard medical care, sexual harrassment or retaliation, problems with visits, etc.; Family Reunification counseling; Support and advice for family members visiting loved ones in jail or prison. Referrals to other resources available as needed.
+
+Legal Services for Prisoners with Children   All of Us or None    
+All Of Us Or None (AOUON), a project of Legal Services for Prisoners with Children, is a grassroots organization led by formerly-imprisoned people committed to fighting for the human dignity of currently and formerly-incarcerated people, and their respective family members, as well as against the systemic discrimination facing them while in captivity and upon their release. AOUON strengthens the voices of people most affected by the punishment (judicial) system and the growth of the prison-industrial complex. Through their grassroots organizing, AOUON is building a powerful political movement to win full restoration of their human and civil rights.  prisonerswithchildren.org
+
+To Get Connected
+Contact Person:  Alex Berliner, Manuel La Fontaine, Organizers 
+Phone: (415) 255-7036 x330, x328  
+Fax: 552-3150
+Email: alex@prisonerswithchildren.org; manuel@prisonerswithchildren.org 
+Hours: Monday - Friday, 9:00am to 5:00pm
+Notes: Please call organiers for more information. 
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated. 
+Client fees, if any: None. 
+Eligible Population: All individuals and family members, in and out of custody. 
+All individuals and family members.
+Faith Based: No.
+
+Direct Services:  Some Access to Internet; Mentorship; Post-Incarceration Support; Assist with writing support letters for people facing charges or the Parole Board; Coordinate annual event to connect family members inside with their children, grandchildren, and families on the outside through our Community Giveback. Referrals to other resources available as needed. Coordinate with other organizations to raise awareness of our struggle against systemic discrimination.
+
+Proyecto Common Touch   Get Out The Jail Vote/CA
+Empowerment by knowledge and mission to distribute and make this relevant information available and accessible in or out of custody. www.proyectocommontouch.org
+To Get Connected
+Contact Persons: Tommy Escarcega, Director
+Phone: (510) 409-1662
+Fax: (510) 845-4622 
+Email: tommyescarcega@yahoo.com
+Hours: Call for hours
+Mailing Address: 830 Allston Way, Berkeley, CA  94710 
+Notes: No referral needed. Call during business hours or write for appointment at other times.
+
+Things To Know
+Languages Spoken: English, Spanish, some Portuguese.
+Accessibility: May be arranged.
+Client fees, if any: None. Donations accepted.
+Eligible Population:  Women, Transgender
+Faith Based: No.
+
+
+Direct Services: Voter Education; Voter Registration; Phone/Voicemail - We will accept a determined number of messages and allow some phone use for related business; Inmate & Parolee Legal Issues; Voting Outreach & Education. Referrals to other resources available as needed.
+
+San Francisco Sheriff's Department   Prisoner Legal Services
+We help the San Francisco Sheriff's Department in its mission to meet or exceed local, state and federal mandates regarding the housing and treatment of prisoners.  PLS provides San Francisco County Jail prisoners with meaningful access to the courts as well as advocacy and limited direct services aimed at assisting clients with problems occasioned by their incarceration and with barriers to reentry.   www.sfsheriff.com
+To Get Connected
+Contact Persons: Any Intern/Staff
+Phone: (415) 558-2472 
+Fax: (415) 558-2490
+Hours: Monday – Friday, 9:00am to 5:00pm
+Location: All San Francisco County Jails, 555 7th Street, #201, San Francisco, CA  94103 
+Notes: No referral needed. Incarcerated clients must submit a request for services; limited drop-in service for recently released prisoners.
+Things To Know
+Languages Spoken: English. Translation services available. 
+Accessibility: Wheelchair accessible. Other disabilities may be accommodated.
+Client fees, if any: None.
+Eligible Population: Incarcerated persons and persons recently released from the custody of the San Francisco County Jail.
+Faith Based: No.
+
+Direct Services: Assistance Getting Driver’s License/Other ID; Transit Vouchers; Post-Incarceration Support; Inmate and Parolee Legal Issues; Family Law; Housing and Eviction Defense; Restraining/Staw Away Orders; Voting Outreach and Education; Jail Conditions; Visits of family Menbers in Jails and Prisons; Child Support/Custody; All legal or official mail may be posted or received on behalf of an inmate upon request.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Abode Services    
+Abode Services’ mission is to end homelessness by assisting low-income, un-housed people, including those with special needs, to secure stable, supportive housing; and to be advocates for the removal of the causes of homelessness.  Abode Services serves people in Alameda and Santa Clara Counties.  www.abodeservices.org/
+
+To Get Connected
+Phone: (510) 657-7409 
+Email:  info@abodeservices.org
+Hours: Monday –Friday, 9am-5pm
+Location: 40849 Fremont Blvd., Fremont, CA  94538
+Notes:  Most of our programs require a referral from a service provider.  However, if
+you are a veteran, transition-age youth, in need of emergency shelter, or living on the streets, we may be able to help with a referral.  Please contact us via phone or email.  You can also visit tinyurl.com/abodeclinic for the schedule of our mobile health clinic or call (510) 252-0910 to reach our shelter.  No drop-ins at main office. 
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None.
+Eligible Population: Individuals and families who are homeless or about to lose their housing, who live in, or want to relocate to, Alameda and Santa Clara counties
+Faith Based: No
+
+Direct Services:  Emergency Shelter; Mobile Health Clinic; Housing Assistance for Veterans; Services for Transition-Age Youth Formerly in Foster Care; Supportive Services for those Reentering the Community through Post Release Control Supervision (must be referred through social worker to Alameda County Sheriff’s Office); Housing Support for Homeless (with low or no income who are seeking to be housed and employed); Medi-Cal and CalFresh Applications for Alameda County.  Referrals to other resources available as needed.
+
+
+
+
+Center For Employment Opportunities (CEO)   Employment Services
+The Center for Employment Opportunities (CEO) is dedicated to providing immediate, effective and comprehensive employment services to men and women with recent criminal convictions. Our highly structured and tightly supervised programs help participants regain the skills and confidence needed for successful transitions to stable, productive lives.  CEO’s vision is that anyone with a recent criminal history who wants to work has the preparation and support needed to find a job and to stay connected to the labor force.  www.ceoworks.org
+
+To Get Connected
+Contact Person: Intake
+Phone: (510) 251-2240 
+Hours: Monday –Friday, 8am-5pm
+Location: 1212 Broadway, Suite 1700, Oakland, CA  94612
+Notes:  Please call for more information. Must be on Alameda County Parole or Alameda County Probation.  Please get referral from supervising officer.
+Things To Know
+Languages Spoken: English
+Accessibility: Wheelchair accessible. 
+Client fees, if any:  None
+Eligible Population: All individuals over the age of 18 referred from Alameda County Parole or Alameda County Probation
+Faith Based: No
+
+Direct Services:  Job Readiness/Life Skills; Employment Training; Employment Placement.
+
+
+
+
+
+
+
+
+
+
+
+Leaders In Community Alternatives   Transitional Day Reporting Center (TDRC)
+The ADRC North is a partnership between the Sacramento Probation Department and Leaders in Community Alternatives  that bridges probation supervision services with comprehensive case management, barrier removal, employment and income benefits acquistion assistance.  In addition to the services LCA has on-site at the ADRC, LCA utilizes Sacramento County Probation's existing contracts for education, vocational and mental health services.  The goals of the ADRC are to reduce recidivism and build self-sufficiency skills in the clients we serve. The new Transitional Day Reporting Center (TDRC) is a community corrections reenrty center that bridges probation supervision services with comprehensive case management, barrier removal, and income benefits acquistion assistance.  In addition to the services LCA will have on-site at the TDRC, LCA will utilize Alameda County probation Department’s existing contracts for employment, vocational services and housing.  We also plan to utilize current contracts of the Alameda County behavioral health Care Services for substance abuse and mental health treatment.  The foals of the TDRC are to reduce recidivism, build self-sufficiency skills, for a thriving healthy community.  
+
+To Get Connected
+Contact Person:  Roth Johnson
+Phone: (510) XXX-XXXX
+Email:  rjohnson@lcaservices.com
+Hours: Monday –Friday, 8am-5pm
+Location: 400 Broadway, Oakland, CA  94604
+Notes:  Please call for more information.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None
+Eligible Population: Clients of the Alameda County Adult Probation Department
+Faith Based: No.
+
+Direct Services: Access to Internet;  Assistance Getting Driver’s License/Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Transit Vouchers; Substance Abuse Treatment; Alcohol Monitoring and Substance Abuse Testing; Health & Wellness Education; Std/Sti Prevention; Anger Management; Group Counseling/Therapy; Intensive Case Management; Individual Counseling/Therapy; Mentorship;  Outreach; Post-Incarceration Support; Restorative Justice/Survivor Impact; Trauma Recovery Services; Housing Placement Assistance; Cognitive Behavorial Therapy; Basic/Remedial Education; GED & High School Education; Reading/Literacy; Vocational Education; Assistance applying for CalFresh/Food Stamps; Assistance applying for PAES/GA/CalWorks; Employment Training; Employment Placement; Employment Retention; Job Readiness/Life Skills; Assistance applying for Health Insurance;  Clean Slate/ Conviction Expungement Services; Voting Outreach & Education; Couples/Family Counseling;   Family Reunification; Parenting Support/Education.
+
+ 
+Goodwill Industries of the greater East Bay   Homelss Services Program
+Our Homeless Services Program works specifically with individuals facing homelessness and the multitude of related challenges. This program offers employment and comprehensive support services to homeless individuals and families in Alameda County. This Program is primarily supported by a Housing and Urban Development (HUD) grant, which provides for housing stabilization, case management, and in-house counseling for those facing chronic homelessness as well as community members more recently impacted by the economic downturn. Goodwill provides these support services at our One Stop Homeless Employment Center in downtown Oakland.   Goodwill’s “Bridges to Work” initiative helps our homeless participants secure transitional employment and job training, and, once skills are established, search for competitive employment.  In 2013, our Homeless Services Program served 622 individuals and continues to meet high demand for their services as community members continue to struggle with rising unemployment and subsequent instability in their housing.
+
+To Get Connected
+One Stop Homeless Center
+1600 San Pablo Avenue, Oakland, CA 94612
+(510) 903-3220
+  
+Goodwill Industries of the Greater East Bay 8-5 m-f
+1301 30th Avenue, Oakland, CA 94601
+(510) 698-7200
+info@eastbaygoodwill.org
+
+San Antonio Fruitvale Community Learning Center
+29th Avenue (bet. International & East 12th St.), Oakland, CA 94607
+(510) 698-7216
+
+
+
+Direct Services:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Options Recovery Service
+At Options, we do not just treat addiction, we treat the whole person.  Our mission is to break the cycle of addiction which causes homelessness, crime and broken families.  optionsrecovery.org
+ 
+To Get Connected
+Contact Person: Greg Nottage, Intake Coordinator
+Phone: (510) 666-9552 
+Hours: Tuesday/Thursday, 8:30am-7:00pm; Monday/Wednesday/Friday, 8:30am-8:00pm
+Location: 1931 Center Street, Berkeley, CA  94704-transitional houses are located in Oakland and Berkeley.
+Things To Know
+Languages Spoken: English
+Accessibility: Wheelchair accessible
+Client fees, if any:  Medi-Cal/AB-109/Re-Entry Court/Private Pay $30 per session.
+Eligible Population: Men and women ages 18 and older.
+Faith Based: N/A
+Notes:  No appointments/walk-ins are welcome.
+
+Direct Services: Out Patient Alcohol and Drug Treatment/Transitional Housing. Options is a day treatment recovery program including 12-step study, self-esteem groups, relaxation training, yoga, anger management, life skills, relapse prevention, smoking cessation, individual counseling, acupuncture and a host of other services.  Other services include shelter/housing and mental health treatment.
+
+
+
+
+WIA Workforce Investment Act   Breaking Thru Barriers
+Our mission is to improve employment, vocational training, and educational outcomes via direct intervention/prevention post release of clients currently on parole or probation. Program is to achieve a reduction of recidivism rates and associated recidivist behaviors associated with Returning Citizens. Link to resource guide:  oaklandpic.org/reentry
+ 
+To Get Connected
+Contact Person: Zina Y. Taylor
+Phone: (510) 768-4462 
+Email:  ztaylor@oaklandpic.org
+Hours: Monday –Friday, 8:30am-4:45pm
+Location: 1212 Broadway, Suie 200, Oakland, CA  94612
+Notes:  This program is dedicated to the formerly incarcerated returning residents 
+Things To Know
+Languages Spoken: English
+Accessibility: Wheelchair accessible-NO. 
+Client fees, if any:  None
+Eligible Population: All individuals between the age of 18 and 60 years old who are Alameda County residents.
+Faith Based: No
+(Parole/Probation) needing help finding employment.
+
+ 
+Direct Services:  Job Readiness/Life Skills; Employment Training; Employment Placement; Supportive Services (transportation, union dues, book/school fees, etc).
+
+
+
+                                                                                                                                                     
+
+
+
+
+
+
+Contra Costa County Behavioral Health Access Line   Alcohol and Other Drug Services
+Contra Costa County Behavioral Health Access Line, Alcohol and Other Drug Services, provides information on existing alcohol and other drug program treatment and prevention services. Referrals will be provided to available residential, detoxification, MAT, NTP, outpatient treatment services in the greater Contra Costa and surrounding regions.   cchealth.org/aod/
+
+To Get Connected
+Contact Person:  Zachariah Todd, AOD Counselor 
+Phone: (800) 846-1652
+Hours: Monday-Friday, 8am-5:00pm
+Notes: Application Procedure: Call 1-800-846-1652
+
+ 
+Things To Know
+Languages Spoken: English, Spanish
+Accessibility:  ADA Accommodations: Wheelchair accessibility 
+Client fees, if any: Sliding scale.  No one will be denied services based on inability to pay.
+Eligible Population: Must be a Contra Costa County resident.
+Faith Based: No
+
+Direct Services:  Contra Costa Residents can access Alcohol and Other Drugs Services through multiple ports of entry: The Information and Referral Phone Line provides information to the general public, and makes prevention referrals 800-846-1652 (Call Toll Free).
+
+
+
+
+
+
+
+
+Discovery House   Residential Substance Abuse Program
+Discovery House provides a 90-day residential substance abuse treatment program Provides a 90-day residential substance abuse treatment program for men utilizing a therapeutic community/social modality. Services include individual, group, and family counseling, psychological and physical evaluation, chemical dependency and co-dependency education, 12-Step work, Narcotics Anonymous meetings, and recreational activities. Arranges for vocational rehabilitation and other services as needed. Some slots available through AB109.  cchealth.org/   and 
+cchealth.org/aod/pdf/Discovery-House-brochure.pdf
+
+To Get Connected
+Contact Person:  Susan Martinez or Intake 
+Phone: (925) 646-9270 
+Fax: (925) 646-9276
+Hours: 24 hours per day/7 days per week
+Location: 4645 Pacheco Blvd., Martinez, CA  94553
+Notes: Application Procedure: Apply by telephone by calling 1-800-846-1652.
+Transportation: From Pleasant Hill BART, take County Connections bus #116
+(headed towards Am-Track), get off at Pacheco and Arthur. 
+ 
+Things To Know
+Languages Spoken: English, Spanish
+Accessibility:  ADA Accommodations: Wheelchair accessibility 
+Client fees, if any: Sliding scale.  No one will be denied services based on inability to pay.
+Eligible Population: Men (only), 18-64 years of age.  Must be a Contra Costa County resident.
+Faith Based: No
+Direct Services: Residential substance abuse treatment; individualized program; exercise and recreational activities; vocational rehabilitation; supportive services and referrals.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rubicon Programs   Financial Opportunity Center 
+Rubicon’s mission is to transform East Bay communities by equipping low-income people to break the cycle of poverty. Rubicon finds support that’s right for each individual – a personalized, comprehensive collection of services that includes job placement, housing, legal services, and financial literacy. We place low-income East Bay residents in jobs and housing and get them access to legal services and healthcare. www.rubiconprograms.org
+
+To Get Connected
+Contact Person: Rubicon Main Line 
+Phone: (510) 412-1725
+Hours: Monday-Thursday: 8:30-5:00pm Friday: 8:30-12:00pm
+Location:  101 Broadway, Richmond, CA  94808 
+Notes: Please call for upcoming Information Session and enrollment dates. If you are supervised underAB109 or Second Chance probation, please contact your assigned Officer for a referral.
+
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible
+Client fees, if any: None
+Eligible Population: Homeless, AB109 and Second Chance Probation, and Parents returning home within last 180 days
+Faith Based: No.
+Direct Services: Employment Readiness; Financial Literacy and Income Support; Healthcare Enrollment; Housing Assistance; Vocational Training Placement; Job Placement; Parenting (partner on-site); Anger Management (partner on-site), Education (literacy and GED services partner on-site), VITA Tax Preparation services. Referrals to other services as appropriate. 
+
+
+
+
+Shelter Inc.   
+SHELTER, Inc. strives to realize a vision: Re-building lives, one family at a time, by giving them a home, the skills and the resources to live the life they deserve.  The mission of SHELTER, Inc. is to prevent and end homelessness for low-income residents of Contra Costa County by providing resources that lead to self-sufficiency.  Our work encompasses three main elements:
+preventing homelessness through rental assistance, case management, and housing counseling services; ending the cycle of homelessness by providing 3 to 24 months of housing in combination with supportive services such as job training, educational services and counseling; and by providing affordable housing to low-income households, including such special needs groups as transition-age youth, people with HIV/AIDS and those with mental health disabilities.  shelterinc.org
+
+
+To Get Connected
+General Inquiries: (925) 335-0698
+Prevention and Homeless Services: ONE DOOR, (925) 338-1038 (Monday-Friday, except holidays, 9:00am-4:00pm)
+Main Office:  1815 Arnold Drive, Martinez, CA  94553
+Notes: For the Rental Assistance Program and application process please call 925-338-1038 between 9:00 a.m. and 4:00 p.m. one time only Monday through Friday (except holidays).  Must call first for an appointment, No drop-ins.
+
+
+Things To Know
+Languages Spoken: English, Spanish.
+What to bring:  For services we ask you have a picture ID, Social Security card and proof of income. Appointment is necessary.
+Accessibility:  Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: Men and women 18 years and older, with or without children, must be a Contra Costa County resident.
+Faith Based: No.
+Direct Services:  Interim Housing for families with children under 18 years old; Transitional Housing; Family Rapid Rehousing; Rental Assistance; Permanent Supportive Housing; Supportive Services for Veteran Families; Intensive Case Management.  Referrals to other services as appropriate.
+
+
+
+
+
+
+The Mission at Kern County
+The Mission at Kern County is the largest provider of homeless and addiction recovery services in all of Kern County.  The Mission at Kern County is the place where the homeless and addicted can come not just for a day of food and night of shelter, but Christ-centered long-term care that transforms lives. The Mission at Kern County’s purpose is to offer an environment conducive to physical, emotional and spiritual well-being of the people we serve by providing hope and future through Jesus Christ.  www.thebrm.org
+
+To Get Connected
+Contact Person: Staff 
+Phone: (661) 325-0863
+Email:  info@themissionkc.org
+Hours: Monday-Thursday: 8:30-5:00pm Friday: 8:30-12:00pm
+Location:  816 East 21st Street, Bakersfield, CA  93305
+Notes: Please call for information regarding services.  No referral needed.
+
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible
+Client fees, if any: None
+Eligible Population: male Only Shelter.  Must not have a conviction for any sex offense or arson and no AB109 placement
+Faith Based: Yes.
+Direct Services: Emergency Shelter; Hygiene/Personal Care Items;  Food/Prepared Meals; Education Services; Primary Healthcare Services; Homeless Recovery Services; Counseling; Life Skills/Life Management; Spiritual Encouragement; Addiction Revovery/Substance Abuse; Discipleship Program. Referrals to other resources available as needed.
+
+
+
+
+
+Salvation Army   Adult Rehabilitation Center
+The Salvation Army’s Adult Rehabilitation Centers provide spiritual, social and emotional assistance for men and women who have lost the ability to cope with their problems and provide for themselves.  Each center offers residential housing, work, and group and individual therapy, all in a clean, wholesome environment. The physical and spiritual care that program participants receive prepares them to re-enter society and return to gainful employment. Many of those who have been rehabilitated are reunited with their families and resume a normal life. bakersfield.satruck.org/rehabilitation-program
+
+To Get Connected
+Contact Person: Brian Austin
+Phone: (800) 728-7825 or (661) 325-8626 ext. 138
+Email:  brian.austin@usw.salvationarmy.org
+Location:  200 19th St, Bakersfield CA 99301 
+Notes: No referrals needed. Drop-ins allowed. Minimum 6 month program. 
+
+
+Things To Know
+Languages Spoken: English.
+What to Bring: State-Issued ID, Social Security Card.
+Accessibility:  No.
+Client fees, if any: None.
+Eligible Population: Must be an adult male and healthy enough to work. Drug & Alcohol Free Environment. No SSI, Unemployment, or Disability Recipients. 
+Faith Based: Yes.
+
+Direct Services: Residential Treatment; Employment Training; Therapy; Clothing; Hygiene/Personal Care Items;  Food/Prepared Meals; Life Skills.
+
+
+
+
+
+
+
+
+Delancey Street Foundation Los Angeles
+Delancey Street is a residential education center for former substance abusers and ex-convicts. Its philosophy is that the people with the problems can teach themselves to become the solution. The program requires a minimum two-year commitment, and many individuals stay for longer. The Delancey Street Foundation Los Angeles facility is located near midtown, right off the Hollywood freeway. The facility, housing approximately 300 residents, was constructed as a 220 room hotel; the Mission style building complex includes a huge ballroom for catering events for up to 500 people, with smaller catering rooms as well. The buildings surround a large 8,000 square foot tropical garden with cascading waterfalls. Residents have completely renovated the building since we bought it in 1993. In order to make the hotel more of a home, residents turned the guest rooms into living units ranging from dorms for the newcomers into small apartments as residents earn their way to more spacious living quarters, and opened up the dining area to 6,000 square feet for resident meals. Delancey Street-Los Angeles also has a 50,000 square foot warehouse Business Complex located in Montebello. This complex houses a number of Delancey Training Schools including Moving & Trucking, Automotive, Auto Body Shop, Warehouse Shipping and Receiving, Terrarium, Ceramics and Iron Handcraft Works and Sales.  www.delanceystreetfoundation.org 
+
+To Get Connected
+Contact Persons: Intake Coordinator
+Phone: (323) 644-4122 
+Fax: (323) 644-4147
+Facility Hours: 24 hours/7 days
+Location: 400 N. Vermont Ave., Los Angeles, CA 90004 
+Notes: No referrals needed. Drop-ins welcome.
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible. Other disabilities accommodated.
+Client fees, if any: No fee.
+Eligible Population: Men, Women, Transgender people, ages 18 older. May not have a criminal conviciton for arson; may not be a registered sex offender; may not have a serious medical/mental health condition requiring medication.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Assistance Getting Drivers License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Medical CareEmergency; Anger Management; Mentorship; Basic/Remedial Education; College & Graduate Education; GED & High School; Education; Reading/Literacy; Vocational Education; Employment Training; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Inmate & Parolee Legal Issues; Voting Outreach & Education; Parenting Support/Education. Referrals to other resources available as needed.
+
+
+
+Five Keys Charter School   Los Angeles
+Five Keys Charter School provides educational options for obtaining a High School Diploma, GED, Computer Literacy, and English as a Second Language.  Our goal is to increase educational levels, finding employment, and reintegrating into the community. Class times and schedules are flexible, offering students classroom based instruction and independent study programs. Five Keys partners with both Worksource and Youthsource centers that provide wrap around support services that our students need to meet their education and Career goals. We have twelve community locations throughout Los Angeles County.  www.fivekeyscharter.org 
+ 
+To Get Connected
+Contact Person: Jose Sanchez, Administrative Coordinator
+Phone: (415) 638-1284 
+Fax: (415) 734-3314
+Email:  joses@fivekeyscharter.org
+Administrative Office:  2677 Zoe Avenue, Huntington Park, CA 90255 
+Hours:  Monday-Friday, 8:30am-4:30pm
+Notes: Free education.  GED test is paid for by 5 Keys.  No referral needed. Drop-ins  welcome.  We have numerous locations in Los Angeles County.  Call for a location near you. 
+ 
+Things To Know
+Languages Spoken: English, Spanish.
+Client fees, if any: None.
+Eligible Population: All individuals 18 and older.
+Faith Based: No.
+
+Locations:
+WorkSource CA -Hub Cities Consortium, 2677 Zoe Ave, Huntington Park, CA 90255
+Southeast L.A.-Crenshaw WorkSource Center, 3965 S. Vermont Ave Los Angeles, CA 90037
+WorkSource Center Wilshire, 3550 Wilshire Blvd, Suite 500 Los Angeles, CA 90010
+WorkSource Center Compton, 2939 E. Pacific Commerce Dr. Compton, CA 90221
+WorkSource Center Goodwill, 342 San Fernando Rd.  Los Angeles, CA 90031
+WorkSource El Monte, 11635 Valley Blvd. Unit G, El Monte, CA 91732
+WorkSource Center Alhambra, 2550 W. Main St. #103, Alhambra, CA 91801
+Boyle Heights Technology Youth Center, 1600 E. Fourth St., Los Angeles, CA 90033
+Para Los Niños East Los Angeles, 3845 Selig Pl. Suite #150, Los Angeles, CA 90031
+New Beginnings Lancaster, 44814 Cedar Ave., Lancaster, CA 93534
+*Healthright 360, 2307 W. 6th Street Los Angeles, CA 90057
+*Amity Foundation: Amistad de Los Angeles,  3745 S. Grand Ave., Los Angeles, CA 90007
+*These sites do not have open enrollment.
+
+Direct Services: Basic/Remedial Education; English as a Second Language; GED & High School Education; Reading/Literacy.  Referrals to other resources available as needed. 
+
+
+
+
+
+
+
+
+
+
+HealthRight360   Outpatient Services
+The mission of HealthRIGHT360 is to give hope, build health, and change lives for people in need.  We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community. www.healthright360.org
+To Get Connected
+Contact Person: Thomas Smith, Intake 
+Phone: (213) 351-2832 
+Fax:  (213) 351-2853 
+Hours: Monday-Friday, 7:00am to 3:30pm
+Locations:  145 West 22nd Street, Los Angeles, CA 90007
+Notes: Must be on parole with SASCA/Parole authorization
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: Proof of SASCA authorization.
+Accessibility: Wheelchair and other disabilities accommodated.
+Client fees: Funded through SASCA.
+Eligible Population: Male/Female for continuum of care funded through SASCA.
+Faith Based: No.
+
+Direct Services: Trauma-Informed Treatment for Co-Ed Clients; Transitional Housing; Sober Living; Substance Abuse Services Referrals; Hygiene/Personal Care Items; Co-occuring Disorder/Dual Diagnosis Treatment; health & Wellness Education; Anger management; Group Counseling/Therapy; Individual Counseling/therapy; mentorship; Trauma recovery services; GED & High School Education Referrals; Job Readiness/Life Skills; Couples/family Counseling; Family Reunification; Parenting Support/Education Referrals.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+HealthRight360   Residential Treatment Services
+The mission of HealthRIGHT360 is to give hope, build health, and change lives for people in need.  We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community. www.healthright360.org
+To Get Connected
+Contact Person: Thomas Smith, Intake 
+Phone: (213) 351-2832 
+Fax:  (213) 351-2853 
+Hours: Monday-Friday, 7:30am to 4:00pm
+Locations:  2307 West 6th Street, Los Angeles, CA 90057
+Notes: Admission requires parole agent approval.  If you cannot reach intake please contact Tracy Bracey at (213) 35102829
+Things To Know
+Languages Spoken: English.  If you need interpreter please let us know. 
+What to Bring: You may bring clothing items (up to 10 days), a portable radio and a cell phone.  If you do not already have a California ID and Social Security Card, the program will assist you in obtai9ning these items.
+Accessibility: Facility is wheelchair accessible including ADA rooms available.
+Client fees: Program is funded through CDCR.
+Eligible Population: Male parolees ages 18 and over.
+Not Eligible:  Special registrations are ineligible for admissions.  Please call.
+Faith Based: No.
+
+
+Direct Services: Residential Substance Abuse Treatment; Trauma-Informed Treatment for Men; Transitional Housing; Gender Responsive Facilities; Transitional Housing Referrals; Hygiene/Personal Care Items; Co-Occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Individual Counseling/Therapy; Mentorship; Trauma Recovery Services; GED & High School Education; Application Assistance with SSI, Child Support, Birth Certificates; Job Readiness/Life Skills; 52 Sessions of CJ or Court Mandated Batters Program; Couples/Family Counseling; Family Reunification; Parenting Support/Education.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+HealthRight360   FOTEP El Monte
+The mission of HealthRIGHT360 is to give hope, build health, and change lives for people in need.  We do this by providing compassionate, integrated care that includes primary medical, mental health, and substance use disorder treatment.  Our services aim to relieve the burden of societal problems by promoting wellness, healthy relationships, productive living, and community. www.healthright360.org
+To Get Connected
+Contact Person: Sonia Crites 
+Phone: (626) 258-0300 
+Fax: (626) 401-2109 
+Hours: Monday-Friday, 8:00am to 6:00pm
+Locations:  12423 Dahlia Avenue, El Monte, CA 91732
+Notes: Admission requires parole agent approval; 2 children under the age of 12 are allowed to stay with their mother.  If the need arises to accommodate more than 2 children this will be assessed on an individual basis.
+Things To Know
+Languages Spoken: English.  Translation services can be made available. 
+What to Bring: You may bring 7 to 10 days’ worth of clothing, may bring preferred bedding, linens, and hygiene items.  Hygiene items will be provided if a client does not have any.  If you do not already have a California ID and Social Security Card, the program will assist you in obtai9ning these items.
+Accessibility: Facility is wheelchair accessible.
+Client fees: Funded through DRP for female parolees..
+Eligible Population: Female paroles and up to 2 children under the age of 12 for each participant. 
+Not Eligible:  Unable to accept anyone with a history of harm to children or required to register as a sex offender.
+Faith Based: No.
+
+
+Direct Services: Trauma-Informed Treatment for Women; Transitional Housing referrals; Substance Abuse Services; Hygiene/Personal Care Items; Co-occuring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Anger Management; Group Counseling/Therapy; Individual Counseling/therapy; mentorship; Trauma Recovery Services; GED & High School Education Referrals; Application Assistance with SSI; Job Readiness/Life Skills; Family Reunification; Parenting Support/Education.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+PATH   Supportive Services/Interim & Transitional Housing
+People Assisting The Homeless (PATH) is a family of agencies working together to end homelessness for individuals, families, and communities throughout Southern California. We strive to do this by prioritizing housing while providing customized supportive services for people in need. Our agencies each address homelessness in a different way—supportive services, permanent housing development, support for homeless families, and community engagement—all of which ultimately help the people we serve make it home.   www.epath.org/site/main.html
+
+To Get Connected
+Contact Person: Receptionist
+Phone: (323) 644-2216 
+Email:  path@epath.org
+Hours: Monday-Friday, 8:00am to 12:00pm, and 12:30pm to 4:00pm.
+Address:  Central Facility, 340 North Madison Avenue, Los Angeles, CA  90004
+Notes: Please call for information.
+    
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: CA ID, Social Security Card, updated TB test, verification of income.  Program will assist clients getting these documents.
+Accessibility: Wheelchair and other disabilities accommodated.
+Client fees: None.
+Eligible Population: Homeless individuals, families, veterans.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Transitional Housing; Substance Abuse Treatment; Transitional Employment; Supportive Housing.  Referrals to other resources available as needed. 
+
+
+
+
+Weingart Center   Homeless Services
+The Weingart Center is a non-profit comprehensive human services organization that was established in 1983 after recognizing that widespread homelessness was a new phenomenon facing the city of Los Angeles. The Weingart Center provides homeless individuals with the basic skills necessary to stabilize their lives, secure income and find permanent housing.  Our organization’s mission is to empower and transform lives by delivering innovative solutions to combat poverty and break the cycle of homelessness. The Weingart Center transitions homeless men and women from street life to self-sufficiency through a variety of programs and services, such as: Workforce Development, Mental Health & Substance Abuse Treatment, Case Management, Veterans Transition Housing, Women’s Renaissance, Re-entry Programs, and various other solutions.  
+
+url: weingart.org/
+
+To Get Connected
+Contact Person: Van Bellows 
+Phone: (213) 627-2151 
+Fax: (213) 489-3108
+Email:  center@weingart.org
+Hours: Monday-Friday 8:00am-4:30pm 
+Locations:  566 South San Pedro Street, Los Angeles, CA 90013
+Notes: For assistance on how to get help, please call our Resource Center at 213-689-2160 
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: CA ID, Social Security Card, program will assist clients to obtain these documents, and no more than two weeks ‘of clothing.
+Accessibility: Wheelchair and other disabilities accommodated.
+Client fees: None.
+Eligible Population: All individuals at least 18 years of age.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; transitional Housing; Assistance with Permanent Housing; Workforce Development; Vocational Training; Job Placement Assistance; Mental Health & Substance Abuse Treatment; Case Management; Veterans Transition Housing; Women’s Renaissance; Reenrty Programs; Trauma-Informed/Gender Responsive Programs; Clinical Services.  Referrals to other resources available as needed. 
+
+ 
+
+
+
+
+Homeward Bound of Marin   Family Center – Emergency Shelter
+Homeward Bound operates the only emergency shelter for homeless families in Marin County, which serves as the entry point for our Family Services Program.  Resource Counselors organize educational and fun activities for children, such as a Teen Activity Group for weekly outings, trips to the beach, pizza/game nights, etc., that enrich their lives and offer a sense of community. Families create action plans that might include improving parenting skills, finding consistent child care, accessing health care, pursuing new educational goals, counseling, job training and securing long-term housing.   hbofm.org/Homeless-Families.html
+
+To Get Connected
+Contact Person:  Resource Counselor
+Phone:  (415) 457-2115
+Hours: Open (please call).
+Location: 430 Mission Avenue, San Rafael, CA 94901
+Notes: Call for availability.
+
+Things To Know
+Languages Spoken: English, spanish.
+Accessibility:  Lower units are wheelchair accessible.
+Client fees, if any: None
+Eligible Population: Must be a Marin resident, must be a parent with a minor child(ren).
+Faith Based: No
+
+Direct Services: Shelter; Support for Job and Housing Search; Food Assistance; Referals to Services like Credit Repair, Tax Help, and Financial Literacy. Families with children under 5 years old have access to child care with Head Start.
+
+
+
+
+
+
+
+Homeward Bound of Marin   Services For Homeless Adult
+The Mill Street Center is the "front door" of our Adult Services Program, the 55-bed Mill Street Center in San Rafael is the county's only night-to-night emergency shelter for homeless individuals. It serves both men and women in separate dormitory-style rooms. A network of volunteers from three dozen churches and community groups shares a monthly rotation to provide a home-cooked hot meal to Mill Street residents. This significant gift has endured since the center opened more than 25 years ago.  As space becomes available, committed residents "graduate" to New Beginnings Center, a second-step shelter that allows residents to stay up to 6 months. 
+url: hbofm.org/Homeless-Adults.html
+
+To Get Connected
+Contact Person:  Resource Counselor
+Phone:  (415) 457-9651 or (800) 428-1488
+Hours: Intake:  Call Monday-Friday at 8:00am.  For questions call anytime.
+Location: 190 Mill Street, San Rafael, CA  94901
+Notes: Call for availability.
+Things To Know
+Languages Spoken: English
+Accessibility:  Wheelchair accessible.
+Client fees, if any: Yes, $3 per night.  If unable to pay please speak to program manager.
+Eligible Population: Must be a Marin resident, must be unaccompanied adult at least 18 years of age.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Counseling; Food Assistance/Prepared Meals.  Referrals to services such as credit repair, job training, recovery support or medical care.
+
+
+
+
+
+
+Napa County Health and Human Services Agency   Alcohol and Drug Services   
+Access, Treatment Authorization, and Quality Services.  If you are seeking substance abuse, addiction treatment services or information on local treatment resources for yourself, a family member or a friend please contact us. Our services follow evidence based practices including NiaTx, Motivational Enhancement, and Motivational Interviewing and are provided in both English and Spanish. www.countyofnapa.org/pages/departmentcontent.aspx?id=4294967796
+
+Overview of Services:
+Screening and Comprehensive Assessments 
+Determination of appropriate treatment placement based on client needs 
+Consultation and Education materials 
+Referrals and linkages to other services within the agency and community 
+Outreach and Engagement services 
+Community presentations, upon request 
+ 
+Eligibility:
+Eligibility requirements differ among the various contracted treatment providers. 
+
+Cost of Services:
+In all treatment agencies, a sliding scale fee, approved by the County Alcohol & Drug Administrator, is applied to services rendered. 
+
+Contact:
+Alcohol and Drug Services Centralized Access Line 
+Phone: (707) 253-4063 
+MONDAY through FRIDAY 8:00am to 5:00 pm, except holidays 
+
+Location of Services: 
+2344 Old Sonoma Road Bldg C, Napa, CA  94559
+
+Direct Services:
+
+
+Community Action of Napa Valley   Hope Center      
+The Hope Resource Center is a drop-in facility that provides basic services such as showers, restrooms, mail, phones and laundry for homeless adults throughout the day. A second tier of services, including medical care, job development, housing assistance, and mental health outreach and assessment are also provided through Community Action Napa Valley (CANV) and other participating agencies.   canv.net-flow.com
+
+To Get Connected
+Contact Person: Staff 
+Phone: (707) 259-8133
+Phone: (707) 253-6156
+Fax:  (707) 253-6156
+Email:  canv@can-v.org (for additional information)
+Intake Hours:  8:00am-4:30pm 
+Location:  1301 4th Street, Napa, CA  94559
+Notes: Must be at least 18 years old and a Napa County resident to receive services. 
+
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible
+Client fees, if any: None – must contribute back for services by helping out with some chores.
+Eligible Population: Must be at least 18 years old and a Napa County resident to receive services.
+Faith Based: No.
+Direct Services: Coordinated assessment for access to Adult Shelter, Showers, Restrooms; Mail, Laundry, Computers, and Referrals to Other Service.
+
+
+
+Leaders in Community Alternatives   ADRC North
+The ADRC North is a partnership between the Sacramento Probation Department and Leaders in Community Alternatives that bridges probation supervision services with comprehensive case management, barrier removal, employment and income benefits acquisition assistance.  In addition to the services LCA has on-site at the ADRC, LCA utilizes Sacramento County Probation's existing contracts for education, vocational and mental health services.  The goals of the ADRC are to reduce recidivism and build self-sufficiency skills in the clients we serve.   lcaservices.com
+
+To Get Connected
+Contact Person:  Christopher Timpson
+Phone:  (916) 876-4042
+Hours: Monday-Friday, 8:00am-8:30pm
+Location: 1215 Del Paso Blvd., Sacramento, CA  95815
+Notes: All clients must be referred by probation.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible.
+Client fees, if any: None.
+Eligible Population: Referred by Probation.
+Faith Based: No.
+
+Direct Services: Case Management; Education (literacy services, high school and GED instruction); Employment Readiness; Job Placement; Job Readiness/Life Skills; Vocational Training; Anger Management; Behavioral Health Assessments and Treatment; Cognitive Behavioral Services. Referrals to other services as appropriate.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint John’s Program for Real Change      
+We provide more than shelter and food. We provide the ability to rise above devastating, negative elements and achieve job-readiness and self-sustainability. Entry into the program is limited, and each step is extremely rigorous. But those who see it through end up with rewarding, happy, and productive lives – for themselves, and for their children. saintjohnsprogram.org
+
+
+To Get Connected
+Contact Person: Intake
+Phone: (916) 453-1482  
+Intake Hours: 8:00am-5:00pm
+Location:  P.O. Box 2443, Fair Oaks Blvd. #369, Sacramento, CA 95825
+Notes: No drop-ins.  We maintain a waitlist so please call for information.
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: ADA Compliant.
+Client fees: None
+Eligible Population:  Women at least 18 years of age and women with children. 
+Faith Based: No.
+Direct Service: Emergency Shelter; Transitional Housing;  Access to Internet; Food/Prepared Meals; Hygiene/Personal Care Items; Childcare; Job Readiness Training; Transitional Employment; Job Placement; Education and GED Certification; Shower Facilities; Substance Abuse Treatment; Domestic Violence Counseling; Medical Care. Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Valley Recovery Center of California      
+At Valley Recovery Center, we believe that a healthy recovery plan involves both the client and the family in conjunction with a strong continuing of care plan. We tailor our approach to each client by identifying his or her particular needs and creating a specific, individualized treatment plan. www.valleyrecoveryca.com
+
+
+To Get Connected
+Contact Person: David Burke
+Phone: (530) 228-8764
+Email:  dburke@summitbhc.com
+Hours: 24 Hour residential program.
+Location:  Sacramento, CA
+Notes: Call to speak with an admissions counselor for a screening and assessment. We are JHACO/by the joint commission. www.valleyrecoverycalifornia.com.
+We accept private insurance/Private Pay with payment options. EAP and managed care. Obama care, workman’s comp cases.
+Things To Know
+Languages Spoken: English. 
+Accessibility: ADA Compliant.
+Client fees: We accept private insurance/Private Pay with payment options. EAP and managed care. Obama care, workman’s comp cases.
+Eligible Population:  Men and Women at least 18 years of age
+Faith Based: We do have faith-based tracks as well.
+
+
+
+
+Direct Service: Substance Abuse Treatment; Residential Treatment; Medically Managed Detox; Dual Diagnosis Residential Treatment.  Referrals to other resources available as needed.
+
+
+Volunteers of America   Men’s A Street Shelter
+Volunteers of America of Sacramento offers emergency shelter to men.  The length of stay at our shelter is 30 days plus two 30 day extensions for a total of 90 days.  We also offer referrals for additional housing options.   www.voa.org
+
+
+To Get Connected
+Contact Person: Intake
+Phone: (916) 448-5507  or (916) 448-1236 
+Intake Hours: 8:00pm-6:00am
+Location:  1400 North A Street, Building B, Sacramento, CA 95811
+Notes: Must be at location by 8:00pm.  Beds are filled on a first come, first served, basis.  For other services call (916) 265-3400.
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: ADA Compliant.
+Client fees: None
+Eligible Population:  Men 18 years of age and older and must be a resident of Sacramento County. 
+Faith Based: No.
+Direct Service: Emergency Shelter; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities. Referrals to other resources available as needed.
+
+
+
+
+Alpha Project   Homeless Services  
+Alpha Project’s mission is to empower individuals, families, and communities by providing work, recovery, housing and support services to people who are motivated to change their lives and achieve self-sufficiency. With a tax deductible donation, you may choose which program you would like to contribute to. Each and every program we offer provides hope, opportunities, and new beginnings to those that are less fortunate.   Alpha Project offers emergency shelter, transitional housing, residential substance abuse treatment and other services. www.alphaproject.org
+
+To Get Connected
+Contact Person: Staff 
+Main Office Phone: (619) 542-1877
+Hours: Monday-Friday, 9:00am to 5:00pm
+Locations:  3737 Fifth Avenue, San Diego, CA  92103
+Notes: Winter Shelter (619) 542-1877; Supportive Housing (619) 696-6500; Transitional Housing (619) 542-1877; No drop-ins, please call for appointment and info on other programs.
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: CA ID, Social Security Card, Program will assist clients getting these documents.
+Accessibility: Wheelchair.
+Client fees: None.
+Eligible Population: All individuals 18 years of age or older and a San Diego County resident.
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Transitional Housing; Substance Abuse Treatment; Transitional Employment; Supportive Housing.  Referrals to other resources available as needed.
+
+
+
+San Diego Rescue Mission   Residential Treatment/Transitional Housing/Emergency Shelter for Men, Women and Children
+Since 1955 San Diego Rescue Mission has helped restore hope for San Diego’s homeless, hungry, addicted, and abused individuals. The Rescue Mission’s comprehensive programs meet basic needs, then go further. With God’s grace and the kindness and generosity of San Diegans, we dedicate ourselves every day to finding long-term solutions to the problem of homelessness.  www.sdrescue.org/
+
+To Get Connected
+Contact Person:  Main Office
+Phone: (619) 687-3720
+Phone: (888) 737-3728
+Men's Center:
+Michael Castaneda (619) 818-1826
+Women & Children's Center:  
+Crystal Robinson (619) 819-1807
+2nd Ave. Transitional Housing:  
+Stephanie Rimer (619) 819-1722
+Recuperative Care Unit:  
+Chris Cessna (619) 819-1760
+Nueva Vida Haven:  
+Karen Keith (619) 819-1845
+Email:  sdrminfo@sdrescue.org
+Hours: Office Hours:  Monday-Friday, 9:00am to 5:00pm; Shelter Hours:  24 hrs/7 days a week
+Address:  PO Box 80427, San Diego, CA 92138.
+Notes: No referral needed.  Please call for information.  
+    
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: CA ID, Social Security Card are helpful but not required.
+Accessibility: Wheelchair  and other disabilities accommodated.
+Client fees: Emergency shelter (No Fee); Transitional Housing (Sliding Scale).
+Eligible Population: All individuals 18 years of age or older, Mothers with children (children up to age 16—for emergency shelter), for the woman and children center (children up to age 12).  
+Faith Based: Yes.  
+
+Direct Services:  Emergency Shelter; Transitional Housing; Substance Abuse Treatment; Recovery for homeless after hospitalization.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+Pathfinders of San Diego   Recovery Services
+Pathfinders is a non-profit organization dedicated to maintaining residential centers which address the needs of individuals recovering from the disease of alcoholism and co-occurring disorders, assisting their families in dealing with the effects of alcoholism, and providing services to the community in its effort to reduce alcohol-related problems. pathfindersrecovery.org/wordpress/
+
+To Get Connected
+Contact Person: Steve Sapp  
+Phone: (619) 239-7370 
+Email:  recovery@pathfindersofsd.com
+Intake Hours: Monday-Friday, 9:00am to 11:00am (except the last two and first two business days of each month and holidays.
+Address:  2980 Cedar Street, 
+San Diego, CA 92102 
+Notes: No appointment necessary.  
+     
+Things To Know
+Languages Spoken: English. 
+What to Bring: Valid ID and current TB test.
+Client fees: sliding scale—food stamps accepted as partial rent payment.
+Eligible Population: Men  18 years and older,  no active warrants, no upcoming court dates,  no arson or sex crimes. May not work for the first 4 to 6 months of the program. 
+Faith Based: No.
+
+Direct Services: Residential Recovery program for male alcoholics. Designed to be a 9 month program.  Based on the Big Book of Alcoholics Anonymous.
+
+ 
+
+ 
+    
+
+
+
+
+
+
+
+
+ 
+
+
+
+David Lewis Community Reentry Center       
+The City of East Palo Alto and the County of San Mateo created and are funding the David Lewis Reentry Program to assist residents returning home from prison or jail with their reintegration back into the community. The David Lewis Reentry Center provides case management, classes in personal development and like skills, and referrals to other community partners for employment services.  www.ci.east-palo-alto.ca.us/index.aspx?nid=255
+
+To Get Connected
+Contact Person:  Jose Cabrera
+Phone:  (650) 853-3188 
+Email:  jcabrera@smcgov.org
+Hours: 8:00am-5:00pm
+Location: 2277 University Avenue, East Palo Alto, CA 94303 
+Notes: It is okay to drop-in and/or call/email for an appointment.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: AB 109 (referred from San Mateo County Probation). We also accept regular probation and parole referrals as well.
+Faith Based:  We are not a faith based program but we do work with churches in our community if a client wishes to participate in faith based activities.
+
+Direct Services: Case Management; Supportive Services; Personal Development; Life Skills; Financial management; Cognitive Restructuring; Resume Development; Job Search; Access to Computers; Referrals to other resources available as needed.
+
+JobTrain	Employment Services       
+JobTrain transforms lives and communities in Silicon Valley. We help the Valley’s most in need reclaim their lives from poverty and unemployment by preparing them for successful, sustainable
+careers in high-demand and emerging fields.  JobTrain is committed to helping those who are most in need to succeed. Our purpose is to improve the lives of people in our community through assessment, attitude and job skills training, and high potential career placement. Full-time vocational training programs include: Culinary Arts, Laborers Construction Fundamentals Training Program, Medical Assistant, Business Administration Skills, Professional Health Care Worker, and Project Build (Construction, Green Technology and Carpenter Pre-Apprenticeship). Students also benefit from Upgrade Trainings, which helps them to advance in their careers. Offerings include GED preparation, Academic Skills for Employment, ESL, and Computer Literacy. Our programs are provided for little or no cost to students.  www.jobtrainworks.org/
+
+To Get Connected
+Contact Person:  JobTrain
+Phone:  (650) 330-6429 
+Fax:  (650) 330-6401 
+Email:  info@jobtrain.org
+Hours: Monday-Friday 8:00am-5:00pm
+Location: 1200 O’Brien Drive, Menlo Park, CA 94025 
+Notes: No appointment, drop-ins welcome for intake process.  We serve San Mateo County residents first.  Come visit our One Stop job search help workshops!  We also have a Single Stop on site for tax, legal, and nutrition help.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: San Mateo County residents have priority.  Must be 18 years of age by the time vocational training is completed.
+Faith Based:  No.
+
+Direct Services: Vocational Training; Employment Readiness; Life Skills; Access to Internet; GED Preparation; ESL; Computer Literacy.  Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Our Common Ground   Substance Abuse Treatment Facility
+Our Common Ground (OCG) is a treatment program for adults with substance abuse and mental health problems. We help people who realize they cannot do it alone – that they need the support, encouragement and challenge from other like-minded individuals who are working toward meaningful and productive lives, without drugs. Our nurturing environment helps each individual take responsibility for his or her own life and build skills for long term substance abuse recovery, rehabilitation and emotional and physical success. Many come back later and tell us about their happiness and success as parents, workers, students and contributing members of their communities due to the rehabilitation therapy they have received in our treatment center. www.ocgworks.org/
+
+To Get Connected
+Contact Person:  Richard Pecoraro, Intake Director
+Phone:  (866) 325-6466
+Intake Phone:  (650) 325-9544 
+Location:  OCG Adult Services, 2560 Pulgas Avenue, Palo Alto, CA  94303.
+Hours: Monday-Friday, 9:00am-5:00pm
+Notes: Please call for appointment.  We offer  Residential Treatment, Day Treatment, Outpatient Treatment.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessibility.
+Client fees, if any: None
+Eligible Population: Must be at least 18 years of age, and not have a conviction for a sex offense or arson.
+Faith Based: No.
+
+Direct Services: Residential Treatment; Evidence-Based Treatment; Case Management; Educational and Vocational Preparation; Conflict resolution; Anger Management; Family/Individual Counseling; Supportive Services.  Referral to other resources available as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+San Mateo County   Service Connect
+Service Connect of San Mateo County provides a range of services aimed at supporting former inmates as they re-enter the community. Service Connect is available to individuals who have served sentences for specific low-level offenses, who live or plan to live in San Mateo County, and who are enrolled in Post-Release Community Supervision (PRCS) or who served their sentence in county jails under the 1170h program. Please check with your Probation Officer to see if you qualify for Service Connect or other re-entry assistance.  Service Connect is collaboration between the San Mateo County Sheriff's Department, Correctional Health, Probation, Human Services Agency, and the Health System. Our staff works across agency lines to reduce recidivism and connect clients with needed services.
+
+To Get Connected
+Contact Person:  Front Desk
+Phone:  (650) 508-6745 
+Hours: 8:00am-5:00pm
+Location: 550 Quarry Road, 2nd Floor, San Carlos, CA 94070 
+Notes: Please check with your Deputy Probation Officer to see if you are eligible for referral/services.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  ADA Accommodations: Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: Must be on probation in San Mateo County.  Please check with your Deputy Probation Officer to see if you are eligible.
+Faith Based: N/A.
+
+Direct Services:  Temporary Emergency Shelter; Emergency Food; Clothing and Transportation Vouchers; Personal Hygiene Kits; Assistance Obtaining California Identification Documents; Case Management;  Assessments for Financial Benefits and Health Coverage; Links to Job Training and Employment; Family Re-Engagement Support; Mental Health and Substance-Abuse Recovery Referrals; Employment Services; Support Groups and Community Mentorship; Peer-to-Peer Mentoring; Moral Reconation Therapy (MRT); Health Services.
+
+
+Mz. Shirliz Transitional Inc.   Clean & Sober Transitional Housing
+Mz. Shirliz offers transitional housing and supportive services for people in recovery from substance abuse/addiction and those who are trying to rebuild their lives post-incarceration. www.mzshirliz.org
+
+To Get Connected
+Contact Person:  Shirley Lamarr
+Phone:  (650) 218-8256 
+Office location:  1447 El Camino Real, Redwood City, CA 94063
+Hours: 8:00am-5:00pm
+Notes: Please call first.  Drop-ins okay if it is a non-medical emergency.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  Wheelchair accessibility.
+Client fees, if any: None
+Eligible Population: Must be at least 18 years of age, and not have a conviction for a sex offense or arson.
+Faith Based: No.
+
+Direct Services: Transitional Housing; Supportive Services; Crisis Center; Individual and group Counseling; Job Training; Job Retention Support.  Referral to other resources, including residential treatment, available as needed.
+
+
+Jericho Project  
+The staff of Jericho Project has determined through professional research and numerous years of personal experience that a structured lifestyle is critical to long-term recovery.  We believe that it is essential to provide each individual with a regular schedule of activities designed to promote stable and responsible living.  Jericho Project is an education center for addicts and ex-convicts.  Our philosophy is that the drugs were not the main problem, but a symptom of the problem. The problem has always been honesty. We work on developing a sense of morals and values that can help keep an individual focused and clean. Our philosophy focuses on healing the body, mind, and spirit. Our Vocational Training department prepares residents for careers in construction, retail, transportation, warehousing and administrative careers.  We also have a state of the art fitness gym where residents are trained by our certified trainers or a General Physical Trainer.  
+url: www.jericho-project.org
+
+To Get Connected
+Contact Person: Nicholas Caluya
+Phone: (415) 656-1700 
+Fax: (415) 715-1333 
+Email: nickcaluya@jerichoproject.net 
+Facility Hours: 24 hours/7 days. Intake hours: Monday – Friday, 9:00am-5:00pm.
+Locations: 470 Valley Drive, Brisbane CA 94005
+Notes: Telephone interviews are available Monday thru Friday between 
+8am and 8pm. Collect calls are accepted (415) 467-9836
+ 
+Things To Know
+Languages Spoken: English, Spanish.
+What to Bring: Program will assist clients with necessary documents. 
+Accessibility: ADA compliant
+Eligible Population: Men ages 18 and older.
+
+Direct Services: Assistance Getting Driver’s License or Other ID; Clothing; Food/Prepared Meals; Hygiene/Personal Care Items; Shower Facilities; Medical Care; Anger Management; Mentorship; Basic/Remedial Education; GED & High School Diploma; Reading/Literacy; Vocational Education; Employment Training; Employment Retention; Job Readiness/Life Skills; Money Management/Personal Financial Education; Inmate & Parolee Legal Voting Outreach & Education; Referrals to other resources available as needed.
+
+
+
+
+
+
+
+
+
+Project 90   Substance Abuse Treatment Services
+Project 90 is a human services organization dedicated to meeting the needs of individuals, families and our communities through comprehensive alcohol and drug recovery.  www.projectninety.org
+To Get Connected
+Contact Person: Intake Department
+Phone: (650) 579-7881 
+Hours: Monday-Friday, 9am to 5pm
+Locations:  Corporate Office, 720 South B Street, San Mateo, CA 94401
+Notes: Drop-in okay.  Interviews to get accepted on to the waitlist occur every Tuesday at 11:00am and every Friday at 11:45am at 416 2nd Avenue, San Mateo, CA  94401
+Things To Know
+Languages Spoken: English. 
+What to Bring: State-Issued ID
+Accessibility: Wheelchair accessible.
+Client fees: Sliding scale.
+Eligible Population: Men ages 18 and older.  Must not have conviction for arson or sex offense.
+Faith Based: No.
+
+Direct Services: Residential Substance Abuse Treatment; Co-occuring Disorders/Dual Diagnosis Treatment; Health and Wellness Education; Anger Management; Case Management; Trauma Recovery Services; Mentorship; Therapy; Clothing; Meals; Hygiene/Personal Care Items.
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+CITYTEAM International   Rescue Mission/Men’s Emergency Shelter 
+In San Jose, Cityteam is providing hot meals, safe shelter, showers, and clean clothing to our city's homeless population. Located in the heart of Silicon Valley, Cityteam brings real help and real hope to the men, women, children, and families in crisis that are struggling with poverty or homelessness in San Jose and throughout Santa Clara County. Cityteam San Jose also has renowned recovery programs for men and women seeking help to transform their lives from addiction to drugs and alcohol. Cityteam provides long-term compassionate ministry to people that walk through our doors. Through the generous support of our staff, volunteers, and donors, Cityteam is able to provide real help and real hope in Christ in order to bring real change into their lives.  www.cityteam.org/san-jose/
+
+To Get Connected
+Contact Person: Shelter Intake
+Phone: (408) 288-2153 Fax: (408) 428-9505 
+Email:  sanjose@cityteam.org
+Intake Hours: Monday-Friday, 9am to 5pm
+Corporate Office:  2304 Zanker Road, San Jose, CA 95131
+Notes: Check in is Monday-Sunday at 5:30pm.  Must show up in person to 1174 Old Bayshore Highway, San Jose, CA  95112 by 5:00pm nightly.  We are a Men only shelter.  Call for more information.
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: ADA compliant.
+Client fees: None.
+Eligible Population: Men ages 18 and older.  
+Faith Based: Yes.
+
+
+Direct Services: Emergency Shelter; Sower Facilities; Meals; Hygiene/Personal Care Items.
+
+
+
+
+
+
+
+
+
+
+
+CITYTEAM International   Substance Abuse Treatment Services
+In San Jose, Cityteam is providing hot meals, safe shelter, showers, and clean clothing to our city's homeless population. Located in the heart of Silicon Valley, Cityteam brings real help and real hope to the men, women, children, and families in crisis that are struggling with poverty or homelessness in San Jose and throughout Santa Clara County. Cityteam San Jose also has renowned recovery programs for men and women seeking help to transform their lives from addiction to drugs and alcohol. Cityteam provides long-term compassionate ministry to people that walk through our doors. Through the generous support of our staff, volunteers, and donors, Cityteam is able to provide real help and real hope in Christ in order to bring real change into their lives.  www.cityteam.org/san-jose/
+
+To Get Connected
+Contact Person: Recovery Program
+Phone: (408) 288-2185 
+Fax: (408) 428-9505 
+Email:  sanjose@cityteam.org
+Intake Hours: Monday-Friday, 9am to 5pm
+Location:  Men’s Recovery Program, 580 Charles Street, San Jose, CA 95112
+Notes: Please call first for an intake.   Call (408) 885-8080 for our Women’s Recovery Program.
+ 
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: State-Issued ID
+Accessibility: Wheelchair accessible.
+Client fees: Sliding Scale.
+Eligible Population: Men ages 18 and older.  
+Faith Based: Yes.
+
+
+Direct Services: Residential Substance Abuse Treatment; 12 Step Program; Health and Wellness Education; Anger Management; Case Management; Mentorship; Therapy; Clothing; Meals; Hygiene/Personal Care Items.  Referrals to other services available as needed.
+
+Project 90       Substance Abuse Treatment Services San Jose
+Project 90 is a human services organization dedicated to meeting the needs of individuals, families and our communities through comprehensive alcohol and drug recovery.  www.projectninety.org
+To Get Connected
+Contact Person: Intake Department
+Phone: (408) 885-1291 
+Hours: Monday-Friday, 9am to 5pm
+Location:  561 South 9th Street, San Jose, CA 95112
+Notes: All clients must be referred through Gateway.  Please contact Gateway at 800-488-9919.
+Things To Know
+Languages Spoken: English. 
+What to Bring: State-Issued ID
+Accessibility: Wheelchair accessible.
+Client fees: Sliding scale.
+Eligible Population: Men and Women, ages 18 and older.  Must not have conviction for arson or sex offense.
+Faith Based: No.
+
+
+Direct Services: Residential Substance Abuse Treatment; Co-occuring Disorders/Dual Diagnosis Treatment; Health and Wellness Education; Anger Management; Case Management; Trauma Recovery Services; Mentorship; Therapy; Clothing; Meals; Hygiene/Personal Care Items.
+
+
+
+Santa Clara County Reentry Center       
+The Re-Entry Resource Center is a centralized location for custodial and non-custodial individuals to receive referral and wrap around services. Our vision is to build safer communities and strengthen families through successful reintegration and reentry of formerly incarcerated individuals back into Santa Clara County.  Our mission is to reduce recidivism by using evidence-based practices in implementing a seamless system of services, supports, and supervision. We offer reentry services, Probation Intake and Assessment, and Custody Alternative Programs. www.sccgov.org/sites/reentry/resourcecenter/Pages/Resource-Center.aspx
+
+
+To Get Connected
+Contact Person: General Information
+Phone: (408) 535-4280  
+Intake Hours: Monday-Friday, 8am to 5pm
+Location:  151 W. Mission Street, San Jose, CA 95110
+Notes: Must be criminal justice involved and reside in Santa Clara County.
+
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: ADA Compliant.
+Client fees: None.
+Eligible Population:  Men/Women ages 18 and older, must reside in Santa Clara County and criminal justice involved. 
+Faith Based: No, but can referred to faith-based reentry resource centers in Santa Clara County.
+
+ 
+Direct Service: Probation Intake and Assessment, Parolee Reentry Program, Behavioral Health Services, Public Benefits & Health Coverage, Reentry Mobile Clinic, Education, Employment, Family Reunification, Legal Advice, linkage to faith-based reentry centers, Housing, Peer Mentor/Support, Expungement, and Food Pantry/Clothing.
+
+
+
+
+Healthy Partnerships	Substance Abuse Services
+Healthy Partnerships (HP) employs a consumer-oriented approach to substance abuse treatment services. Clients participating in these services can either enter voluntarily or through court-ordered to do so. HP works closely with Probation and Parole in compliance with any court mandates. Clients requesting services are assessed for individual treatment plans. We provide outpatient substance abuse services.  www.healthypartnerships.com/
+
+
+To Get Connected
+Phone: (707) 425-1799 (if you have private insurance) or (707) 784-2220 (if you do not have insurance and Solano County Substance Abuse Services will provide you with a referral).
+Hours: Monday-Friday, 8am to 5pm
+Location:  1735 Enterprise Dr. Suite A
+Fairfield, CA 94533
+Notes: If you do not have insurance please call (707) 784 2220 for assessment.  
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.  ADA Compliant.
+Client fees: None.
+Eligible Population:  Men/Women ages 18 and older, must reside in Solano County.
+Faith Based: No/Yes
+
+Not done…Bobbye bmoore@healthypartnerships.com
+
+ 
+Direct Service: Outpatient Substance Abuse Services; Case Management; DUI Services; Group Therapy; Individual Counseling.
+
+
+
+Mission SOLANO Rescue Mission	
+Mission SOLANO Rescue Mission focused its vision to develop long-term residential treatment for homeless addicted men, women, and Veterans. Since then, Mission SOLANO has successfully met the basic necessities of the homeless and poverty stricken population. Our unique and nationally recognized Nomadic Sheltering Program provides emergency shelter nights to those in need, while maintaining and managing our Community Outreach Center (COC) and Social Industries distributing food, clothing and ongoing community services. In 2009 we opened our Bridge To Life Center, our long-term solution to homelessness. Through transitional housing and a holistic program, we address spiritual, physical, emotional, psychosocial and vocational needs. Our six buildings are able to provide for 208 individuals through our Hope Home for Homeless Vets, the Matt Garcia Home for Women and Children, and twelve two-bedroom family units.  Our doors are open 24 hours a day, 365 days a year. Help is available without charge to any person regardless of race, color, creed or social standing.   www.missionsolano.org
+
+To Get Connected
+Phone: (707) 425-3663  
+Hours: Monday-Friday, 8am to 5pm
+Locations:  Community Outreach Center, 740 Travis Blvd, Fairfield, CA  94553; Bridge to Life Center, 310 Beck Avenue, Fairfield, CA  94553
+Notes: May show up for a bed at 2:30pm daily to see if there is room.  No reservations, first come, first serve.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Call for information.
+Client fees: None.
+Eligible Population:  Men/Women ages 18 and older.  Must be a Solano County resident.
+Faith Based: Yes
+
+ 
+Direct Service: Emergency Shelter; Long-Term Residential; Food/Meals Prepared; Clothing.
+
+
+
+
+
+
+
+
+
+
+
+
+Solano County Substance Abuse Services	
+Solano County Substance Abuse Services is dedicated to providing a continuum of care that benefits the clients and providers. Utilizing a combined administrative, clinical, and preventive services approach, we deliver coordinated services to the diverse populations of Solano County who are impacted by alcohol, tobacco, and other drugs (ATOD), and related issues such as domestic violence. solanocounty.com/depts/hss/sas/default.asp
+
+To Get Connected
+Phone: (707) 784-2220  
+Fax: (707) 425-4038  
+Hours: Monday-Friday, 8am to 5pm
+Locations:  2101 Courage Drive, Suite 101, Fairfield, CA  94553.
+Notes: Please call for an appointment.  If you need to stop using alcohol or substances immediately, call the Southern Solano Alcohol Council Detox at (707) 643-2715 or visit the nearest emergency room.
+Things To Know
+Languages Spoken: English, Spanish. 
+Accessibility: Wheelchair accessible.  
+Client fees: Will be discussed during intake. If you do not have insurance you will not be turned away.
+Eligible Population: All individuals 18 years of age and older, uninsured or Medi-Cal, must be a Solano County resident.  Must have used drugs or alcohol in the past year.
+Faith Based: No.
+
+ 
+Direct Service: Detox; Residential Substance Abuse Treatment; Outpatient Substance Abuse Treatment.
+
+
+
+
+COTS   The Petaluma Kitchen
+Committee on the Shelterless (COTS) Petaluma Kitchen offers daily meals and weekly boxes of emergency food.  The Petaluma Kitchen serves critical meals to many low income families, seniors and individuals in our community. In this community kitchen, located at 900 Hopper Street in Petaluma, COTS provides a nutritious meal each day to homeless and at-risk families and individuals. The Food Box Program provides weekly boxes of supplemental groceries to residents of Petaluma who meet the Emergency Food Assistance Program (EFAP) income requirements.  Food Boxes are delivered on Saturdays or may be picked up Sunday – Thursday 9:30-11am.  To apply for the Food Box Program must show a current photo id, proof of their address in Petaluma, and proof of their income.     www.cots-homeless.org/index.php/how-we-help/homeless-services/
+
+To Get Connected
+Contact Person:  The Petaluma Kitchen
+Phone :  (707) 765-6530 x131 
+Hours: Free meals are served daily: Breakfast from 7:30-9:00am, Lunch from11:30am-1:00pm, Dinner for MIC residents only from 5:00-6:00pm
+Location: P.O. Box 2744, Petaluma, CA 94953; 900 Hopper Street, Petaluma, CA  94952
+Things To Know
+Languages Spoken: English.
+Accessibility:  Wheelchair accessible.
+Client fees, if any: None
+Eligible Population: All are welcome. Children must be accompanied by a parent. 
+Faith Based: No.
+Notes: It is okay to drop-in.
+
+Direct Services: Food/Prepared Meals; Clothing; Shower Facilities; Access to Laundry Machines.  The Petaluma Kitchen is the central contact point of COTS' outreach to persons living on the streets, to encourage them to seek shelter and support at the Mary Isaak Center.
+
+
+
+
+
+
+
+
+
+
+
+
+
+COTS   Mary Isaak Center (transitional Housing/Emergency Shelter)
+Committee on the Shelterless (COTS) Mary Isaak Center facility is the setting for the majority of COTS' programs and services. These programs help families and single adults to heal from trauma and homelessness, gain life skills, optimize their income, and acquire permanent housing. We know that trauma influences how people respond and live in the world. If we do not deal with this history, it is extremely difficult to help people move forward.  The second floor of the building is dedicated to the Family Transitional Housing program, which provides shelter and a wide range of transformative programs for up to 11 families at a time. Families may stay for up to two years, during which time they receive intensive support services and individualized case management. Parents are required to participate in Kids First, COTS' 12-week parenting skills training, and in Rent Right, a 9-week course in financial literacy and housing search. More than 70% of families graduate into permanent housing and independent stable lives. The 100-bed Emergency Shelter for Single Adults is located on the first floor of the Mary Isaak Center. Services include food, clothing, showers, access to phones and a messaging system, access to computers, transportation assistance, mental health and chemical dependency recovery support, job skills training, and assistance in obtaining employment and/or public benefits. Residents may stay for up to six months and more than 50% graduate into either transitional or permanent housing. The Emergency Shelter for Single Adults serves up to 500 individuals annually.  www.cots-homeless.org/index.php/how-we-help/homeless-services
+
+To Get Connected
+Contact Person:  Staff
+Phone:  (707) 765-6530
+Hours: Vary depending on program.  Business hours are Monday-Friday, 9:00am-5:00pm.
+Location: P.O. Box 2744, Petaluma, CA 94953; 900 Hopper Street, Petaluma, CA  94952
+Notes: It is okay to drop-in.
+
+Things To Know
+Languages Spoken: English, Spanish.  Translation services available upon request.
+Accessibility:  Wheelchair accessibile.
+Client fees, if any: None
+Eligible Population: Homeless adults and families. 
+Faith Based: No.
+
+Direct Services: Emergency Shelter; Transitional Housing; Life Skills; Food/Prepared Meals; Clothing; Shower Facilities; Access to Laundry Machines.  The Petaluma Kitchen is the central contact point of COTS' outreach to persons living on the streets, to encourage them to seek shelter and support at the Mary Isaak Center.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Redwood Gospel Mission   Men’s Shelter and Women’s Shelter
+The Redwood Gospel Mission offers a men's emergency shelter.  The Men's Mission is for men experiencing homelessness. There is a Transitional Savings Program, where guests can remain at the Mission for six months to save money while they put their lives back together and form a plan to leave homelessness behind. The Redwood Gospel also offers an emergency shelter for women.  The Rose serves women with children (girls of all ages, boys ages 11 and under) experiencing homelessness  There is a Transitional Savings Program, where guests can remain at the Rose for six months to save money while they put their lives back together and learn the skills necessary to put homelessness behind them. www.srmission.org/index.php 
+
+To Get Connected
+Contact Person:  
+Men’s Mission
+Intake/ Richard Sundahl
+Phone: (707) 542-4817 
+The Rose (Women’s Shelter)
+Intake/ Chris Keys
+Phone:  (707) 573-0490 (call after 3:30pm)
+Hours: 24 Hours/day
+Location: 101 6th Street, Santa Rosa, CA, 95401
+Notes: Drop-ins welcome.
+
+Things To Know
+Languages Spoken: NA
+Accessibility:  Limited Accommodations.
+Client fees, if any: None
+Eligible Population: Must be at least 18 years old to receive services, unless emancipated.
+Faith Based: Yes.
+
+Direct Services: Emergency Shelter; Transitional Housing; Food/Prepared Meals; Hygiene/Personal Care Items; P.O. Box/Mail Service; Local Phone; Shower Facilities; Mental Health Treatment; Medical Care; Health & Wellness Education; Group Counseling/Therapy; Individual Counseling/Therapy; Job Readiness/Life Skills; Money Management/Personal Financial Education).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sonoma County Job Link
+Job Link is Sonoma County's one-stop career center. Job Link serves job seekers with meetings with Job Counselors, training scholarships, classes on resume writing and online job search, access to a computer lab and disability tools. Job Link hosts hiring events and job fairs at the Job Link office which has a computer lab for on-line applications and interview space.  The Job Link Website, www.joblinksonomacounty.com is a virtual one-stop, offering many services online, 24 hours a day.  www.joblinksonomacounty.com 
+
+To Get Connected
+Contact Person:  Front Desk
+Phone: (707) 565-5550 
+Hours: Monday – Friday  8:00am - 5:00pm;
+Resource Center 8:00am - 4:45pm; Computer Lab 8:30am - 4:00pm Monday - Thursday, 8:30am -3:30pm Friday.
+Location: 2227 Capricorn Way, Suite 100,Santa Rosa, CA  95407
+Notes: Must attend a Job Link Orientation M-F at 1:30pm—no appointment needed.  Spanish speaking orientation on Thursdays at 10:00am.
+
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  ADA Accommodations: Wheelchair accessibility 
+Client fees, if any: None
+Eligible Population: Must be at least 18 years old to receive services.
+Faith Based: No.
+
+Direct Services: Job Readiness; Job Search Assistance; Resume Writing.
+
+Sonoma County Probation   Day Reporting Center
+The Sonoma County Probation Day Reporting Center is a comprehensive program designed to accommodate the needs of individuals under probation supervision who have recently been incarcerated and are transitioning back into the community.  The focus of the center is to provide evidenced based programming to the participants to promote behavior change.  Additionally, through the use of on-site community partners, participants can quickly access much needed resources to address personal, educational, and vocational goals, with the ultimate objective of reducing recidivism.
+
+To Get Connected
+Contact Person:  DRC Staff
+Phone: (707) 565-8041 
+Hours: Monday/Wednesday/Friday 9:00am-8:00pm; Tuesday/Thursday 7:00am-6:00pm
+Location: 2400-A County Center Drive, Santa Rosa, CA 95403
+Notes: Referrals made directly from Sonoma County Adult Probation. 
+Things To Know
+Languages Spoken: English/Spanish.
+Client fees, if any: Participation in assigned programming is free of charge.
+Eligible Population: the AB 109 population and those individuals under probation supervision with high risk for recidivism.
+Faith Based: No
+
+Direct Services: Cognitive behavioral Intervention Groups; Aggression Replacement training; Eligibility Worker; Vocational and Educational Services; Substance Abuse/Mental Health Assessment and Referral Resources; Chemical Testing.  Referrals to other resources are available as needed.
+
+Turning Point   Residential Treatment Program
+A program of center Point DAAC, Turning Point is a residential treatment program from 30 to 270 days.  Turning Point Residential Program offers co-ed and gender-specific services, with a specialized treatment track intended for those with co-occurring mental health and substance abuse problems. Additional treatment tracks include: Working Adults Program (for individuals seeking intensive treatment while maintaining their employment) and an Opiate Addictions Program (in coordination with Narcotic Replacement Therapy, such as Methadone or Suboxone).  Core components of residential treatment at Turning Point includes initial participant assessment/placement, individual, collateral/family and group counseling, case management and individualized treatment planning, mental health evaluation and short-term on-site counseling support as warranted, as well as services focusing on life skills such as maintaining health, building and maintaining socially supportive relationships, recognizing and preventing substance abuse relapse, avoiding violence and criminal behavior, recognizing and shifting self-defeating thinking and behavior pattern, parenting skills and stress management and improved coping skills.  www.daacinfo.org/PS_residential.shtml
+
+To Get Connected
+Contact Person:  Central Intake Department
+Phone: (707) 544-3295 
+Hours: Monday–Friday, 9:00am-5:00pm
+Location: 2401 professional drive, Santa Rosa, CA  95401
+Notes: Call first for appointment.  If you are interested in residential or outpatient care please call. 
+Things To Know
+Languages Spoken: English, Spanish.
+Accessibility:  ADA Accommodations: Wheelchair accessibility. 
+Client fees, if any: Sliding scale.  Funding available.  Will be discussed during intake.
+Eligible Population: All individuals 18 and older who are residents of Sonoma County.
+Faith Based: No.
+
+Direct Services: Residential Substance Abuse Treatment; Outpatient; Individualized Treatment Plans; Case Management; Cognitive Behavioral Therapy; Co-Occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education; Outside AA/NA Meetings.


### PR DESCRIPTION
Every two years, the San Francisco Reentry Council (part of the San Francisco Adult Probation Department) publishes "Getting Out & Staying Out" - a reference manual with information about social services in the city.

They've provided the contents of their 2013/2014 guidebook in plain text format as the basis for [Code for San Francisco](http://codeforsanfrancisco.org/)'s [OpenReferral](https://github.com/sfbrigade/sf-openreferral) project.

To process the data, we've added import scripts for APD guidebook text files.  The scripts were copied from SF OpenReferral's setup scripts.

See:
- [importer.rb](https://github.com/sfbrigade/sf-openreferral/blob/b7717cca674bb642597ccdf04fb4ed5eddcec129/lib/importer.rb)
- [organization_parser.rb](https://github.com/sfbrigade/sf-openreferral/blob/b7717cca674bb642597ccdf04fb4ed5eddcec129/lib/organization_parser.rb)
- [import.rb](https://github.com/sfbrigade/sf-openreferral/blob/b7717cca674bb642597ccdf04fb4ed5eddcec129/db/seeds.rb)

We ran the import scripts to generate the organization yaml.

Note: There was one instance of a three-way duplicate that requires further investigation:

```
new file: organizations/san-francisco-department-of-child-support-services.yml
new file: organizations/san-francisco-department-of-child-support-services_dup.yml
new file: organizations/san-francisco-department-of-child-support-services_dup_dup.yml
```
